### PR TITLE
refactor: add nominal id types

### DIFF
--- a/src/printer/SemanticPrinter.zig
+++ b/src/printer/SemanticPrinter.zig
@@ -28,15 +28,12 @@ fn printSymbol(self: *SemanticPrinter, symbol: *const Semantic.Symbol, symbols: 
 
     try self.printer.pPropStr("name", symbol.name);
     try self.printer.pPropStr("debugName", symbol.debug_name);
-    // try self.printer.pPropStr("kind", symbol.kind);
     const decl = self.semantic.ast.nodes.items(.tag)[symbol.decl];
     try self.printer.pPropWithNamespacedValue("declNode", decl);
-    // try self.printer.pPropStr("type", symbol.type);
     try self.printer.pProp("scope", "{d}", symbol.scope);
     try self.printer.pPropJson("flags", symbol.flags);
-    try self.printer.pPropJson("members", symbols.getMembers(symbol.id).items);
-    try self.printer.pPropJson("exports", symbols.getExports(symbol.id).items);
-    // try self.printer.pPropStr("location", symbol.location);
+    try self.printer.pPropJson("members", @as([]u32, @ptrCast(symbols.getMembers(symbol.id).items)));
+    try self.printer.pPropJson("exports", @as([]u32, @ptrCast(symbols.getExports(symbol.id).items)));
 }
 
 pub fn printScopeTree(self: *SemanticPrinter) !void {
@@ -81,11 +78,12 @@ fn printScope(self: *SemanticPrinter, scope: *const Semantic.Scope) !void {
         // var bindings = std.StringHashMap(Symbol.Id).init(fixed_alloc.get());
         // defer bindings.deinit();
         for (scopes.bindings.items[scope.id].items) |id| {
-            var name = bound_names[id];
+            const i = id.int();
+            var name = bound_names[i];
             if (name.len == 0) {
-                name = debug_names[id];
+                name = debug_names[i];
             }
-            try p.pProp(name, "{d}", id);
+            try p.pProp(name, "{d}", i);
         }
     }
 

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -677,7 +677,7 @@ fn enterRoot(self: *SemanticBuilder) !void {
         .debug_name = "@This()",
         .flags = .{ .s_const = true },
     });
-    util.assert(root_symbol_id == 0, "Creating root symbol returned id {d} which is not the expected root id (0)", .{root_symbol_id});
+    util.assert(root_symbol_id.int() == 0, "Creating root symbol returned id {d} which is not the expected root id (0)", .{root_symbol_id});
     try self.enterContainerSymbol(root_symbol_id);
 }
 
@@ -692,7 +692,7 @@ inline fn assertRoot(self: *const SemanticBuilder) void {
     self.assertCtx(self._node_stack.items[0] == Semantic.ROOT_NODE_ID, "assertRoot: node stack is not at root", .{});
 
     self.assertCtx(self._symbol_stack.items.len == 1, "assertRoot: symbol stack is not at root", .{});
-    self.assertCtx(self._symbol_stack.items[0] == 0, "assertRoot: symbol stack is not at root", .{}); // TODO: create root symbol id.
+    self.assertCtx(self._symbol_stack.items[0].int() == 0, "assertRoot: symbol stack is not at root", .{}); // TODO: create root symbol id.
 }
 
 /// Update a single flag on the set of current scope flags, returning its
@@ -1064,8 +1064,9 @@ fn printSymbolStack(self: *const SemanticBuilder) void {
 
     print("Symbol stack:\n", .{});
     for (self._symbol_stack.items) |id| {
-        const name = names[id];
-        print("  - {d}: {s}\n", .{ id, name });
+        const i = id.int();
+        const name = names[i];
+        print("  - {d}: {s}\n", .{ i, name });
     }
 }
 
@@ -1136,7 +1137,7 @@ test "Struct/enum fields are bound bound to the struct/enums's member table" {
             var iter = semantic.symbols.iter();
             const names = semantic.symbols.symbols.items(.name);
             while (iter.next()) |id| {
-                const name = names[id];
+                const name = names[id.int()];
                 if (std.mem.eql(u8, name, "bar")) {
                     bar = semantic.symbols.get(id);
                 } else if (std.mem.eql(u8, name, "Foo")) {

--- a/src/semantic/id.zig
+++ b/src/semantic/id.zig
@@ -1,0 +1,151 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+/// Create a nominal identifier type with the same memory layout as `TRepr` (an
+/// unsigned integer type).
+///
+/// The returned identifier type, `Id`, also has an `Optional` type that can be
+/// used to compactly represent `?Id`. The only caveat is, since `Optional` uses
+/// the largest possible value to represent `null`, `Id` must all be one less than
+/// `TRepr`'s maximum value.
+pub fn NominalId(TRepr: type) type {
+    const info = @typeInfo(TRepr);
+    comptime {
+        const err = "NominalId representation must be an unsigned integer";
+        switch (info) {
+            .Int => if (info.Int.signedness == .signed) @compileError(err),
+            else => @compileError(err),
+        }
+    }
+    const max = std.math.maxInt(TRepr);
+
+    return enum(TRepr) {
+        _,
+
+        const Id = @This();
+        pub const Repr = TRepr;
+        pub const MAX = max;
+
+        pub inline fn new(value: Repr) Id {
+            return @enumFromInt(value);
+        }
+
+        /// Get this id in its integer representation.
+        ///
+        /// This is the same as `Id.into(Repr)`.
+        pub inline fn int(self: Id) Repr {
+            return @intFromEnum(self);
+        }
+
+        /// Check if two Ids are equal.
+        pub inline fn eq(self: Id, other: Id) bool {
+            return self.int() == other.int();
+        }
+
+        /// Cast a value into an Id.
+        ///
+        /// When `value` has the same type as `Repr`, this is effectively the
+        /// same as `new(value)`.
+        pub inline fn from(value: anytype) Id {
+            const T = @TypeOf(value);
+            return switch (T) {
+                Repr => return @enumFromInt(value),
+                Id => return value,
+                Optional => @enumFromInt(@intFromEnum(value)),
+                // allow other int types
+                else => {
+                    const intoInfo = @typeInfo(T);
+                    switch (intoInfo) {
+                        .Int => {
+                            if (comptime intoInfo.Int.bits > info.Int.bits) {
+                                assert(value <= max);
+                            }
+                            if (comptime intoInfo.Int.signedness == .signed) {
+                                assert(value >= 0);
+                            }
+                            return @enumFromInt(@as(Repr, @intCast(value)));
+                        },
+                        else => @compileError("Cannot create Id from type " ++ @typeName(T) ++ ". Only Maybe and " ++ @typeName(Repr) ++ " are supported."),
+                    }
+                },
+            };
+        }
+
+        /// Cast this id into another type.
+        ///
+        /// - `into()` supports zero-overhead casts into the representation type,
+        ///   itself, and integer types with more bits
+        /// - You may also cast into `Id.Maybe`, but a bounds check is made,
+        ///   panicking if the value is `MAX`.
+        /// - Casting into other integer types is allowed, bounds checks are
+        ///   made for types with fewer bits.
+        pub inline fn into(self: Id, T: type) T {
+            switch (T) {
+                Repr => return @intFromEnum(self),
+                Id => return self,
+                Optional => {
+                    std.debug.assert(self.int() != MAX);
+                    return @enumFromInt(@intFromEnum(self));
+                },
+                // try to turn this into another int type
+                else => {
+                    const intoInfo = @typeInfo(T);
+                    switch (intoInfo) {
+                        .Int => {
+                            if (comptime intoInfo.Int.bits < info.Int.bits) {
+                                assert(self <= std.math.maxInt(T));
+                            }
+                            return @intFromEnum(self);
+                        },
+                        else => @compileError("Cannot create Id from type " ++ @typeName(T) ++ ". Only Maybe and " ++ @typeName(Repr) ++ " are supported."),
+                    }
+                },
+            }
+        }
+
+        /// Try to turn this id into its corresponding optional type. Returns
+        /// `null` if the id is `MAX` (which is used to represent `Optional.none`).
+        pub inline fn optional(self: Id) ?Optional {
+            return if (@intFromEnum(self) == MAX)
+                null
+            else
+                @enumFromInt(@intFromEnum(self));
+        }
+
+        /// A compact representation of `?Id` using the Id's maximum value as `null`.
+        pub const Optional = enum(Repr) {
+            none = max,
+            _,
+
+            pub const MAX = max - 1;
+
+            pub fn new(value: Repr) ?Optional {
+                return if (value == max) null else @enumFromInt(value);
+            }
+
+            /// Get this id in its integer representation.
+            ///
+            /// This is the same as `Optional.into(Repr)`.
+            pub inline fn int(self: Optional) Repr {
+                return @intFromEnum(self);
+            }
+
+            /// Check if two ids are equal.
+            pub inline fn eq(self: Id, other: Id) bool {
+                return self.int() == other.int();
+            }
+
+            /// Try to cast an optional id ito its concrete id type.
+            pub inline fn unwrap(self: Optional) ?Id {
+                return if (self == .none)
+                    null
+                else
+                    @enumFromInt(@intFromEnum(self));
+            }
+
+            pub inline fn tryFrom(value: anytype) ?Optional {
+                return Id.from(value).optional();
+            }
+        };
+    };
+}


### PR DESCRIPTION
Only `Symbol.Id` is updated to use `NominalId`.