### PR TITLE
perf(semantic): use SoA for `SymbolTable`

### DIFF
--- a/src/lint.zig
+++ b/src/lint.zig
@@ -102,11 +102,10 @@ pub const Linter = struct {
         }
         print("Symbols:\n", .{});
         {
-            var i: Semantic.Symbol.Id = 0;
-            while (i < semantic_result.value.symbols.symbols.len) {
-                const symbol = semantic_result.value.symbols.get(i);
+            var iter = semantic_result.value.symbols.iter();
+            while (iter.next()) |id| {
+                const symbol = semantic_result.value.symbols.get(id);
                 print("\t{s}\t{any}\n", .{ symbol.name, symbol });
-                i += 1;
             }
         }
         // semantic_result.deinitErrors();

--- a/src/lint.zig
+++ b/src/lint.zig
@@ -101,8 +101,13 @@ pub const Linter = struct {
             @panic("semantic analysis failed");
         }
         print("Symbols:\n", .{});
-        for (semantic_result.value.symbols.symbols.items) |symbol| {
-            print("\t{s}\t{any}\n", .{ symbol.name, symbol });
+        {
+            var i: Semantic.Symbol.Id = 0;
+            while (i < semantic_result.value.symbols.symbols.len) {
+                const symbol = semantic_result.value.symbols.get(i);
+                print("\t{s}\t{any}\n", .{ symbol.name, symbol });
+                i += 1;
+            }
         }
         // semantic_result.deinitErrors();
         const semantic = semantic_result.value;

--- a/src/printer/SemanticPrinter.zig
+++ b/src/printer/SemanticPrinter.zig
@@ -10,11 +10,10 @@ pub fn printSymbolTable(self: *SemanticPrinter, symbols: *const Semantic.SymbolT
     try self.printer.pushArray();
     defer self.printer.pop();
 
-    var i: Semantic.Symbol.Id = 0;
-    while (i < symbols.symbols.len) {
-        const symbol = symbols.get(i);
+    var iter = symbols.iter();
+    while (iter.next()) |id| {
+        const symbol = symbols.get(id);
         try self.printSymbol(symbol, symbols);
-        i += 1;
     }
 }
 

--- a/src/printer/SemanticPrinter.zig
+++ b/src/printer/SemanticPrinter.zig
@@ -10,8 +10,11 @@ pub fn printSymbolTable(self: *SemanticPrinter, symbols: *const Semantic.SymbolT
     try self.printer.pushArray();
     defer self.printer.pop();
 
-    for (symbols.symbols.items) |symbol| {
-        try self.printSymbol(&symbol, symbols);
+    var i: Semantic.Symbol.Id = 0;
+    while (i < symbols.symbols.len) {
+        const symbol = symbols.get(i);
+        try self.printSymbol(symbol, symbols);
+        i += 1;
     }
 }
 

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -491,16 +491,15 @@ test "Struct/enum fields are bound bound to the struct/enums's member table" {
         var foo: ?*const Semantic.Symbol = null;
         var bar: ?*const Semantic.Symbol = null;
         {
-            var i: Semantic.Symbol.Id = 0;
+            var iter = semantic.symbols.iter();
             const names = semantic.symbols.symbols.items(.name);
-            while (i < semantic.symbols.symbols.len) {
-                const name = names[i];
+            while (iter.next()) |id| {
+                const name = names[id];
                 if (std.mem.eql(u8, name, "bar")) {
-                    bar = semantic.symbols.get(i);
+                    bar = semantic.symbols.get(id);
                 } else if (std.mem.eql(u8, name, "Foo")) {
-                    foo = semantic.symbols.get(i);
+                    foo = semantic.symbols.get(id);
                 }
-                i += 1;
             }
         }
 

--- a/src/semantic/Semantic.zig
+++ b/src/semantic/Semantic.zig
@@ -42,11 +42,10 @@ const Type = std.builtin.Type;
 const assert = std.debug.assert;
 
 const scope = @import("./scope.zig");
-const symbol = @import("./symbol.zig");
+pub const Symbol = @import("./Symbol.zig");
+pub const SymbolTable = Symbol.SymbolTable;
 pub const Scope = scope.Scope;
-pub const Symbol = symbol.Symbol;
 pub const ScopeTree = scope.ScopeTree;
-pub const SymbolTable = symbol.SymbolTable;
 
 const str = @import("../str.zig");
 const string = str.string;

--- a/src/semantic/Symbol.zig
+++ b/src/semantic/Symbol.zig
@@ -1,0 +1,198 @@
+//! A declared variable/function/whatever.
+//!
+//! Type: `pub struct Symbol<'a>`
+
+/// Identifier name.
+///
+/// Symbols only borrow their names. These string slices reference data in
+/// source text, which owns the allocation.
+///
+/// `&'a str`
+name: string,
+/// This symbol's type. Only present if statically determinable, since
+/// analysis doesn't currently do type checking.
+// ty: ?Type,
+/// Unique identifier for this symbol.
+id: Id,
+/// Scope this symbol is declared in.
+scope: Scope.Id,
+/// Index of the AST node declaring this symbol.
+///
+/// Usually a `var`/`const` declaration, function statement, etc.
+decl: Ast.Node.Index,
+visibility: Visibility,
+flags: Flags,
+
+/// Symbols on "instance objects" (e.g. field properties and instance
+/// methods).
+///
+/// Do not write to this list directly.
+members: SymbolIdList = .{},
+/// Symbols directly accessible on the symbol itself (e.g. static methods,
+/// constants, enum members).
+///
+/// Do not write to this list directly.
+exports: SymbolIdList = .{},
+
+/// Uniquely identifies a symbol across a source file.
+pub const Id = u32;
+pub const MAX_ID = std.math.maxInt(Id);
+
+/// Visibility to external code.
+///
+/// Does not encode convention-based visibility. This reflects the `pub` Zig
+/// keyword.
+///
+/// TODO: handle exports?
+pub const Visibility = enum {
+    public,
+    private,
+};
+pub const Flags = packed struct {
+    /// Comptime symbol.
+    ///
+    /// Not `true` for inferred comptime parameters. That is, this is only
+    /// `true` when the `comptime` modifier is present.
+    s_comptime: bool = false,
+    /// TODO: not recorded yet
+    s_const: bool = false,
+    /// Indicates a container field.
+    ///
+    /// ```zig
+    /// const Foo = struct {
+    ///   bar: u32, // <- this is a container field
+    /// }
+    /// ```
+    s_member: bool = false,
+};
+
+/// Stores symbols created and referenced within a Zig program.
+///
+/// ## Members and Exports
+/// - members are "instance properties". Zig doesn't have classes, and doesn't
+///   exactly have methods, so this is a bit of a misnomer. Basically, if you
+///   create a new variable or constant that is an instantiation of a struct, its
+///   struct fields and "methods" are members
+///
+/// - Exports are symbols directly accessible on the symbol itself. A symbol's
+///   exports include private functions, even though accessing them is a compile
+///   error.
+///
+/// ```zig
+/// const Foo = struct {
+///   bar: i32,                       // member
+///   pub const qux = 42,             // export
+///   const quux = 42,                // export, not public
+///   pub fn baz(self: *Foo) void {}, // member
+///   pub fn bang() void {},          // export
+/// };
+/// ```
+pub const SymbolTable = struct {
+    /// Indexed by symbol id.
+    ///
+    /// Do not write to this list directly.
+    symbols: std.MultiArrayList(Symbol) = .{},
+
+    pub inline fn get(self: *const SymbolTable, id: Symbol.Id) *const Symbol {
+        return &self.symbols.get(id);
+    }
+
+    // zig fmt: off
+    pub fn addSymbol(
+        self: *SymbolTable,
+        alloc: Allocator,
+        declaration_node: Ast.Node.Index,
+        name: string,
+        scope_id: Scope.Id,
+        visibility: Symbol.Visibility,
+        flags: Symbol.Flags,
+    ) !Symbol.Id {
+
+        assert(self.symbols.len < Symbol.MAX_ID);
+
+        const id: Symbol.Id = @intCast(self.symbols.len);
+        const symbol =  Symbol{
+            .name = name,
+            // .ty = ty,
+            .id = id,
+            .scope = scope_id,
+            .visibility = visibility,
+            .flags = flags,
+            .decl = declaration_node,
+        };
+
+        try self.symbols.append(alloc, symbol);
+
+        return id;
+    }
+    // zig fmt: on
+
+    pub inline fn getMembers(self: *const SymbolTable, container: Symbol.Id) *const SymbolIdList {
+        return &self.symbols.items(.members)[container];
+    }
+
+    pub inline fn getMembersMut(self: *SymbolTable, container: Symbol.Id) *SymbolIdList {
+        return &self.symbols.items(.members)[container];
+    }
+
+    pub fn addMember(self: *SymbolTable, alloc: Allocator, member: Symbol.Id, container: Symbol.Id) !void {
+        try self.getMembersMut(container).append(alloc, member);
+    }
+
+    pub inline fn getExports(self: *const SymbolTable, container: Symbol.Id) *const SymbolIdList {
+        return &self.symbols.items(.exports)[container];
+    }
+
+    pub inline fn getExportsMut(self: *SymbolTable, container: Symbol.Id) *SymbolIdList {
+        return &self.symbols.items(.exports)[container];
+    }
+
+    pub inline fn addExport(self: *SymbolTable, alloc: Allocator, member: Symbol.Id, container: Symbol.Id) !void {
+        try self.getExportsMut(container).append(alloc, member);
+    }
+
+    pub inline fn iter(self: *const SymbolTable) Iterator {
+        return Iterator{ .table = self };
+    }
+
+    pub fn deinit(self: *SymbolTable, alloc: Allocator) void {
+        {
+            var i: Id = 0;
+            const len: Id = @intCast(self.symbols.len);
+            while (i < len) {
+                self.getMembersMut(i).deinit(alloc);
+                self.getExportsMut(i).deinit(alloc);
+                i += 1;
+            }
+        }
+        self.symbols.deinit(alloc);
+    }
+};
+
+pub const Iterator = struct {
+    curr: Symbol.Id = 0,
+    table: *const SymbolTable,
+
+    pub fn next(self: *Iterator) ?Symbol.Id {
+        if (self.curr >= self.table.symbols.len) {
+            return null;
+        }
+        const id = self.curr;
+        self.curr += 1;
+        return id;
+    }
+};
+
+const Symbol = @This();
+
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+const Ast = std.zig.Ast;
+const Scope = @import("scope.zig").Scope;
+const Type = std.builtin.Type;
+
+const assert = std.debug.assert;
+const string = @import("../str.zig").string;
+
+const SymbolIdList = std.ArrayListUnmanaged(Symbol.Id);

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -151,6 +151,10 @@ pub const SymbolTable = struct {
         try self.getExportsMut(container).append(alloc, member);
     }
 
+    pub inline fn iter(self: *const SymbolTable) Iterator {
+        return Iterator{ .table = self };
+    }
+
     pub fn deinit(self: *SymbolTable, alloc: Allocator) void {
         {
             var i: Id = 0;
@@ -162,6 +166,20 @@ pub const SymbolTable = struct {
             }
         }
         self.symbols.deinit(alloc);
+    }
+};
+
+pub const Iterator = struct {
+    curr: Symbol.Id = 0,
+    table: *const SymbolTable,
+
+    pub fn next(self: *Iterator) ?Symbol.Id {
+        if (self.curr >= self.table.symbols.len) {
+            return null;
+        }
+        const id = self.curr;
+        self.curr += 1;
+        return id;
     }
 };
 

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -1,69 +1,69 @@
-const std = @import("std");
+//! A declared variable/function/whatever.
+//!
+//! Type: `pub struct Symbol<'a>`
 
-const Allocator = std.mem.Allocator;
-const Ast = std.zig.Ast;
-const Scope = @import("scope.zig").Scope;
-const Type = std.builtin.Type;
-
-const assert = std.debug.assert;
-const string = @import("../str.zig").string;
-
-/// A declared variable/function/whatever.
+/// Identifier name.
 ///
-/// Type: `pub struct Symbol<'a>`
-pub const Symbol = struct {
-    /// Identifier name.
-    ///
-    /// Symbols only borrow their names. These string slices reference data in
-    /// source text, which owns the allocation.
-    ///
-    /// `&'a str`
-    name: string,
-    /// This symbol's type. Only present if statically determinable, since
-    /// analysis doesn't currently do type checking.
-    // ty: ?Type,
-    /// Unique identifier for this symbol.
-    id: Id,
-    /// Scope this symbol is declared in.
-    scope: Scope.Id,
-    /// Index of the AST node declaring this symbol.
-    ///
-    /// Usually a `var`/`const` declaration, function statement, etc.
-    decl: Ast.Node.Index,
-    visibility: Visibility,
-    flags: Flags,
+/// Symbols only borrow their names. These string slices reference data in
+/// source text, which owns the allocation.
+///
+/// `&'a str`
+name: string,
+/// This symbol's type. Only present if statically determinable, since
+/// analysis doesn't currently do type checking.
+// ty: ?Type,
+/// Unique identifier for this symbol.
+id: Id,
+/// Scope this symbol is declared in.
+scope: Scope.Id,
+/// Index of the AST node declaring this symbol.
+///
+/// Usually a `var`/`const` declaration, function statement, etc.
+decl: Ast.Node.Index,
+visibility: Visibility,
+flags: Flags,
 
-    /// Uniquely identifies a symbol across a source file.
-    pub const Id = u32;
-    pub const MAX_ID = std.math.maxInt(Id);
+/// Symbols on "instance objects" (e.g. field properties and instance
+/// methods).
+///
+/// Do not write to this list directly.
+members: SymbolIdList = .{},
+/// Symbols directly accessible on the symbol itself (e.g. static methods,
+/// constants, enum members).
+///
+/// Do not write to this list directly.
+exports: SymbolIdList = .{},
 
-    /// Visibility to external code.
+/// Uniquely identifies a symbol across a source file.
+pub const Id = u32;
+pub const MAX_ID = std.math.maxInt(Id);
+
+/// Visibility to external code.
+///
+/// Does not encode convention-based visibility. This reflects the `pub` Zig
+/// keyword.
+///
+/// TODO: handle exports?
+pub const Visibility = enum {
+    public,
+    private,
+};
+pub const Flags = packed struct {
+    /// Comptime symbol.
     ///
-    /// Does not encode convention-based visibility. This reflects the `pub` Zig
-    /// keyword.
+    /// Not `true` for inferred comptime parameters. That is, this is only
+    /// `true` when the `comptime` modifier is present.
+    s_comptime: bool = false,
+    /// TODO: not recorded yet
+    s_const: bool = false,
+    /// Indicates a container field.
     ///
-    /// TODO: handle exports?
-    pub const Visibility = enum {
-        public,
-        private,
-    };
-    pub const Flags = packed struct {
-        /// Comptime symbol.
-        ///
-        /// Not `true` for inferred comptime parameters. That is, this is only
-        /// `true` when the `comptime` modifier is present.
-        s_comptime: bool = false,
-        /// TODO: not recorded yet
-        s_const: bool = false,
-        /// Indicates a container field.
-        ///
-        /// ```zig
-        /// const Foo = struct {
-        ///   bar: u32, // <- this is a container field
-        /// }
-        /// ```
-        s_member: bool = false,
-    };
+    /// ```zig
+    /// const Foo = struct {
+    ///   bar: u32, // <- this is a container field
+    /// }
+    /// ```
+    s_member: bool = false,
 };
 
 /// Stores symbols created and referenced within a Zig program.
@@ -91,30 +91,27 @@ pub const SymbolTable = struct {
     /// Indexed by symbol id.
     ///
     /// Do not write to this list directly.
-    symbols: std.ArrayListUnmanaged(Symbol) = .{},
-    /// Symbols on "instance objects" (e.g. field properties and instance
-    /// methods).
-    ///
-    /// Do not write to this list directly.
-    members: std.ArrayListUnmanaged(SymbolIdList) = .{},
-    /// Symbols directly accessible on the symbol itself (e.g. static methods,
-    /// constants, enum members).
-    ///
-    /// Do not write to this list directly.
-    exports: std.ArrayListUnmanaged(SymbolIdList) = .{},
+    symbols: std.MultiArrayList(Symbol) = .{},
 
-    const SymbolIdList = std.ArrayListUnmanaged(Symbol.Id);
-
-    pub inline fn get(self: *SymbolTable, id: Symbol.Id) *const Symbol {
-        return &self.symbols.items[id];
+    pub inline fn get(self: *const SymbolTable, id: Symbol.Id) *const Symbol {
+        return &self.symbols.get(id);
     }
-    pub fn addSymbol(self: *SymbolTable, alloc: Allocator, declaration_node: Ast.Node.Index, name: string, scope_id: Scope.Id, visibility: Symbol.Visibility, flags: Symbol.Flags) !*Symbol {
-        assert(self.symbols.items.len < Symbol.MAX_ID);
 
-        const id: Symbol.Id = @intCast(self.symbols.items.len);
-        const symbol: *Symbol = try self.symbols.addOne(alloc);
-        symbol.* = Symbol{
-            // line break
+    // zig fmt: off
+    pub fn addSymbol(
+        self: *SymbolTable,
+        alloc: Allocator,
+        declaration_node: Ast.Node.Index,
+        name: string,
+        scope_id: Scope.Id,
+        visibility: Symbol.Visibility,
+        flags: Symbol.Flags,
+    ) !Symbol.Id {
+
+        assert(self.symbols.len < Symbol.MAX_ID);
+
+        const id: Symbol.Id = @intCast(self.symbols.len);
+        const symbol =  Symbol{
             .name = name,
             // .ty = ty,
             .id = id,
@@ -124,57 +121,60 @@ pub const SymbolTable = struct {
             .decl = declaration_node,
         };
 
-        try self.members.append(alloc, .{});
-        try self.exports.append(alloc, .{});
+        try self.symbols.append(alloc, symbol);
 
-        // sanity check
-        assert(self.symbols.items.len == self.members.items.len);
-        assert(self.symbols.items.len == self.exports.items.len);
+        return id;
+    }
+    // zig fmt: on
 
-        return symbol;
+    pub inline fn getMembers(self: *const SymbolTable, container: Symbol.Id) *const SymbolIdList {
+        return &self.symbols.items(.members)[container];
+    }
+
+    pub inline fn getMembersMut(self: *SymbolTable, container: Symbol.Id) *SymbolIdList {
+        return &self.symbols.items(.members)[container];
     }
 
     pub fn addMember(self: *SymbolTable, alloc: Allocator, member: Symbol.Id, container: Symbol.Id) !void {
-        var members = &self.members.items[container];
-        try members.append(alloc, member);
-    }
-
-    pub inline fn getMembers(self: *const SymbolTable, container: Symbol.Id) *const SymbolIdList {
-        return &self.members.items[container];
-    }
-
-    pub fn addExport(self: *SymbolTable, alloc: Allocator, member: Symbol.Id, container: Symbol.Id) !void {
-        var exports = &self.exports.items[container];
-        try exports.append(alloc, member);
+        try self.getMembersMut(container).append(alloc, member);
     }
 
     pub inline fn getExports(self: *const SymbolTable, container: Symbol.Id) *const SymbolIdList {
-        return &self.exports.items[container];
+        return &self.symbols.items(.exports)[container];
+    }
+
+    pub inline fn getExportsMut(self: *SymbolTable, container: Symbol.Id) *SymbolIdList {
+        return &self.symbols.items(.exports)[container];
+    }
+
+    pub inline fn addExport(self: *SymbolTable, alloc: Allocator, member: Symbol.Id, container: Symbol.Id) !void {
+        try self.getExportsMut(container).append(alloc, member);
     }
 
     pub fn deinit(self: *SymbolTable, alloc: Allocator) void {
+        {
+            var i: Id = 0;
+            const len: Id = @intCast(self.symbols.len);
+            while (i < len) {
+                self.getMembersMut(i).deinit(alloc);
+                self.getExportsMut(i).deinit(alloc);
+                i += 1;
+            }
+        }
         self.symbols.deinit(alloc);
-
-        {
-            var i: usize = 0;
-            const len = self.members.items.len;
-            while (i < len) {
-                var members = self.members.items[i];
-                members.deinit(alloc);
-                i += 1;
-            }
-            self.members.deinit(alloc);
-        }
-
-        {
-            var i: usize = 0;
-            const len = self.exports.items.len;
-            while (i < len) {
-                var exports = self.exports.items[i];
-                exports.deinit(alloc);
-                i += 1;
-            }
-            self.exports.deinit(alloc);
-        }
     }
 };
+
+const Symbol = @This();
+
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+const Ast = std.zig.Ast;
+const Scope = @import("scope.zig").Scope;
+const Type = std.builtin.Type;
+
+const assert = std.debug.assert;
+const string = @import("../str.zig").string;
+
+const SymbolIdList = std.ArrayListUnmanaged(Symbol.Id);


### PR DESCRIPTION
- refactor: move `exports` and `members` lists from `SymbolTable` into `Symbol`
- refactor: make `Symbol` a top-level struct
- perf: use `MultiArrayList` to store symbols
- feat: add `Symbol.Iterator`

With this change, `members` and `exports` now belong to `Symbols` (which is better logically) without sacrificing the memory layout benefits of having an array of arrays.