### PR TITLE
feat(semantic): record bound symbols in scope tree

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
         with:
           version: ${{ env.ZIG_VERSION }}
       # Run tests
+      - run: zig build --fetch
       - run: just test
 
   e2e:
@@ -64,6 +65,7 @@ jobs:
       - uses: goto-bus-stop/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
+      - run: zig build --fetch
       - run: just submodules
       - run: just e2e
       - name: Check for changes

--- a/src/semantic/Scope.zig
+++ b/src/semantic/Scope.zig
@@ -58,7 +58,10 @@ pub const ScopeTree = struct {
     /// Mappings from scopes to their descendants.
     children: std.ArrayListUnmanaged(ScopeIdList) = .{},
 
+    bindings: std.ArrayListUnmanaged(SymbolIdList) = .{},
+
     const ScopeIdList = std.ArrayListUnmanaged(Scope.Id);
+    const SymbolIdList = std.ArrayListUnmanaged(Symbol.Id);
 
     /// Create a new scope and insert it into the scope tree.
     ///
@@ -69,10 +72,15 @@ pub const ScopeTree = struct {
         const id: Scope.Id = @intCast(self.scopes.len);
 
         // initialize the new scope
-        try self.scopes.append(alloc, Scope{ .id = id, .parent = parent, .flags = flags });
+        try self.scopes.append(alloc, Scope{
+            .id = id,
+            .parent = parent,
+            .flags = flags,
+        });
 
         // set up it's child list
         try self.children.append(alloc, .{});
+        try self.bindings.append(alloc, .{});
 
         // Add it to its parent's list of child scopes
         if (parent != null) {
@@ -85,6 +93,10 @@ pub const ScopeTree = struct {
         assert(self.scopes.len == self.children.items.len);
 
         return id;
+    }
+
+    pub fn addBinding(self: *ScopeTree, alloc: Allocator, scope_id: Scope.Id, symbol_id: Symbol.Id) Allocator.Error!void {
+        return self.bindings.items[scope_id].append(alloc, symbol_id);
     }
 
     pub fn deinit(self: *ScopeTree, alloc: Allocator) void {
@@ -100,6 +112,9 @@ pub const ScopeTree = struct {
             }
             self.children.deinit(alloc);
         }
+        for (0..self.bindings.items.len) |i| {
+            self.bindings.items[i].deinit(alloc);
+        }
     }
 };
 
@@ -109,6 +124,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Ast = std.zig.Ast;
 const Type = std.builtin.Type;
+const Symbol = @import("Symbol.zig");
 
 const string = @import("util").string;
 const assert = std.debug.assert;

--- a/src/semantic/Scope.zig
+++ b/src/semantic/Scope.zig
@@ -115,6 +115,7 @@ pub const ScopeTree = struct {
         for (0..self.bindings.items.len) |i| {
             self.bindings.items[i].deinit(alloc);
         }
+        self.bindings.deinit(alloc);
     }
 };
 

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -849,15 +849,18 @@ inline fn declareSymbol(
     self: *SemanticBuilder,
     opts: DeclareSymbol,
 ) !Symbol.Id {
-    return self._semantic.symbols.addSymbol(
+    const scope = opts.scope_id orelse self.currentScope();
+    const symbol_id = try self._semantic.symbols.addSymbol(
         self._gpa,
         opts.declaration_node orelse self.currentNode(),
         opts.name,
         opts.debug_name,
-        opts.scope_id orelse self.currentScope(),
+        scope,
         opts.visibility,
         opts.flags,
     );
+    try self._semantic.scopes.addBinding(self._gpa, scope, symbol_id);
+    return symbol_id;
 }
 
 // =========================================================================

--- a/src/semantic/Symbol.zig
+++ b/src/semantic/Symbol.zig
@@ -104,11 +104,11 @@ pub const SymbolTable = struct {
     /// Do not write to this list directly.
     symbols: std.MultiArrayList(Symbol) = .{},
 
+    /// Get a symbol from the table.
     pub inline fn get(self: *const SymbolTable, id: Symbol.Id) *const Symbol {
         return &self.symbols.get(id);
     }
 
-    // zig fmt: off
     pub fn addSymbol(
         self: *SymbolTable,
         alloc: Allocator,
@@ -119,11 +119,10 @@ pub const SymbolTable = struct {
         visibility: Symbol.Visibility,
         flags: Symbol.Flags,
     ) Allocator.Error!Symbol.Id {
-
         assert(self.symbols.len < Symbol.MAX_ID);
 
         const id: Symbol.Id = @intCast(self.symbols.len);
-        const symbol =  Symbol{
+        const symbol = Symbol{
             .name = name orelse "",
             .debug_name = debug_name orelse "",
             // .ty = ty,
@@ -138,7 +137,6 @@ pub const SymbolTable = struct {
 
         return id;
     }
-    // zig fmt: on
 
     pub inline fn getMembers(self: *const SymbolTable, container: Symbol.Id) *const SymbolIdList {
         return &self.symbols.items(.members)[container];

--- a/test/snapshots/snapshot-coverage/simple/pass/block.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/block.zig.snap
@@ -143,34 +143,50 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "empty": 1, 
+      "one": 3, 
+      "two": 5, 
+      "many": 8, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "x": 2, 
+                  
+                }, "children": [
                   {
                     "id": 4, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 
@@ -183,28 +199,37 @@
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 6, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 7, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "y": 4, 
+                  
+                }, "children": [
                   {
                     "id": 8, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 
@@ -217,28 +242,38 @@
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 10, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 11, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "z": 6, 
+                  
+                }, "children": [
                   {
                     "id": 12, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      "a": 7, 
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 
@@ -251,28 +286,42 @@
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 14, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 15, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "a": 9, 
+                  
+                }, "children": [
                   {
                     "id": 16, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      "b": 10, 
+                      "c": 11, 
+                      "d": 12, 
+                      "e": 13, 
+                      "f": 14, 
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/block_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/block_comptime.zig.snap
@@ -35,7 +35,11 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "x": 1, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
@@ -43,7 +47,10 @@
           "comptime", 
           
         ], 
-        "children": [], 
+        "bindings": {
+          "y": 2, 
+          
+        }, "children": [], 
         
       }, 
     ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/cond_if.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/cond_if.zig.snap
@@ -80,34 +80,51 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "std": 1, 
+      "builtin": 2, 
+      "msg": 3, 
+      "simpleIf": 4, 
+      "comptimeIf": 7, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "i": 5, 
+                  
+                }, "children": [
                   {
                     "id": 4, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, {
                     "id": 5, 
@@ -115,7 +132,10 @@
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      "pow": 6, 
+                      
+                    }, "children": [], 
                     
                   }, {
                     "id": 6, 
@@ -123,7 +143,9 @@
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 
@@ -136,21 +158,27 @@
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 8, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 9, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  
+                }, "children": [
                   {
                     "id": 10, 
                     "flags": [
@@ -158,7 +186,9 @@
                       "comptime", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
@@ -71,34 +71,51 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "Foo": 1, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           "block", 
           
         ], 
-        "children": [
+        "bindings": {
+          "a": 2, 
+          "b": 3, 
+          "c": 4, 
+          "Bar": 5, 
+          "isNotA": 6, 
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
                   "function", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  
+                }, "children": [
                   {
                     "id": 4, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
@@ -98,34 +98,54 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "std": 1, 
+      "Managed": 2, 
+      "main": 3, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "allocator": 4, 
+                  "a": 5, 
+                  "b": 6, 
+                  "i": 7, 
+                  "c": 8, 
+                  "as": 9, 
+                  
+                }, "children": [
                   {
                     "id": 4, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
@@ -107,14 +107,22 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "Box": 1, 
+      "FixedIntArray": 5, 
+      "add": 8, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           "comptime", 
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
@@ -122,7 +130,9 @@
               "comptime", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
@@ -130,7 +140,9 @@
                   "comptime", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  
+                }, "children": [
                   {
                     "id": 4, 
                     "flags": [
@@ -138,27 +150,38 @@
                       "comptime", 
                       
                     ], 
-                    "children": [
+                    "bindings": {
+                      "inner": 2, 
+                      "Self": 3, 
+                      "deref": 4, 
+                      
+                    }, "children": [
                       {
                         "id": 5, 
                         "flags": [
                           
                         ], 
-                        "children": [
+                        "bindings": {
+                          
+                        }, "children": [
                           {
                             "id": 6, 
                             "flags": [
                               "function", 
                               
                             ], 
-                            "children": [
+                            "bindings": {
+                              
+                            }, "children": [
                               {
                                 "id": 7, 
                                 "flags": [
                                   "block", 
                                   
                                 ], 
-                                "children": [], 
+                                "bindings": {
+                                  
+                                }, "children": [], 
                                 
                               }, 
                             ], 
@@ -178,7 +201,9 @@
           "comptime", 
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 9, 
             "flags": [
@@ -186,7 +211,9 @@
               "comptime", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 10, 
                 "flags": [
@@ -194,7 +221,10 @@
                   "comptime", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "l": 6, 
+                  
+                }, "children": [
                   {
                     "id": 11, 
                     "flags": [
@@ -202,7 +232,9 @@
                       "comptime", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, {
                     "id": 12, 
@@ -211,7 +243,10 @@
                       "comptime", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      "inner": 7, 
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 
@@ -224,21 +259,28 @@
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 14, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 15, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "a2": 10, 
+                  
+                }, "children": [
                   {
                     "id": 16, 
                     "flags": [
@@ -246,7 +288,10 @@
                       "comptime", 
                       
                     ], 
-                    "children": [
+                    "bindings": {
+                      "c": 9, 
+                      
+                    }, "children": [
                       {
                         "id": 17, 
                         "flags": [
@@ -254,7 +299,9 @@
                           "comptime", 
                           
                         ], 
-                        "children": [], 
+                        "bindings": {
+                          
+                        }, "children": [], 
                         
                       }, 
                     ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
@@ -44,54 +44,74 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "foo": 1, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "inner": 2, 
+                  
+                }, "children": [
                   {
                     "id": 4, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [
+                    "bindings": {
+                      "bar": 3, 
+                      
+                    }, "children": [
                       {
                         "id": 5, 
                         "flags": [
                           
                         ], 
-                        "children": [
+                        "bindings": {
+                          
+                        }, "children": [
                           {
                             "id": 6, 
                             "flags": [
                               "function", 
                               
                             ], 
-                            "children": [
+                            "bindings": {
+                              
+                            }, "children": [
                               {
                                 "id": 7, 
                                 "flags": [
                                   "block", 
                                   
                                 ], 
-                                "children": [], 
+                                "bindings": {
+                                  
+                                }, "children": [], 
                                 
                               }, 
                             ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
@@ -80,34 +80,52 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "std": 1, 
+      "bad": 2, 
+      "good": 3, 
+      "Foo": 4, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           "block", 
           
         ], 
-        "children": [
+        "bindings": {
+          "foo": 5, 
+          "Bar": 6, 
+          "baz": 7, 
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
                   "function", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  
+                }, "children": [
                   {
                     "id": 4, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
@@ -71,34 +71,50 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "std": 1, 
+      "forOverArr": 2, 
+      "forWithMultiBindingClosure": 5, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "arr": 3, 
+                  
+                }, "children": [
                   {
                     "id": 4, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      "power_of_two": 4, 
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 
@@ -111,42 +127,55 @@
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 6, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 7, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "mat4x4": 6, 
+                  
+                }, "children": [
                   {
                     "id": 8, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [
+                    "bindings": {
+                      
+                    }, "children": [
                       {
                         "id": 9, 
                         "flags": [
                           "block", 
                           
                         ], 
-                        "children": [
+                        "bindings": {
+                          
+                        }, "children": [
                           {
                             "id": 10, 
                             "flags": [
                               "block", 
                               
                             ], 
-                            "children": [], 
+                            "bindings": {
+                              
+                            }, "children": [], 
                             
                           }, 
                         ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
@@ -152,34 +152,52 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "std": 1, 
+      "simpleWhile": 2, 
+      "whileWithClosure": 5, 
+      "whileWithExpr": 10, 
+      "rangeHasNumber": 14, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "i": 3, 
+                  
+                }, "children": [
                   {
                     "id": 4, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      "power_of_two": 4, 
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 
@@ -192,28 +210,40 @@
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 6, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 7, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "map": 6, 
+                  "iter": 7, 
+                  
+                }, "children": [
                   {
                     "id": 8, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      "k": 8, 
+                      "v": 9, 
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 
@@ -226,28 +256,38 @@
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 10, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 11, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "x": 11, 
+                  "y": 12, 
+                  
+                }, "children": [
                   {
                     "id": 12, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, {
                     "id": 13, 
@@ -255,7 +295,10 @@
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      "my_xy": 13, 
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 
@@ -268,35 +311,46 @@
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 15, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 16, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  "i": 15, 
+                  
+                }, "children": [
                   {
                     "id": 17, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [
+                    "bindings": {
+                      
+                    }, "children": [
                       {
                         "id": 18, 
                         "flags": [
                           "block", 
                           
                         ], 
-                        "children": [], 
+                        "bindings": {
+                          
+                        }, "children": [], 
                         
                       }, 
                     ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/struct_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/struct_members.zig.snap
@@ -53,14 +53,23 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "Foo": 1, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           "block", 
           
         ], 
-        "children": [], 
+        "bindings": {
+          "a": 2, 
+          "B": 3, 
+          "C": 4, 
+          
+        }, "children": [], 
         
       }, 
     ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
@@ -53,27 +53,40 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "a": 1, 
+      "b": 2, 
+      "Foo": 3, 
+      "new": 4, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           
         ], 
-        "children": [
+        "bindings": {
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
               "function", 
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
                   "block", 
                   
                 ], 
-                "children": [], 
+                "bindings": {
+                  
+                }, "children": [], 
                 
               }, 
             ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
@@ -107,61 +107,90 @@
       "top", 
       
     ], 
-    "children": [
+    "bindings": {
+      "@This()": 0, 
+      "Writer": 1, 
+      
+    }, "children": [
       {
         "id": 1, 
         "flags": [
           "block", 
           
         ], 
-        "children": [
+        "bindings": {
+          "ptr": 2, 
+          "writeAllFn": 3, 
+          "init": 4, 
+          "writeAll": 10, 
+          
+        }, "children": [
           {
             "id": 2, 
             "flags": [
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 3, 
                 "flags": [
                   "function", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  
+                }, "children": [
                   {
                     "id": 4, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [
+                    "bindings": {
+                      "T": 5, 
+                      "ptr_info": 6, 
+                      "gen": 7, 
+                      
+                    }, "children": [
                       {
                         "id": 5, 
                         "flags": [
                           "block", 
                           
                         ], 
-                        "children": [
+                        "bindings": {
+                          "writeAll": 8, 
+                          
+                        }, "children": [
                           {
                             "id": 6, 
                             "flags": [
                               
                             ], 
-                            "children": [
+                            "bindings": {
+                              
+                            }, "children": [
                               {
                                 "id": 7, 
                                 "flags": [
                                   "function", 
                                   
                                 ], 
-                                "children": [
+                                "bindings": {
+                                  
+                                }, "children": [
                                   {
                                     "id": 8, 
                                     "flags": [
                                       "block", 
                                       
                                     ], 
-                                    "children": [], 
+                                    "bindings": {
+                                      "self": 9, 
+                                      
+                                    }, "children": [], 
                                     
                                   }, 
                                 ], 
@@ -180,21 +209,27 @@
             "flags": [
               
             ], 
-            "children": [
+            "bindings": {
+              
+            }, "children": [
               {
                 "id": 10, 
                 "flags": [
                   "function", 
                   
                 ], 
-                "children": [
+                "bindings": {
+                  
+                }, "children": [
                   {
                     "id": 11, 
                     "flags": [
                       "block", 
                       
                     ], 
-                    "children": [], 
+                    "bindings": {
+                      
+                    }, "children": [], 
                     
                   }, 
                 ], 


### PR DESCRIPTION
This data was already available in the symbol table (symbol -> scope). Now the reverse is also recorded (scope -> its symbols).

I also refactored `declareSymbol` et al to use named parameters. Makes setting defaults much easier.