### PR TITLE
test(semantic): symbol and reference flag unit tests

### DIFF
--- a/src/semantic/Symbol.zig
+++ b/src/semantic/Symbol.zig
@@ -72,6 +72,7 @@ pub const Flags = packed struct {
     ///
     /// If it's declared with a `const` or `var` keyword, this is true. Note
     /// that this includes static and threadlocal variables.
+    ///
     /// ## References
     /// - [Container Level Variables](https://ziglang.org/documentation/master/#Container-Level-Variables)
     /// - [Local Variables](https://ziglang.org/documentation/master/#Local-Variables)
@@ -104,7 +105,6 @@ pub const Flags = packed struct {
     /// }
     /// ```
     s_member: bool = false,
-
     /// A function declaration. Never a builtin. Could be a method.
     s_fn: bool = false,
     /// A function parameter.


### PR DESCRIPTION
This pull request includes several changes to the `src/semantic` module, primarily focusing on improving the handling of symbol flags and references in tests. The most important changes include adding new test cases for symbol flags, updating existing tests to include reference flags, and minor documentation updates.

### Improvements to symbol flags handling:

* [`src/semantic/test/symbol_decl_test.zig`](diffhunk://#diff-f57bb59ba688c57d254ac7ed57d2f194260c838815feaddaa2331c0b4ab67eb6R12-R60): Added a new test `test "Symbol flags for various declarations of 'x'"` to verify symbol flags for different declarations.

### Enhancements to reference flags tests:

* [`src/semantic/test/symbol_ref_test.zig`](diffhunk://#diff-3d643eef507057efb89c60651dc83a9e309e7b4bfa04b20c09d1edb42cb5593cL58-R77): Updated the `test "simple references where `x` is referenced a single time"` to include expected reference flags and added new test cases. [[1]](diffhunk://#diff-3d643eef507057efb89c60651dc83a9e309e7b4bfa04b20c09d1edb42cb5593cL58-R77) [[2]](diffhunk://#diff-3d643eef507057efb89c60651dc83a9e309e7b4bfa04b20c09d1edb42cb5593cR87-R130) [[3]](diffhunk://#diff-3d643eef507057efb89c60651dc83a9e309e7b4bfa04b20c09d1edb42cb5593cR140-R154)

### Minor documentation updates:

* [`src/semantic/Symbol.zig`](diffhunk://#diff-ce5dcdaa242de029c9f716f363245d575bbd751ee3dc8fc2b857860aa2b4b20bR75): Added a references section to the documentation for container and local variables.