### PR TITLE
fix(semantic): bugs in reference recording

### DIFF
--- a/src/printer/Printer.zig
+++ b/src/printer/Printer.zig
@@ -151,6 +151,10 @@ pub fn pop(self: *Printer) void {
     _ = res catch @panic("failed to write container end");
 }
 
+pub fn popIndent(self: *Printer) void {
+    self.pop();
+    self.pIndent() catch @panic("failed to write indent after container end");
+}
 pub fn pIndent(self: *Printer) !void {
     try self.writer.writeAll(self._newline);
     try self.writer.writeByteNTimes(self.indent, self.shiftwidth * self.container_stack.items.len);

--- a/src/printer/SemanticPrinter.zig
+++ b/src/printer/SemanticPrinter.zig
@@ -121,7 +121,7 @@ fn printScope(self: *SemanticPrinter, scope: *const Semantic.Scope) !void {
     {
         try p.pPropName("bindings");
         try p.pushObject();
-        defer p.pop();
+        defer p.popIndent();
         // var bindings = std.StringHashMap(Symbol.Id).init(fixed_alloc.get());
         // defer bindings.deinit();
         for (scopes.bindings.items[scope.id.int()].items) |id| {
@@ -144,7 +144,7 @@ fn printScope(self: *SemanticPrinter, scope: *const Semantic.Scope) !void {
     }
     try p.pPropName("children");
     try p.pushArray();
-    defer p.pop();
+    defer p.popIndent();
     for (children.items) |child_id| {
         const child = &scopes.getScope(child_id);
         try self.printScope(child);

--- a/src/printer/SemanticPrinter.zig
+++ b/src/printer/SemanticPrinter.zig
@@ -19,6 +19,9 @@ pub fn printSymbolTable(self: *SemanticPrinter) !void {
     while (iter.next()) |id| {
         const symbol = symbols.get(id);
         try self.printSymbol(symbol, symbols);
+        if (id.int() + 1 != symbols.symbols.len) {
+            try self.printer.pIndent();
+        }
     }
 }
 

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -1067,7 +1067,7 @@ fn resolveReferencesInCurrentScope(self: *SemanticBuilder) Allocator.Error!void 
         }
     }
 
-    const num_unresolved = curr.items.len - resolved_map.len;
+    const num_unresolved = curr.items.len - num_resolved;
     if (num_unresolved > 0) {
         if (parent) |p| {
             try p.ensureUnusedCapacity(self._gpa, num_unresolved);
@@ -1082,6 +1082,7 @@ fn resolveReferencesInCurrentScope(self: *SemanticBuilder) Allocator.Error!void 
             _ = self._unresolved_references.frames.pop();
         } else {
             const temp = try self._gpa.dupe(Reference.Id, curr.items);
+            defer self._gpa.free(temp);
             var i: usize = 0;
             var j: usize = 0;
             while (i < temp.len) : (i += 1) {

--- a/src/semantic/Symbol.zig
+++ b/src/semantic/Symbol.zig
@@ -174,6 +174,12 @@ pub const SymbolTable = struct {
         return self.references.get(reference_id.into(usize));
     }
 
+    pub fn getReferences(
+        self: *const SymbolTable,
+        symbol_id: Symbol.Id,
+    ) []const Reference.Id {
+        return self.symbols.items(.references)[symbol_id.int()].items;
+    }
     pub fn getReferencesMut(
         self: *SymbolTable,
         symbol_id: Symbol.Id,
@@ -203,6 +209,24 @@ pub const SymbolTable = struct {
 
     pub inline fn addExport(self: *SymbolTable, alloc: Allocator, member: Symbol.Id, container: Symbol.Id) Allocator.Error!void {
         try self.getExportsMut(container).append(alloc, member);
+    }
+
+    /// Look for a symbol bound to the given identifier. Mostly used for
+    /// testing.
+    ///
+    /// Returns the first found
+    /// symbol. Since symbols are bound in the order they're declared, this will
+    /// be the first declaration.
+    pub fn getSymbolNamed(self: *const SymbolTable, name: []const u8) ?Symbol.Id {
+        const names = self.symbols.items(.name);
+
+        for (0..names.len) |symbol_id| {
+            if (std.mem.eql(u8, names[symbol_id], name)) {
+                return Symbol.Id.from(symbol_id);
+            }
+        }
+
+        return null;
     }
 
     pub inline fn iter(self: *const SymbolTable) Iterator {

--- a/src/semantic/test/symbol_ref_test.zig
+++ b/src/semantic/test/symbol_ref_test.zig
@@ -1,0 +1,137 @@
+const std = @import("std");
+const mem = std.mem;
+const util = @import("util");
+
+const SemanticBuilder = @import("../SemanticBuilder.zig");
+const Semantic = @import("../Semantic.zig");
+const Symbol = @import("../Symbol.zig");
+const report = @import("../../reporter.zig");
+const Reference = @import("../Reference.zig");
+
+const t = std.testing;
+const panic = std.debug.panic;
+const print = std.debug.print;
+
+var r = report.GraphicalReporter.init(std.io.getStdErr().writer(), report.GraphicalFormatter.unicode(t.allocator, false));
+
+fn build(src: [:0]const u8) !Semantic {
+    var builder = SemanticBuilder.init(t.allocator);
+    defer builder.deinit();
+
+    var result = builder.build(src) catch |e| {
+        print("Analysis failed on source:\n\n{s}\n", .{src});
+        return e;
+    };
+    errdefer result.value.deinit();
+    r.reportErrors(result.errors.toManaged(t.allocator));
+    if (result.hasErrors()) {
+        panic("Analysis failed on source:\n\n{s}\n", .{src});
+    }
+
+    return result.value;
+}
+
+test "references record where and how a symbol is used" {
+    const src =
+        \\fn foo() u32 {
+        \\  var x: u32 = 1;
+        \\  const y: u32 = x + 1;
+        \\  x += y;
+        \\  return x;
+        \\}
+    ;
+    var semantic = try build(src);
+    defer semantic.deinit();
+    const symbols = semantic.symbols;
+    const scopes = semantic.scopes;
+
+    // FIXME: should be 2 (maybe 3?) but is 4
+    try t.expectEqual(4, scopes.len());
+    try t.expectEqual(0, symbols.unresolved_references.items.len);
+
+    const x: Symbol.Id = symbols.getSymbolNamed("x") orelse {
+        @panic("Could not find variable `x`.");
+    };
+
+    var refs = symbols.iterReferences(x);
+    try t.expectEqual(3, refs.len());
+
+    // const y: u32 = x + 1;
+    var ref = refs.next().?;
+    try t.expectEqual(ref.flags, Reference.Flags{ .read = true });
+
+    // x += y;
+    ref = refs.next().?;
+    try t.expectEqual(ref.flags, Reference.Flags{ .read = true, .write = true });
+
+    // return x;
+    ref = refs.next().?;
+    try t.expectEqual(ref.flags, Reference.Flags{ .read = true });
+}
+
+test "various read references" {
+    const sources = [_][:0]const u8{
+        \\const x = 1;
+        \\const y = x;
+        ,
+        \\const std = @import("std");
+        \\fn foo() void {
+        \\  var x = 1;
+        \\  const y = 2;
+        \\  if (x > y) {
+        \\    std.debug.print("x is greater than y\n", .{});
+        \\  }
+        \\}
+        ,
+        // FIXME: these are all failing
+        // \\fn foo() void {
+        // \\  {
+        // \\    const y = x;
+        // \\    _ = y;
+        // \\  }
+        // \\  const x = 1;
+        // \\}
+        // ,
+        // \\fn foo() void {
+        // \\  const y = x;
+        // \\  _ = y;
+        // \\}
+        // \\const x = 1;
+        // ,
+        // \\fn foo(x: u32) u32 {
+        // \\  return x;
+        // \\}
+        // ,
+        // \\const std = @import("std");
+        // \\fn main() u32 {
+        // \\  const arr = std.heap.page_allocator.alloc(u32, 8) catch |x| @panic(@errorName(x));
+        // \\}
+        // ,
+        // \\const std = @import("std");
+        // \\fn main() u32 {
+        // \\  const y: ?u32 = null;
+        // \\  if (y) |x| {
+        // \\    std.debug.print("y is non-null: {d}\n", .{x});
+        // \\  }
+        // \\}
+    };
+
+    for (sources) |source| {
+        var sem = try build(source);
+        defer sem.deinit();
+        const x: Symbol.Id = brk: {
+            if (sem.symbols.getSymbolNamed("x")) |_x| {
+                break :brk _x;
+            } else {
+                panic("Symbol 'x' not found in source:\n\n{s}\n", .{source});
+            }
+        };
+        const refs = sem.symbols.getReferences(x);
+        t.expectEqual(1, refs.len) catch |e| {
+            print("Source:\n\n{s}\n", .{source});
+            return e;
+        };
+        // try t.expectFmt(refs.len == 1, "Expected 'x' to have 1 reference, found {d}. Source:\n\n{s}\n", .{ refs.len, source });
+        // // try t.expect(refs.len == 2);
+    }
+}

--- a/src/semantic/test/symbol_ref_test.zig
+++ b/src/semantic/test/symbol_ref_test.zig
@@ -14,9 +14,8 @@ const t = std.testing;
 const panic = std.debug.panic;
 const print = std.debug.print;
 
-var r = report.GraphicalReporter.init(std.io.getStdErr().writer(), report.GraphicalFormatter.unicode(t.allocator, false));
-
 fn build(src: [:0]const u8) !Semantic {
+    var r = report.GraphicalReporter.init(std.io.getStdErr().writer(), report.GraphicalFormatter.unicode(t.allocator, false));
     var builder = SemanticBuilder.init(t.allocator);
     defer builder.deinit();
 

--- a/test/snapshots/snapshot-coverage/simple/pass/block.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/block.zig.snap
@@ -206,7 +206,8 @@
       "two": 5, 
       "many": 8, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -214,7 +215,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -223,7 +225,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -233,7 +236,8 @@
                 "bindings": {
                   "x": 2, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": [
@@ -242,14 +246,18 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, {
         "id": semantic.id.NominalId(u32)(5), 
         "flags": [
@@ -257,7 +265,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(6), 
             "flags": [
@@ -266,7 +275,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(7), 
                 "flags": [
@@ -276,7 +286,8 @@
                 "bindings": {
                   "y": 4, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(8), 
                     "flags": [
@@ -285,14 +296,18 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, {
         "id": semantic.id.NominalId(u32)(9), 
         "flags": [
@@ -300,7 +315,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(10), 
             "flags": [
@@ -309,7 +325,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(11), 
                 "flags": [
@@ -319,7 +336,8 @@
                 "bindings": {
                   "z": 6, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(12), 
                     "flags": [
@@ -329,14 +347,18 @@
                     "bindings": {
                       "a": 7, 
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, {
         "id": semantic.id.NominalId(u32)(13), 
         "flags": [
@@ -344,7 +366,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(14), 
             "flags": [
@@ -353,7 +376,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(15), 
                 "flags": [
@@ -363,7 +387,8 @@
                 "bindings": {
                   "a": 9, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(16), 
                     "flags": [
@@ -377,15 +402,20 @@
                       "e": 13, 
                       "f": 14, 
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/block.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/block.zig.snap
@@ -12,7 +12,8 @@
       "members": [1,2,3,4,5,6,7,8,9,10,11,12,13,14], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "empty", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -24,7 +25,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "x", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -37,7 +39,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "one", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -49,7 +52,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "y", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -62,7 +66,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "two", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -74,7 +79,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "z", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -87,7 +93,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "a", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -100,7 +107,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "many", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -112,7 +120,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "a", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -125,7 +134,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "b", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -138,7 +148,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "c", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -151,7 +162,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "d", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -164,7 +176,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "e", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -177,7 +190,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "f", 
       "debugName": "", 
       "declNode": "simple_var_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/block_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/block_comptime.zig.snap
@@ -51,7 +51,8 @@
       "@This()": 0, 
       "x": 1, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -62,9 +63,11 @@
         "bindings": {
           "y": 2, 
           
-        }, "children": [], 
+        }, 
+        "children": [], 
         
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/block_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/block_comptime.zig.snap
@@ -12,7 +12,8 @@
       "members": [1], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "x", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -24,7 +25,8 @@
       "members": [2], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "y", 
       "debugName": "", 
       "declNode": "simple_var_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/cond_if.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/cond_if.zig.snap
@@ -123,7 +123,8 @@
       "simpleIf": 4, 
       "comptimeIf": 7, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -131,7 +132,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -140,7 +142,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -150,7 +153,8 @@
                 "bindings": {
                   "i": 5, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": [
@@ -159,7 +163,8 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, {
                     "id": semantic.id.NominalId(u32)(5), 
@@ -170,7 +175,8 @@
                     "bindings": {
                       "pow": 6, 
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, {
                     "id": semantic.id.NominalId(u32)(6), 
@@ -180,14 +186,18 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, {
         "id": semantic.id.NominalId(u32)(7), 
         "flags": [
@@ -195,7 +205,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(8), 
             "flags": [
@@ -204,7 +215,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(9), 
                 "flags": [
@@ -213,7 +225,8 @@
                 ], 
                 "bindings": {
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(10), 
                     "flags": [
@@ -223,15 +236,20 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/cond_if.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/cond_if.zig.snap
@@ -12,7 +12,8 @@
       "members": [1,2,3,4,5,6,7], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "std", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -25,7 +26,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "builtin", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -39,7 +41,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "msg", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -51,7 +54,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "simpleIf", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -63,7 +67,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "i", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -81,7 +86,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "pow", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -94,7 +100,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "comptimeIf", 
       "debugName": "", 
       "declNode": "fn_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
@@ -12,7 +12,8 @@
       "members": [1], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "Foo", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -26,7 +27,8 @@
       "members": [2,3,4,5,6], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "a", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -38,7 +40,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "b", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -50,7 +53,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "c", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -62,7 +66,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "Bar", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -74,7 +79,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "isNotA", 
       "debugName": "", 
       "declNode": "fn_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
@@ -99,7 +99,8 @@
       "@This()": 0, 
       "Foo": 1, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -113,7 +114,8 @@
           "Bar": 5, 
           "isNotA": 6, 
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -121,7 +123,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -130,7 +133,8 @@
                 ], 
                 "bindings": {
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": [
@@ -139,15 +143,20 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
@@ -94,7 +94,10 @@
       
     }, 
   ], 
-  "unresolvedReferences": [],
+  "unresolvedReferences": [
+    {"symbol":null,"scope":4,"node":"identifier","identifier":"self","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    
+  ], 
   "scopes": {
     "id": semantic.id.NominalId(u32)(0), 
     "flags": [

--- a/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
@@ -162,7 +162,8 @@
       "Managed": 2, 
       "main": 3, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -170,7 +171,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -179,7 +181,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -194,7 +197,8 @@
                   "c": 8, 
                   "as": 9, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": [
@@ -203,15 +207,20 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
@@ -12,7 +12,8 @@
       "members": [1,2,3,4,5,6,7,8,9], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "std", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -28,7 +29,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "Managed", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -43,7 +45,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "main", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -55,7 +58,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "allocator", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -72,7 +76,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "a", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -88,7 +93,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "b", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -104,7 +110,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "i", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -118,7 +125,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "c", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -133,7 +141,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "as", 
       "debugName": "", 
       "declNode": "simple_var_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
@@ -152,7 +152,8 @@
       "FixedIntArray": 5, 
       "add": 8, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -161,7 +162,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -171,7 +173,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -181,7 +184,8 @@
                 ], 
                 "bindings": {
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": [
@@ -194,7 +198,8 @@
                       "Self": 3, 
                       "deref": 4, 
                       
-                    }, "children": [
+                    }, 
+                    "children": [
                       {
                         "id": semantic.id.NominalId(u32)(5), 
                         "flags": [
@@ -202,7 +207,8 @@
                         ], 
                         "bindings": {
                           
-                        }, "children": [
+                        }, 
+                        "children": [
                           {
                             "id": semantic.id.NominalId(u32)(6), 
                             "flags": [
@@ -211,7 +217,8 @@
                             ], 
                             "bindings": {
                               
-                            }, "children": [
+                            }, 
+                            "children": [
                               {
                                 "id": semantic.id.NominalId(u32)(7), 
                                 "flags": [
@@ -220,20 +227,27 @@
                                 ], 
                                 "bindings": {
                                   
-                                }, "children": [], 
+                                }, 
+                                "children": [], 
                                 
                               }, 
                             ], 
+                            
                           }, 
                         ], 
+                        
                       }, 
                     ], 
+                    
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, {
         "id": semantic.id.NominalId(u32)(8), 
         "flags": [
@@ -242,7 +256,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(9), 
             "flags": [
@@ -252,7 +267,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(10), 
                 "flags": [
@@ -263,7 +279,8 @@
                 "bindings": {
                   "l": 6, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(11), 
                     "flags": [
@@ -273,7 +290,8 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, {
                     "id": semantic.id.NominalId(u32)(12), 
@@ -285,14 +303,18 @@
                     "bindings": {
                       "inner": 7, 
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, {
         "id": semantic.id.NominalId(u32)(13), 
         "flags": [
@@ -300,7 +322,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(14), 
             "flags": [
@@ -309,7 +332,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(15), 
                 "flags": [
@@ -319,7 +343,8 @@
                 "bindings": {
                   "a2": 10, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(16), 
                     "flags": [
@@ -330,7 +355,8 @@
                     "bindings": {
                       "c": 9, 
                       
-                    }, "children": [
+                    }, 
+                    "children": [
                       {
                         "id": semantic.id.NominalId(u32)(17), 
                         "flags": [
@@ -340,17 +366,23 @@
                         ], 
                         "bindings": {
                           
-                        }, "children": [], 
+                        }, 
+                        "children": [], 
                         
                       }, 
                     ], 
+                    
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
@@ -12,7 +12,8 @@
       "members": [1,2,3,4,5,6,7,8,9,10], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "Box", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -24,7 +25,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "inner", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -36,7 +38,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "Self", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -49,7 +52,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "deref", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -61,7 +65,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "FixedIntArray", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -73,7 +78,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "l", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -87,7 +93,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "inner", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -99,7 +106,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "add", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -111,7 +119,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "c", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -124,7 +133,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "a2", 
       "debugName": "", 
       "declNode": "simple_var_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
@@ -149,7 +149,17 @@
       
     }, 
   ], 
-  "unresolvedReferences": [],
+  "unresolvedReferences": [
+    {"symbol":null,"scope":1,"node":"identifier","identifier":"type","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":7,"node":"identifier","identifier":"self","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":8,"node":"identifier","identifier":"usize","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":13,"node":"identifier","identifier":"isize","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":13,"node":"identifier","identifier":"usize","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":16,"node":"identifier","identifier":"a","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":15,"node":"identifier","identifier":"a","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":15,"node":"identifier","identifier":"b","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    
+  ], 
   "scopes": {
     "id": semantic.id.NominalId(u32)(0), 
     "flags": [

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
@@ -12,7 +12,8 @@
       "members": [1,2], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "foo", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -24,7 +25,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "inner", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -37,7 +39,8 @@
       "members": [3], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "bar", 
       "debugName": "", 
       "declNode": "fn_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
@@ -62,7 +62,8 @@
       "@This()": 0, 
       "foo": 1, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -70,7 +71,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -79,7 +81,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -89,7 +92,8 @@
                 "bindings": {
                   "inner": 2, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": [
@@ -99,7 +103,8 @@
                     "bindings": {
                       "bar": 3, 
                       
-                    }, "children": [
+                    }, 
+                    "children": [
                       {
                         "id": semantic.id.NominalId(u32)(5), 
                         "flags": [
@@ -107,7 +112,8 @@
                         ], 
                         "bindings": {
                           
-                        }, "children": [
+                        }, 
+                        "children": [
                           {
                             "id": semantic.id.NominalId(u32)(6), 
                             "flags": [
@@ -116,7 +122,8 @@
                             ], 
                             "bindings": {
                               
-                            }, "children": [
+                            }, 
+                            "children": [
                               {
                                 "id": semantic.id.NominalId(u32)(7), 
                                 "flags": [
@@ -125,21 +132,29 @@
                                 ], 
                                 "bindings": {
                                   
-                                }, "children": [], 
+                                }, 
+                                "children": [], 
                                 
                               }, 
                             ], 
+                            
                           }, 
                         ], 
+                        
                       }, 
                     ], 
+                    
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
@@ -54,7 +54,13 @@
       
     }, 
   ], 
-  "unresolvedReferences": [],
+  "unresolvedReferences": [
+    {"symbol":null,"scope":1,"node":"identifier","identifier":"u32","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":5,"node":"identifier","identifier":"u32","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":7,"node":"identifier","identifier":"b","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":3,"node":"identifier","identifier":"a","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    
+  ], 
   "scopes": {
     "id": semantic.id.NominalId(u32)(0), 
     "flags": [

--- a/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
@@ -107,7 +107,13 @@
       
     }, 
   ], 
-  "unresolvedReferences": [],
+  "unresolvedReferences": [
+    {"symbol":null,"scope":0,"node":"identifier","identifier":"undefined","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":0,"node":"identifier","identifier":"null","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":1,"node":"identifier","identifier":"undefined","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":4,"node":"identifier","identifier":"self","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    
+  ], 
   "scopes": {
     "id": semantic.id.NominalId(u32)(0), 
     "flags": [

--- a/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
@@ -12,7 +12,8 @@
       "members": [1,2,3,4], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "std", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -25,7 +26,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "bad", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -37,7 +39,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "good", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -49,7 +52,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "Foo", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -62,7 +66,8 @@
       "members": [5,6,7], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "foo", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -74,7 +79,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "Bar", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -86,7 +92,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "baz", 
       "debugName": "", 
       "declNode": "fn_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
@@ -114,7 +114,8 @@
       "good": 3, 
       "Foo": 4, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -126,7 +127,8 @@
           "Bar": 6, 
           "baz": 7, 
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -134,7 +136,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -143,7 +146,8 @@
                 ], 
                 "bindings": {
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": [
@@ -152,15 +156,20 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
@@ -12,7 +12,8 @@
       "members": [1,2,3,4,5,6], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "std", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -26,7 +27,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "forOverArr", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -38,7 +40,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "arr", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -51,7 +54,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "power_of_two", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -64,7 +68,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "forWithMultiBindingClosure", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -76,7 +81,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "mat4x4", 
       "debugName": "", 
       "declNode": "simple_var_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
@@ -97,7 +97,15 @@
       
     }, 
   ], 
-  "unresolvedReferences": [],
+  "unresolvedReferences": [
+    {"symbol":null,"scope":4,"node":"identifier","identifier":"i","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":4,"node":"identifier","identifier":"i","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":8,"node":"identifier","identifier":"row","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":9,"node":"identifier","identifier":"row_index","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":9,"node":"identifier","identifier":"column_index","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":10,"node":"identifier","identifier":"cell","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    
+  ], 
   "scopes": {
     "id": semantic.id.NominalId(u32)(0), 
     "flags": [

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
@@ -104,7 +104,8 @@
       "forOverArr": 2, 
       "forWithMultiBindingClosure": 5, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -112,7 +113,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -121,7 +123,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -131,7 +134,8 @@
                 "bindings": {
                   "arr": 3, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": [
@@ -141,14 +145,18 @@
                     "bindings": {
                       "power_of_two": 4, 
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, {
         "id": semantic.id.NominalId(u32)(5), 
         "flags": [
@@ -156,7 +164,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(6), 
             "flags": [
@@ -165,7 +174,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(7), 
                 "flags": [
@@ -175,7 +185,8 @@
                 "bindings": {
                   "mat4x4": 6, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(8), 
                     "flags": [
@@ -184,7 +195,8 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [
+                    }, 
+                    "children": [
                       {
                         "id": semantic.id.NominalId(u32)(9), 
                         "flags": [
@@ -193,7 +205,8 @@
                         ], 
                         "bindings": {
                           
-                        }, "children": [
+                        }, 
+                        "children": [
                           {
                             "id": semantic.id.NominalId(u32)(10), 
                             "flags": [
@@ -202,19 +215,26 @@
                             ], 
                             "bindings": {
                               
-                            }, "children": [], 
+                            }, 
+                            "children": [], 
                             
                           }, 
                         ], 
+                        
                       }, 
                     ], 
+                    
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
@@ -233,7 +233,8 @@
       "whileWithExpr": 10, 
       "rangeHasNumber": 14, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -241,7 +242,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -250,7 +252,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -260,7 +263,8 @@
                 "bindings": {
                   "i": 3, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": [
@@ -270,14 +274,18 @@
                     "bindings": {
                       "power_of_two": 4, 
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, {
         "id": semantic.id.NominalId(u32)(5), 
         "flags": [
@@ -285,7 +293,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(6), 
             "flags": [
@@ -294,7 +303,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(7), 
                 "flags": [
@@ -305,7 +315,8 @@
                   "map": 6, 
                   "iter": 7, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(8), 
                     "flags": [
@@ -316,14 +327,18 @@
                       "k": 8, 
                       "v": 9, 
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, {
         "id": semantic.id.NominalId(u32)(9), 
         "flags": [
@@ -331,7 +346,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(10), 
             "flags": [
@@ -340,7 +356,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(11), 
                 "flags": [
@@ -351,7 +368,8 @@
                   "x": 11, 
                   "y": 12, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(12), 
                     "flags": [
@@ -360,7 +378,8 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, {
                     "id": semantic.id.NominalId(u32)(13), 
@@ -371,14 +390,18 @@
                     "bindings": {
                       "my_xy": 13, 
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, {
         "id": semantic.id.NominalId(u32)(14), 
         "flags": [
@@ -386,7 +409,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(15), 
             "flags": [
@@ -395,7 +419,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(16), 
                 "flags": [
@@ -405,7 +430,8 @@
                 "bindings": {
                   "i": 15, 
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(17), 
                     "flags": [
@@ -414,7 +440,8 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [
+                    }, 
+                    "children": [
                       {
                         "id": semantic.id.NominalId(u32)(18), 
                         "flags": [
@@ -423,17 +450,23 @@
                         ], 
                         "bindings": {
                           
-                        }, "children": [], 
+                        }, 
+                        "children": [], 
                         
                       }, 
                     ], 
+                    
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
@@ -12,7 +12,8 @@
       "members": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "std", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -27,7 +28,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "simpleWhile", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -39,7 +41,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "i", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -55,7 +58,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "power_of_two", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -68,7 +72,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "whileWithClosure", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -80,7 +85,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "map", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -95,7 +101,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "iter", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -108,7 +115,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "k", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -121,7 +129,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "v", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -134,7 +143,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "whileWithExpr", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -146,7 +156,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "x", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -161,7 +172,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "y", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -176,7 +188,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "my_xy", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -189,7 +202,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "rangeHasNumber", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -201,7 +215,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "i", 
       "debugName": "", 
       "declNode": "simple_var_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
@@ -233,7 +233,19 @@
       
     }, 
   ], 
-  "unresolvedReferences": [],
+  "unresolvedReferences": [
+    {"symbol":null,"scope":8,"node":"identifier","identifier":"ent","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":8,"node":"identifier","identifier":"ent","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":14,"node":"identifier","identifier":"usize","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":14,"node":"identifier","identifier":"usize","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":14,"node":"identifier","identifier":"usize","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":16,"node":"identifier","identifier":"begin","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":16,"node":"identifier","identifier":"end","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":17,"node":"identifier","identifier":"number","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":18,"node":"identifier","identifier":"true","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":16,"node":"identifier","identifier":"false","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    
+  ], 
   "scopes": {
     "id": semantic.id.NominalId(u32)(0), 
     "flags": [

--- a/test/snapshots/snapshot-coverage/simple/pass/struct_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/struct_members.zig.snap
@@ -73,7 +73,8 @@
       "@This()": 0, 
       "Foo": 1, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -85,9 +86,11 @@
           "B": 3, 
           "C": 4, 
           
-        }, "children": [], 
+        }, 
+        "children": [], 
         
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/struct_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/struct_members.zig.snap
@@ -12,7 +12,8 @@
       "members": [1], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "Foo", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -24,7 +25,8 @@
       "members": [2,3,4], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "a", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -36,7 +38,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "B", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -48,7 +51,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "C", 
       "debugName": "", 
       "declNode": "simple_var_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
@@ -12,7 +12,8 @@
       "members": [1,2,3,4], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "a", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -24,7 +25,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "b", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -36,7 +38,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "Foo", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -48,7 +51,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "new", 
       "debugName": "", 
       "declNode": "fn_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
@@ -76,7 +76,8 @@
       "Foo": 3, 
       "new": 4, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -84,7 +85,8 @@
         ], 
         "bindings": {
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -93,7 +95,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -102,13 +105,17 @@
                 ], 
                 "bindings": {
                   
-                }, "children": [], 
+                }, 
+                "children": [], 
                 
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/unresolved_import.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/unresolved_import.zig.snap
@@ -12,7 +12,8 @@
       "members": [1], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "foo", 
       "debugName": "", 
       "declNode": "simple_var_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/unresolved_import.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/unresolved_import.zig.snap
@@ -37,7 +37,8 @@
       "@This()": 0, 
       "foo": 1, 
       
-    }, "children": [], 
+    }, 
+    "children": [], 
     
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
@@ -12,7 +12,8 @@
       "members": [1], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "Writer", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -25,7 +26,8 @@
       "members": [2,3,4,5,6,7,10], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "ptr", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -39,7 +41,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "writeAllFn", 
       "debugName": "", 
       "declNode": "container_field_init", 
@@ -51,7 +54,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "init", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -63,7 +67,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "T", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -76,7 +81,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "ptr_info", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -89,7 +95,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "gen", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -102,7 +109,8 @@
       "members": [8,9], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "writeAll", 
       "debugName": "", 
       "declNode": "fn_decl", 
@@ -114,7 +122,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "self", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
@@ -127,7 +136,8 @@
       "members": [], 
       "exports": [], 
       
-    }, {
+    }, 
+    {
       "name": "writeAll", 
       "debugName": "", 
       "declNode": "fn_decl", 

--- a/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
@@ -152,7 +152,8 @@
       "@This()": 0, 
       "Writer": 1, 
       
-    }, "children": [
+    }, 
+    "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
         "flags": [
@@ -165,7 +166,8 @@
           "init": 4, 
           "writeAll": 10, 
           
-        }, "children": [
+        }, 
+        "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
             "flags": [
@@ -173,7 +175,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": [
@@ -182,7 +185,8 @@
                 ], 
                 "bindings": {
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": [
@@ -194,7 +198,8 @@
                       "ptr_info": 6, 
                       "gen": 7, 
                       
-                    }, "children": [
+                    }, 
+                    "children": [
                       {
                         "id": semantic.id.NominalId(u32)(5), 
                         "flags": [
@@ -204,7 +209,8 @@
                         "bindings": {
                           "writeAll": 8, 
                           
-                        }, "children": [
+                        }, 
+                        "children": [
                           {
                             "id": semantic.id.NominalId(u32)(6), 
                             "flags": [
@@ -212,7 +218,8 @@
                             ], 
                             "bindings": {
                               
-                            }, "children": [
+                            }, 
+                            "children": [
                               {
                                 "id": semantic.id.NominalId(u32)(7), 
                                 "flags": [
@@ -221,7 +228,8 @@
                                 ], 
                                 "bindings": {
                                   
-                                }, "children": [
+                                }, 
+                                "children": [
                                   {
                                     "id": semantic.id.NominalId(u32)(8), 
                                     "flags": [
@@ -231,20 +239,27 @@
                                     "bindings": {
                                       "self": 9, 
                                       
-                                    }, "children": [], 
+                                    }, 
+                                    "children": [], 
                                     
                                   }, 
                                 ], 
+                                
                               }, 
                             ], 
+                            
                           }, 
                         ], 
+                        
                       }, 
                     ], 
+                    
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, {
             "id": semantic.id.NominalId(u32)(9), 
             "flags": [
@@ -252,7 +267,8 @@
             ], 
             "bindings": {
               
-            }, "children": [
+            }, 
+            "children": [
               {
                 "id": semantic.id.NominalId(u32)(10), 
                 "flags": [
@@ -261,7 +277,8 @@
                 ], 
                 "bindings": {
                   
-                }, "children": [
+                }, 
+                "children": [
                   {
                     "id": semantic.id.NominalId(u32)(11), 
                     "flags": [
@@ -270,15 +287,20 @@
                     ], 
                     "bindings": {
                       
-                    }, "children": [], 
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 
+                
               }, 
             ], 
+            
           }, 
         ], 
+        
       }, 
     ], 
+    
   }, 
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
@@ -151,7 +151,17 @@
       
     }, 
   ], 
-  "unresolvedReferences": [],
+  "unresolvedReferences": [
+    {"symbol":null,"scope":6,"node":"identifier","identifier":"anyopaque","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":6,"node":"identifier","identifier":"u8","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":8,"node":"identifier","identifier":"pointer","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":8,"node":"identifier","identifier":"data","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":9,"node":"identifier","identifier":"u8","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":11,"node":"identifier","identifier":"self","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":11,"node":"identifier","identifier":"self","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    {"symbol":null,"scope":11,"node":"identifier","identifier":"data","flags":{"read":true,"write":false,"call":false,"type":false,"member":false,"_":0}}, 
+    
+  ], 
   "scopes": {
     "id": semantic.id.NominalId(u32)(0), 
     "flags": [


### PR DESCRIPTION
- fix(semantic): bug when resolving references on scope exit causing references that occur before declarations to never be resolved. Caused by incorrect unresolved reference count, which in turn caused unresolved references to never be moved to parent stack frame.
- test(semantic): reference counting unit tests.
- fix(printer): better indenting when printing symbols and scopes.