### PR TITLE
feat(semantic): bind if/else payloads

### DIFF
--- a/src/semantic/Symbol.zig
+++ b/src/semantic/Symbol.zig
@@ -76,6 +76,16 @@ pub const Flags = packed struct {
     /// - [Container Level Variables](https://ziglang.org/documentation/master/#Container-Level-Variables)
     /// - [Local Variables](https://ziglang.org/documentation/master/#Local-Variables)
     s_variable: bool = false,
+    /// A symbol bound by a control flow statement. e.g. `x` in `if (foo) |x| {}`
+    ///
+    /// Note that no identifier node is parsed for payload symbols, so symbols
+    /// of this type will have their `declaration_node` set to the control flow
+    /// block itself.
+    ///
+    /// `while`, `for`, `if`, `else`, and `catch` may all bind payloads.  Like
+    /// function parameters, these are implicitly `const` and always have
+    /// `s_const` set.
+    s_payload: bool = false,
     /// Comptime symbol.
     ///
     /// Not `true` for inferred comptime parameters. That is, this is only

--- a/src/semantic/test/symbol_decl_test.zig
+++ b/src/semantic/test/symbol_decl_test.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+const test_util = @import("util.zig");
+
+const Semantic = @import("../Semantic.zig");
+const Symbol = @import("../Symbol.zig");
+
+const t = std.testing;
+const build = test_util.build;
+const panic = std.debug.panic;
+const print = std.debug.print;
+
+test "control flow payloads - value and error" {
+    // all of these should have `x` and `err` bound.
+    const sources = [_][:0]const u8{
+        \\fn main() void {
+        \\  const res: anyerror!u32 = 1;
+        \\  if (res) |x| {
+        \\    _ = x;
+        \\  } else |err| {
+        \\    _ = err;
+        \\  }
+        \\}
+    };
+
+    for (sources) |source| {
+        var sem = try build(source);
+        defer sem.deinit();
+
+        const x: Symbol.Id = sem.symbols.getSymbolNamed("x") orelse {
+            panic("Symbol 'x' not found in source:\n\n{s}\n\n", .{source});
+        };
+        const err: Symbol.Id = sem.symbols.getSymbolNamed("err") orelse {
+            panic("Symbol 'err' not found in source:\n\n{s}\n\n", .{source});
+        };
+
+        {
+            const flags: Symbol.Flags = sem.symbols.symbols.items(.flags)[x.int()];
+            try t.expect(flags.s_payload);
+            try t.expect(flags.s_const);
+        }
+
+        {
+            const flags: Symbol.Flags = sem.symbols.symbols.items(.flags)[err.int()];
+            try t.expect(flags.s_payload);
+            try t.expect(flags.s_const);
+        }
+    }
+}

--- a/src/semantic/test/util.zig
+++ b/src/semantic/test/util.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const mem = std.mem;
+
+const SemanticBuilder = @import("../SemanticBuilder.zig");
+const Semantic = @import("../Semantic.zig");
+const report = @import("../../reporter.zig");
+
+const printer = @import("../../root.zig").printer;
+
+const t = std.testing;
+const panic = std.debug.panic;
+const print = std.debug.print;
+
+pub fn build(src: [:0]const u8) !Semantic {
+    var r = report.GraphicalReporter.init(std.io.getStdErr().writer(), report.GraphicalFormatter.unicode(t.allocator, false));
+    var builder = SemanticBuilder.init(t.allocator);
+    defer builder.deinit();
+
+    var result = builder.build(src) catch |e| {
+        print("Analysis failed on source:\n\n{s}\n\n", .{src});
+        return e;
+    };
+    errdefer result.value.deinit();
+    r.reportErrors(result.errors.toManaged(t.allocator));
+    if (result.hasErrors()) {
+        panic("Analysis failed on source:\n\n{s}\n\n", .{src});
+    }
+
+    return result.value;
+}
+
+pub fn debugSemantic(semantic: *const Semantic) !void {
+    var p = printer.Printer.init(t.allocator, std.io.getStdErr().writer());
+    defer p.deinit();
+    var sp = printer.SemanticPrinter.new(&p, semantic);
+
+    print("Symbol table:\n\n", .{});
+    try sp.printSymbolTable();
+
+    print("\n\nUnresolved references:\n\n", .{});
+    try sp.printUnresolvedReferences();
+
+    print("\n\nScopes:\n\n", .{});
+    try sp.printScopeTree();
+    print("\n\n", .{});
+}

--- a/test/fixtures/simple/pass/cond_if.zig
+++ b/test/fixtures/simple/pass/cond_if.zig
@@ -24,8 +24,16 @@ fn simpleIf() void {
 }
 
 fn comptimeIf() void {
-
     comptime if (builtin.os.tag == .windows) {
-         @compileError("Windows is not supported");
+        @compileError("Windows is not supported");
     };
+}
+
+fn ifWithPayload() void {
+    const res: anyerror!u32 = 1;
+    if (res) |x| {
+        std.debug.print("value: {d}\n", .{x});
+    } else |err| {
+        std.debug.print("error: {s}\n", .{err});
+    }
 }

--- a/test/snapshots/snapshot-coverage/simple/pass/cond_if.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/cond_if.zig.snap
@@ -9,7 +9,7 @@
       "references": [
         
       ], 
-      "members": [1,2,3,4,5,6,7], 
+      "members": [1,2,3,4,5,6,7,8,9], 
       "exports": [], 
       
     }, 
@@ -20,7 +20,9 @@
       "scope": semantic.id.NominalId(u32)(0), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":1,"scope":4,"node":"identifier","identifier":"std","flags":["read"]}, 
+        {"symbol":1,"scope":7,"node":"identifier","identifier":"std","flags":["read"]}, 
+        {"symbol":1,"scope":23,"node":"identifier","identifier":"std","flags":["read"]}, 
+        {"symbol":1,"scope":25,"node":"identifier","identifier":"std","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -35,7 +37,7 @@
       "flags": ["variable", "const"], 
       "references": [
         {"symbol":2,"scope":0,"node":"identifier","identifier":"builtin","flags":["read"]}, 
-        {"symbol":2,"scope":9,"node":"identifier","identifier":"builtin","flags":["read"]}, 
+        {"symbol":2,"scope":15,"node":"identifier","identifier":"builtin","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -72,15 +74,15 @@
       "name": "i", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(5), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":5,"scope":3,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":5,"scope":3,"node":"identifier","identifier":"i","flags":["read"]}, 
         {"symbol":5,"scope":5,"node":"identifier","identifier":"i","flags":["read"]}, 
         {"symbol":5,"scope":5,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":5,"scope":5,"node":"identifier","identifier":"i","flags":["write"]}, 
-        {"symbol":5,"scope":6,"node":"identifier","identifier":"i","flags":["write"]}, 
+        {"symbol":5,"scope":10,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":5,"scope":10,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":5,"scope":10,"node":"identifier","identifier":"i","flags":["write"]}, 
+        {"symbol":5,"scope":12,"node":"identifier","identifier":"i","flags":["write"]}, 
         
       ], 
       "members": [], 
@@ -91,10 +93,10 @@
       "name": "pow", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(5), 
+      "scope": semantic.id.NominalId(u32)(10), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":6,"scope":5,"node":"identifier","identifier":"pow","flags":["read"]}, 
+        {"symbol":6,"scope":10,"node":"identifier","identifier":"pow","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -114,6 +116,61 @@
       "exports": [], 
       
     }, 
+    {
+      "name": "ifWithPayload", 
+      "debugName": "", 
+      "declNode": "fn_decl", 
+      "scope": semantic.id.NominalId(u32)(0), 
+      "flags": ["fn"], 
+      "references": [
+        
+      ], 
+      "members": [], 
+      "exports": [], 
+      
+    }, 
+    {
+      "name": "res", 
+      "debugName": "", 
+      "declNode": "simple_var_decl", 
+      "scope": semantic.id.NominalId(u32)(21), 
+      "flags": ["variable", "const"], 
+      "references": [
+        {"symbol":9,"scope":21,"node":"identifier","identifier":"res","flags":["read"]}, 
+        
+      ], 
+      "members": [], 
+      "exports": [], 
+      
+    }, 
+    {
+      "name": "x", 
+      "debugName": "", 
+      "declNode": "block_two_semicolon", 
+      "scope": semantic.id.NominalId(u32)(22), 
+      "flags": ["payload", "const"], 
+      "references": [
+        {"symbol":10,"scope":23,"node":"identifier","identifier":"x","flags":["read"]}, 
+        
+      ], 
+      "members": [], 
+      "exports": [], 
+      
+    }, 
+    {
+      "name": "err", 
+      "debugName": "", 
+      "declNode": "block_two_semicolon", 
+      "scope": semantic.id.NominalId(u32)(24), 
+      "flags": ["payload", "const"], 
+      "references": [
+        {"symbol":11,"scope":25,"node":"identifier","identifier":"err","flags":["read"]}, 
+        
+      ], 
+      "members": [], 
+      "exports": [], 
+      
+    }, 
   ], 
   "unresolvedReferences": [],
   "scopes": {
@@ -126,6 +183,7 @@
       "msg": 3, 
       "simpleIf": 4, 
       "comptimeIf": 7, 
+      "ifWithPayload": 8, 
       
     }, 
     "children": [
@@ -135,16 +193,32 @@
         "bindings": {
           
         }, 
+        "children": [], 
+        
+      }, {
+        "id": semantic.id.NominalId(u32)(2), 
+        "flags": [], 
+        "bindings": {
+          
+        }, 
+        "children": [], 
+        
+      }, {
+        "id": semantic.id.NominalId(u32)(3), 
+        "flags": [], 
+        "bindings": {
+          
+        }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(2), 
+            "id": semantic.id.NominalId(u32)(4), 
             "flags": ["function"], 
             "bindings": {
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(3), 
+                "id": semantic.id.NominalId(u32)(5), 
                 "flags": ["block"], 
                 "bindings": {
                   "i": 5, 
@@ -152,25 +226,119 @@
                 }, 
                 "children": [
                   {
-                    "id": semantic.id.NominalId(u32)(4), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, {
-                    "id": semantic.id.NominalId(u32)(5), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      "pow": 6, 
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, {
                     "id": semantic.id.NominalId(u32)(6), 
-                    "flags": ["block"], 
+                    "flags": [], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [
+                      {
+                        "id": semantic.id.NominalId(u32)(7), 
+                        "flags": ["block"], 
+                        "bindings": {
+                          
+                        }, 
+                        "children": [], 
+                        
+                      }, 
+                    ], 
+                    
+                  }, {
+                    "id": semantic.id.NominalId(u32)(8), 
+                    "flags": [], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [], 
+                    
+                  }, {
+                    "id": semantic.id.NominalId(u32)(9), 
+                    "flags": [], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [
+                      {
+                        "id": semantic.id.NominalId(u32)(10), 
+                        "flags": ["block"], 
+                        "bindings": {
+                          "pow": 6, 
+                          
+                        }, 
+                        "children": [], 
+                        
+                      }, 
+                    ], 
+                    
+                  }, {
+                    "id": semantic.id.NominalId(u32)(11), 
+                    "flags": [], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [
+                      {
+                        "id": semantic.id.NominalId(u32)(12), 
+                        "flags": ["block"], 
+                        "bindings": {
+                          
+                        }, 
+                        "children": [], 
+                        
+                      }, 
+                    ], 
+                    
+                  }, 
+                ], 
+                
+              }, 
+            ], 
+            
+          }, 
+        ], 
+        
+      }, {
+        "id": semantic.id.NominalId(u32)(13), 
+        "flags": [], 
+        "bindings": {
+          
+        }, 
+        "children": [
+          {
+            "id": semantic.id.NominalId(u32)(14), 
+            "flags": ["function"], 
+            "bindings": {
+              
+            }, 
+            "children": [
+              {
+                "id": semantic.id.NominalId(u32)(15), 
+                "flags": ["block"], 
+                "bindings": {
+                  
+                }, 
+                "children": [
+                  {
+                    "id": semantic.id.NominalId(u32)(16), 
+                    "flags": ["comptime"], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [
+                      {
+                        "id": semantic.id.NominalId(u32)(17), 
+                        "flags": ["block", "comptime"], 
+                        "bindings": {
+                          
+                        }, 
+                        "children": [], 
+                        
+                      }, 
+                    ], 
+                    
+                  }, {
+                    "id": semantic.id.NominalId(u32)(18), 
+                    "flags": ["comptime"], 
                     "bindings": {
                       
                     }, 
@@ -186,33 +354,64 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(7), 
+        "id": semantic.id.NominalId(u32)(19), 
         "flags": [], 
         "bindings": {
           
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(8), 
+            "id": semantic.id.NominalId(u32)(20), 
             "flags": ["function"], 
             "bindings": {
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(9), 
+                "id": semantic.id.NominalId(u32)(21), 
                 "flags": ["block"], 
                 "bindings": {
+                  "res": 9, 
                   
                 }, 
                 "children": [
                   {
-                    "id": semantic.id.NominalId(u32)(10), 
-                    "flags": ["block", "comptime"], 
+                    "id": semantic.id.NominalId(u32)(22), 
+                    "flags": [], 
                     "bindings": {
+                      "x": 10, 
                       
                     }, 
-                    "children": [], 
+                    "children": [
+                      {
+                        "id": semantic.id.NominalId(u32)(23), 
+                        "flags": ["block"], 
+                        "bindings": {
+                          
+                        }, 
+                        "children": [], 
+                        
+                      }, 
+                    ], 
+                    
+                  }, {
+                    "id": semantic.id.NominalId(u32)(24), 
+                    "flags": [], 
+                    "bindings": {
+                      "err": 11, 
+                      
+                    }, 
+                    "children": [
+                      {
+                        "id": semantic.id.NominalId(u32)(25), 
+                        "flags": ["block"], 
+                        "bindings": {
+                          
+                        }, 
+                        "children": [], 
+                        
+                      }, 
+                    ], 
                     
                   }, 
                 ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
@@ -138,7 +138,7 @@
       "name": "inner", 
       "debugName": "", 
       "declNode": "container_field_init", 
-      "scope": semantic.id.NominalId(u32)(12), 
+      "scope": semantic.id.NominalId(u32)(14), 
       "flags": ["member"], 
       "references": [
         
@@ -164,11 +164,11 @@
       "name": "a", 
       "debugName": "", 
       "declNode": "identifier", 
-      "scope": semantic.id.NominalId(u32)(13), 
+      "scope": semantic.id.NominalId(u32)(15), 
       "flags": ["comptime", "const", "fn_param"], 
       "references": [
-        {"symbol":12,"scope":16,"node":"identifier","identifier":"a","flags":["read"]}, 
-        {"symbol":12,"scope":15,"node":"identifier","identifier":"a","flags":["read"]}, 
+        {"symbol":12,"scope":18,"node":"identifier","identifier":"a","flags":["read"]}, 
+        {"symbol":12,"scope":17,"node":"identifier","identifier":"a","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -179,10 +179,10 @@
       "name": "b", 
       "debugName": "", 
       "declNode": "identifier", 
-      "scope": semantic.id.NominalId(u32)(13), 
+      "scope": semantic.id.NominalId(u32)(15), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":13,"scope":15,"node":"identifier","identifier":"b","flags":["read"]}, 
+        {"symbol":13,"scope":17,"node":"identifier","identifier":"b","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -193,10 +193,10 @@
       "name": "c", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(16), 
+      "scope": semantic.id.NominalId(u32)(18), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":14,"scope":16,"node":"identifier","identifier":"c","flags":["read"]}, 
+        {"symbol":14,"scope":18,"node":"identifier","identifier":"c","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -207,10 +207,10 @@
       "name": "a2", 
       "debugName": "", 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(15), 
+      "scope": semantic.id.NominalId(u32)(17), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":15,"scope":15,"node":"identifier","identifier":"a2","flags":["read"]}, 
+        {"symbol":15,"scope":17,"node":"identifier","identifier":"a2","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -221,8 +221,8 @@
   "unresolvedReferences": [
     {"symbol":null,"scope":1,"node":"identifier","identifier":"type","flags":["read"]}, 
     {"symbol":null,"scope":8,"node":"identifier","identifier":"usize","flags":["read"]}, 
-    {"symbol":null,"scope":13,"node":"identifier","identifier":"isize","flags":["read"]}, 
-    {"symbol":null,"scope":13,"node":"identifier","identifier":"usize","flags":["read"]}, 
+    {"symbol":null,"scope":15,"node":"identifier","identifier":"isize","flags":["read"]}, 
+    {"symbol":null,"scope":15,"node":"identifier","identifier":"usize","flags":["read"]}, 
     
   ], 
   "scopes": {
@@ -334,14 +334,32 @@
                 "children": [
                   {
                     "id": semantic.id.NominalId(u32)(11), 
-                    "flags": ["block", "comptime"], 
+                    "flags": ["comptime"], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [
+                      {
+                        "id": semantic.id.NominalId(u32)(12), 
+                        "flags": ["block", "comptime"], 
+                        "bindings": {
+                          
+                        }, 
+                        "children": [], 
+                        
+                      }, 
+                    ], 
+                    
+                  }, {
+                    "id": semantic.id.NominalId(u32)(13), 
+                    "flags": ["comptime"], 
                     "bindings": {
                       
                     }, 
                     "children": [], 
                     
                   }, {
-                    "id": semantic.id.NominalId(u32)(12), 
+                    "id": semantic.id.NominalId(u32)(14), 
                     "flags": ["block", "comptime"], 
                     "bindings": {
                       "inner": 10, 
@@ -359,7 +377,7 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(13), 
+        "id": semantic.id.NominalId(u32)(15), 
         "flags": [], 
         "bindings": {
           "a": 12, 
@@ -368,14 +386,14 @@
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(14), 
+            "id": semantic.id.NominalId(u32)(16), 
             "flags": ["function"], 
             "bindings": {
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(15), 
+                "id": semantic.id.NominalId(u32)(17), 
                 "flags": ["block"], 
                 "bindings": {
                   "a2": 15, 
@@ -383,7 +401,7 @@
                 }, 
                 "children": [
                   {
-                    "id": semantic.id.NominalId(u32)(16), 
+                    "id": semantic.id.NominalId(u32)(18), 
                     "flags": ["block", "comptime"], 
                     "bindings": {
                       "c": 14, 
@@ -391,8 +409,26 @@
                     }, 
                     "children": [
                       {
-                        "id": semantic.id.NominalId(u32)(17), 
-                        "flags": ["block", "comptime"], 
+                        "id": semantic.id.NominalId(u32)(19), 
+                        "flags": ["comptime"], 
+                        "bindings": {
+                          
+                        }, 
+                        "children": [
+                          {
+                            "id": semantic.id.NominalId(u32)(20), 
+                            "flags": ["block", "comptime"], 
+                            "bindings": {
+                              
+                            }, 
+                            "children": [], 
+                            
+                          }, 
+                        ], 
+                        
+                      }, {
+                        "id": semantic.id.NominalId(u32)(21), 
+                        "flags": ["comptime"], 
                         "bindings": {
                           
                         }, 

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
@@ -21,7 +21,7 @@
       "flags": ["variable", "const"], 
       "references": [
         {"symbol":1,"scope":4,"node":"identifier","identifier":"std","flags":["read"]}, 
-        {"symbol":1,"scope":10,"node":"identifier","identifier":"std","flags":["read"]}, 
+        {"symbol":1,"scope":11,"node":"identifier","identifier":"std","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -103,7 +103,7 @@
     {"symbol":null,"scope":8,"node":"identifier","identifier":"row","flags":["read"]}, 
     {"symbol":null,"scope":9,"node":"identifier","identifier":"row_index","flags":["read"]}, 
     {"symbol":null,"scope":9,"node":"identifier","identifier":"column_index","flags":["read"]}, 
-    {"symbol":null,"scope":10,"node":"identifier","identifier":"cell","flags":["read"]}, 
+    {"symbol":null,"scope":11,"node":"identifier","identifier":"cell","flags":["read"]}, 
     
   ], 
   "scopes": {
@@ -195,7 +195,25 @@
                         "children": [
                           {
                             "id": semantic.id.NominalId(u32)(10), 
-                            "flags": ["block"], 
+                            "flags": [], 
+                            "bindings": {
+                              
+                            }, 
+                            "children": [
+                              {
+                                "id": semantic.id.NominalId(u32)(11), 
+                                "flags": ["block"], 
+                                "bindings": {
+                                  
+                                }, 
+                                "children": [], 
+                                
+                              }, 
+                            ], 
+                            
+                          }, {
+                            "id": semantic.id.NominalId(u32)(12), 
+                            "flags": [], 
                             "bindings": {
                               
                             }, 

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
@@ -281,7 +281,7 @@
     {"symbol":null,"scope":14,"node":"identifier","identifier":"usize","flags":["read"]}, 
     {"symbol":null,"scope":14,"node":"identifier","identifier":"usize","flags":["read"]}, 
     {"symbol":null,"scope":14,"node":"identifier","identifier":"usize","flags":["read"]}, 
-    {"symbol":null,"scope":18,"node":"identifier","identifier":"true","flags":["read"]}, 
+    {"symbol":null,"scope":19,"node":"identifier","identifier":"true","flags":["read"]}, 
     {"symbol":null,"scope":16,"node":"identifier","identifier":"false","flags":["read"]}, 
     
   ], 
@@ -463,7 +463,25 @@
                     "children": [
                       {
                         "id": semantic.id.NominalId(u32)(18), 
-                        "flags": ["block"], 
+                        "flags": [], 
+                        "bindings": {
+                          
+                        }, 
+                        "children": [
+                          {
+                            "id": semantic.id.NominalId(u32)(19), 
+                            "flags": ["block"], 
+                            "bindings": {
+                              
+                            }, 
+                            "children": [], 
+                            
+                          }, 
+                        ], 
+                        
+                      }, {
+                        "id": semantic.id.NominalId(u32)(20), 
+                        "flags": [], 
                         "bindings": {
                           
                         }, 


### PR DESCRIPTION
`x` and `err` now get bound
```zig
const res: anyerror!u32 = 1;
if (res) |x| {
  _ = x;
} else |err| {
  _ = err;
}
```

Also adds `s_payload` symbol flag.