### PR TITLE
feat(print): `--print-ast` prints symbol table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ zig-out
 *.swp
 *.swo
 .idea
+
+# temp files
+tmp/
+temp/
+*.tmp

--- a/src/printer/Printer.zig
+++ b/src/printer/Printer.zig
@@ -39,13 +39,21 @@ pub fn pProp(self: *Printer, key: []const u8, comptime fmt: []const u8, value: a
     self.pComma();
 }
 
-pub inline fn pPropStr(self: *Printer, key: []const u8, value: []const u8) !void {
-    if (value.len >= 2 and value[0] == '"' and value[value.len - 1] == '"') {
-        return self.pProp(key, "{s}", value);
+pub inline fn pPropStr(self: *Printer, key: []const u8, value: anytype) !void {
+    const T = @TypeOf(value);
+
+    if (T == []const u8) {
+        if (value.len >= 2 and value[0] == '"' and value[value.len - 1] == '"') {
+            return self.pProp(key, "{s}", value);
+        }
+        return self.pProp(key, "\"{s}\"", value);
+    } else {
+        return self.pProp(key, "\"{any}\"", value);
     }
-    return self.pProp(key, "\"{s}\"", value);
 }
 
+/// Print a `"key": value` pair with a trailing comma. Value is stringified
+/// into JSON before printing.
 pub fn pPropJson(self: *Printer, key: []const u8, value: anytype) !void {
     try self.pPropName(key);
     try stringify(value, .{}, self.writer);

--- a/src/printer/SemanticPrinter.zig
+++ b/src/printer/SemanticPrinter.zig
@@ -1,0 +1,39 @@
+printer: *Printer,
+
+pub fn new(printer: *Printer) SemanticPrinter {
+    return SemanticPrinter{
+        .printer = printer,
+    };
+}
+
+pub fn printSymbolTable(self: *SemanticPrinter, symbols: *const Semantic.SymbolTable) !void {
+    try self.printer.pushArray();
+    defer self.printer.pop();
+
+    for (symbols.symbols.items) |symbol| {
+        try self.printSymbol(&symbol);
+    }
+}
+
+fn printSymbol(self: *SemanticPrinter, symbol: *const Semantic.Symbol) !void {
+    try self.printer.pushObject();
+    defer self.printer.pop();
+
+    try self.printer.pPropStr("name", symbol.name);
+    // try self.printer.pPropStr("kind", symbol.kind);
+    try self.printer.pProp("declNode", "{d}", symbol.decl);
+    // try self.printer.pPropStr("type", symbol.type);
+    try self.printer.pProp("scope", "{d}", symbol.scope);
+    try self.printer.pPropJson("flags", symbol.flags);
+    // try self.printer.pPropStr("location", symbol.location);
+}
+
+const SemanticPrinter = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Printer = @import("./Printer.zig");
+
+const _semantic = @import("../semantic.zig");
+const SemanticBuilder = _semantic.Builder;
+const Semantic = _semantic.Semantic;

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -134,7 +134,7 @@ pub const Builder = struct {
         // - bind function declarations
         // - record symbol types and signatures
         // - record symbol references
-        // - Scope flags for unions, structs, and enums. Blocks are currently handled (TOOD: that needs testing).
+        // - Scope flags for unions, structs, and enums. Blocks are currently handled (TODO: that needs testing).
         // - Test the shit out of it
         const tag: Ast.Node.Tag = self._semantic.ast.nodes.items(.tag)[node_id];
         switch (tag) {

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -130,6 +130,12 @@ pub const Builder = struct {
             return;
         }
 
+        // TODO:
+        // - bind function declarations
+        // - record symbol types and signatures
+        // - record symbol references
+        // - Scope flags for unions, structs, and enums. Blocks are currently handled (TOOD: that needs testing).
+        // - Test the shit out of it
         const tag: Ast.Node.Tag = self._semantic.ast.nodes.items(.tag)[node_id];
         switch (tag) {
             .root => unreachable, // root node is never referenced.
@@ -239,8 +245,6 @@ pub const Builder = struct {
             assert(var_decl.ast.init_node < self.AST().nodes.len);
             try self.visitNode(var_decl.ast.init_node);
         }
-
-        // return self.visitRecursive(node);
     }
 
     // =========================================================================
@@ -258,6 +262,7 @@ pub const Builder = struct {
         self._scope_stack.appendAssumeCapacity(root_scope.id);
     }
 
+    /// Enter a new scope, pushing it onto the stack.
     fn enterScope(self: *Builder, flags: Scope.Flags) !void {
         print("entering scope\n", .{});
         const parent_id = self._scope_stack.getLast(); // panics if stack is empty
@@ -265,12 +270,16 @@ pub const Builder = struct {
         try self._scope_stack.append(self._gpa, scope.id);
     }
 
+    /// Exit the current scope. It is a bug to pop the root scope.
     inline fn exitScope(self: *Builder) void {
         print("exiting scope\n", .{});
         assert(self._scope_stack.items.len > 1); // cannot pop root scope
         _ = self._scope_stack.pop();
     }
 
+    /// Get the current scope.
+    ///
+    /// This should never panic because the root scope is never exited.
     inline fn currentScope(self: *const Builder) Scope.Id {
         assert(self._scope_stack.items.len != 0);
         return self._scope_stack.getLast();


### PR DESCRIPTION
I also plan on using this for snapshot tests