### PR TITLE
test(e2e): open snapshot file after tests run

### DIFF
--- a/src/Error.zig
+++ b/src/Error.zig
@@ -19,7 +19,8 @@ source: ?ArcStr = null,
 help: ?string = null,
 
 // Although this is not [:0]const u8, it should not be mutated. Needs to be mut
-// for Arc dealloc reasons.
+// to indicate to Arc it's owned by the Error. Otherwise, arc.deinit() won't
+// free the slice.
 const ArcStr = Arc([:0]u8);
 pub const PossiblyStaticStr = struct {
     static: bool = true,

--- a/src/reporter/Reporter.zig
+++ b/src/reporter/Reporter.zig
@@ -17,6 +17,7 @@ pub fn Reporter(
             };
         }
         pub fn reportErrors(self: *Self, errors: std.ArrayList(Error)) void {
+            if (errors.items.len == 0) return;
             self.writer_lock.lock();
             defer self.writer_lock.unlock();
 


### PR DESCRIPTION
Only open a suite's snapshot file after all tests have run. Before, canceling a test in the middle of a run would leave the snapshot file empty, which is annoying.