### PR TITLE
feat(linter): generalize rule metadata

### DIFF
--- a/src/linter.zig
+++ b/src/linter.zig
@@ -94,7 +94,7 @@ pub const Linter = struct {
                     const err = try Error.fmt(
                         self.gpa,
                         "Rule '{s}' failed to run: {s}",
-                        .{ rule.name, @errorName(e) },
+                        .{ rule.meta.name, @errorName(e) },
                     );
                     try ctx.errors.append(err);
                 };
@@ -110,7 +110,7 @@ pub const Linter = struct {
                     const err = try Error.fmt(
                         self.gpa,
                         "Rule '{s}' failed to run: {s}",
-                        .{ rule.name, @errorName(e) },
+                        .{ rule.meta.name, @errorName(e) },
                     );
                     try ctx.errors.append(err);
                 };

--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -22,7 +22,7 @@ pub fn init(gpa: Allocator, semantic: *const Semantic, source: *Source) Context 
 // invocations.
 
 pub inline fn updateForRule(self: *Context, rule: *const Rule) void {
-    self.curr_rule_name = rule.name;
+    self.curr_rule_name = rule.meta.name;
 }
 
 // ============================== SHORTHANDS ===============================

--- a/src/linter/rules/no_undefined.zig
+++ b/src/linter/rules/no_undefined.zig
@@ -12,7 +12,10 @@ const Rule = @import("../rule.zig").Rule;
 const NodeWrapper = @import("../rule.zig").NodeWrapper;
 
 const NoUndefined = @This();
-pub const Name = "no-undefined";
+pub const Meta: Rule.Meta = .{
+    .name = "no-undefined",
+    .category = .restriction,
+};
 
 pub fn runOnNode(_: *const NoUndefined, wrapper: NodeWrapper, ctx: *LinterContext) void {
     const node = wrapper.node;

--- a/src/linter/rules/no_unresolved.zig
+++ b/src/linter/rules/no_unresolved.zig
@@ -12,7 +12,10 @@ const Rule = @import("../rule.zig").Rule;
 const NodeWrapper = @import("../rule.zig").NodeWrapper;
 
 const NoUnresolved = @This();
-pub const Name = "no-unresolved";
+pub const Meta: Rule.Meta = .{
+    .name = "no-unresolved",
+    .category = .correctness,
+};
 
 pub fn runOnNode(_: *const NoUnresolved, wrapper: NodeWrapper, ctx: *LinterContext) void {
     const node = wrapper.node;

--- a/src/linter/tester.zig
+++ b/src/linter/tester.zig
@@ -28,7 +28,7 @@ const TestError = error{
 pub const LintTesterError = SnapshotError || TestError;
 
 pub fn init(alloc: Allocator, rule: Rule) RuleTester {
-    const filename = std.mem.concat(alloc, u8, &[_]string{ rule.name, ".zig" }) catch @panic("OOM");
+    const filename = std.mem.concat(alloc, u8, &[_]string{ rule.meta.name, ".zig" }) catch @panic("OOM");
     var linter = Linter.init(alloc);
     linter.rules.append(rule) catch @panic("OOM");
 
@@ -61,7 +61,7 @@ pub fn withPath(self: *RuleTester, source_dir: string) *RuleTester {
 
 pub fn withPass(self: *RuleTester, comptime pass: []const [:0]const u8) *RuleTester {
     self.passes.appendSlice(self.alloc, pass) catch |e| {
-        const name = self.rule.name;
+        const name = self.rule.meta.name;
         panic("Failed to add pass cases to RuleTester for {s}: {s}", .{ name, @errorName(e) });
     };
     return self;
@@ -69,7 +69,7 @@ pub fn withPass(self: *RuleTester, comptime pass: []const [:0]const u8) *RuleTes
 
 pub fn withFail(self: *RuleTester, comptime fail: []const [:0]const u8) *RuleTester {
     self.fails.appendSlice(self.alloc, fail) catch |e| {
-        const name = self.rule.name;
+        const name = self.rule.meta.name;
         panic("Failed to add fail cases to RuleTester for {s}: {s}", .{ name, @errorName(e) });
     };
     return self;
@@ -114,7 +114,7 @@ fn runImpl(self: *RuleTester) LintTesterError!void {
                 self.diagnostic.message = BooStr.fmt(
                     self.alloc,
                     "Expected test case #{d} to pass:\n\n{s}\n\nError: {s}\n",
-                    .{ i + 1, self.rule.name, @errorName(e) },
+                    .{ i + 1, self.rule.meta.name, @errorName(e) },
                 ) catch @panic("OOM");
                 return LintTesterError.PassFailed;
             },
@@ -177,7 +177,7 @@ fn saveSnapshot(self: *RuleTester) SnapshotError!void {
             return e;
         };
         defer snapshot_dir.close();
-        const snapshot_filename = try std.mem.concat(self.alloc, u8, &[_]string{ self.rule.name, ".snap" });
+        const snapshot_filename = try std.mem.concat(self.alloc, u8, &[_]string{ self.rule.meta.name, ".snap" });
         defer self.alloc.free(snapshot_filename);
         const snapshot_file = snapshot_dir.createFile(snapshot_filename, .{ .truncate = true }) catch |e| {
             self.diagnostic.message = BooStr.fmt(
@@ -237,7 +237,10 @@ const assert = std.debug.assert;
 const NodeWrapper = @import("rule.zig").NodeWrapper;
 const LinterContext = @import("lint_context.zig");
 const MockRule = struct {
-    pub const Name = "my-rule";
+    pub const Meta: Rule.Meta = .{
+        .name = "my-rule",
+        .category = .correctness,
+    };
     pub fn runOnNode(_: *const MockRule, _: NodeWrapper, _: *LinterContext) void {}
 };
 test RuleTester {

--- a/tasks/new-rule.ts
+++ b/tasks/new-rule.ts
@@ -57,7 +57,11 @@ const NodeWrapper = _rule.NodeWrapper;
 
 // Rule metadata
 const ${StructName} = @This();
-pub const Name = "${name}";
+pub const Meta: Rule.Meta = .{
+    .name = "${name}",
+    // TODO: set the category to an appropriate value
+    .category = .correctness,
+};
 
 // Runs on each node in the AST. Useful for syntax-based rules.
 pub fn runOnNode(_: *const ${StructName}, wrapper: NodeWrapper, ctx: *LinterContext) void {


### PR DESCRIPTION
This pull request introduces significant changes to the `Rule` struct and its usage across various files in the linter module. The primary change involves replacing the `name` field in `Rule` with a `meta` field that includes additional metadata such as `name`, `category`, and a `default` flag. This update necessitated modifications in several files to accommodate the new `meta` structure.

Key changes include:

### Changes to `Rule` Struct:
* [`src/linter/rule.zig`](diffhunk://#diff-c1081df3f33f9211b84196d844bcbec110d72cd83888108a4131268684723c48L36-R54): Replaced `name` field with `meta` field in `Rule` struct and added `Meta` and `Category` sub-structs to encapsulate rule metadata. [[1]](diffhunk://#diff-c1081df3f33f9211b84196d844bcbec110d72cd83888108a4131268684723c48L36-R54) [[2]](diffhunk://#diff-c1081df3f33f9211b84196d844bcbec110d72cd83888108a4131268684723c48L50-R66) [[3]](diffhunk://#diff-c1081df3f33f9211b84196d844bcbec110d72cd83888108a4131268684723c48L70-R85)

### Updates to Rule Metadata Usage:
* [`src/linter.zig`](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9L97-R97): Updated error formatting to use `rule.meta.name` instead of `rule.name`. [[1]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9L97-R97) [[2]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9L113-R113)
* [`src/linter/lint_context.zig`](diffhunk://#diff-f5d36d219229632a486456028f6a8e955fccb7f7c75c55b839537fd9f461c25fL25-R25): Modified `updateForRule` function to use `rule.meta.name`.
* [`src/linter/tester.zig`](diffhunk://#diff-78e1ba3a34645b2848fd16dcb0231072fdd7edb66f7519ae2a347d7b4a666256L31-R31): Updated various functions to use `rule.meta.name` for generating filenames and error messages. [[1]](diffhunk://#diff-78e1ba3a34645b2848fd16dcb0231072fdd7edb66f7519ae2a347d7b4a666256L31-R31) [[2]](diffhunk://#diff-78e1ba3a34645b2848fd16dcb0231072fdd7edb66f7519ae2a347d7b4a666256L64-R72) [[3]](diffhunk://#diff-78e1ba3a34645b2848fd16dcb0231072fdd7edb66f7519ae2a347d7b4a666256L117-R117) [[4]](diffhunk://#diff-78e1ba3a34645b2848fd16dcb0231072fdd7edb66f7519ae2a347d7b4a666256L180-R180) [[5]](diffhunk://#diff-78e1ba3a34645b2848fd16dcb0231072fdd7edb66f7519ae2a347d7b4a666256L240-R243)

### Rule Metadata in Specific Rules:
* [`src/linter/rules/no_undefined.zig`](diffhunk://#diff-29d61ca28b780645f45d4737e154ba094ff3cf3de3cc77b29fedf1ebf21d54ceL15-R18): Replaced `Name` field with `Meta` field in `NoUndefined` rule.
* [`src/linter/rules/no_unresolved.zig`](diffhunk://#diff-df051598f673a3d71162b57b3886d568ce38e62dadacee0daa983e1b87418dcfL15-R18): Replaced `Name` field with `Meta` field in `NoUnresolved` rule.

### Template Update:
* [`tasks/new-rule.ts`](diffhunk://#diff-70f0eb34bcd24a7398646ac4962c988436cdcd95efc91fa6d7242e2e8fbb3994L60-R64): Updated new rule template to include `Meta` field instead of `Name`.