### PR TITLE
feat(semantic): link scopes to the nodes that create them

### DIFF
--- a/src/linter/rules.zig
+++ b/src/linter/rules.zig
@@ -1,2 +1,3 @@
 pub const NoUndefined = @import("./rules/no_undefined.zig");
 pub const NoUnresolved = @import("./rules/no_unresolved.zig");
+pub const HomelessTry = @import("./rules/homeless_try.zig");

--- a/src/linter/rules.zig
+++ b/src/linter/rules.zig
@@ -1,3 +1,2 @@
 pub const NoUndefined = @import("./rules/no_undefined.zig");
 pub const NoUnresolved = @import("./rules/no_unresolved.zig");
-pub const HomelessTry = @import("./rules/homeless_try.zig");

--- a/src/semantic/Symbol.zig
+++ b/src/semantic/Symbol.zig
@@ -113,6 +113,8 @@ pub const Flags = packed struct {
     /// declaration node. Zig does not appear to create an identifier node for parameters.
     s_fn_param: bool = false,
     s_catch_param: bool = false,
+
+    pub const Flag = std.meta.FieldEnum(Flags);
 };
 
 /// Stores symbols created and referenced within a Zig program.

--- a/src/semantic/test/symbol_ref_test.zig
+++ b/src/semantic/test/symbol_ref_test.zig
@@ -31,8 +31,8 @@ test "references record where and how a symbol is used" {
     const symbols = semantic.symbols;
     const scopes = semantic.scopes;
 
-    // FIXME: should be 2 (maybe 3?) but is 4
-    try t.expectEqual(4, scopes.len());
+    // 0: root, 1: function signature (and params), 2: function body
+    try t.expectEqual(3, scopes.len());
     try t.expectEqual(0, symbols.unresolved_references.items.len);
 
     const x: Symbol.Id = symbols.getSymbolNamed("x") orelse {

--- a/test/snapshots/snapshot-coverage/simple/pass/block.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/block.zig.snap
@@ -33,10 +33,10 @@
       "debugName": "", 
       "token": 7, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":2,"scope":3,"node":"identifier","identifier":"x","flags":["read"]}, 
+        {"symbol":2,"scope":2,"node":"identifier","identifier":"x","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -62,10 +62,10 @@
       "debugName": "", 
       "token": 23, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(7), 
+      "scope": semantic.id.NominalId(u32)(5), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":4,"scope":8,"node":"identifier","identifier":"y","flags":["write"]}, 
+        {"symbol":4,"scope":6,"node":"identifier","identifier":"y","flags":["write"]}, 
         
       ], 
       "members": [], 
@@ -91,10 +91,10 @@
       "debugName": "", 
       "token": 41, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(11), 
+      "scope": semantic.id.NominalId(u32)(8), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":6,"scope":12,"node":"identifier","identifier":"z","flags":["write"]}, 
+        {"symbol":6,"scope":9,"node":"identifier","identifier":"z","flags":["write"]}, 
         
       ], 
       "members": [], 
@@ -106,10 +106,10 @@
       "debugName": "", 
       "token": 47, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(12), 
+      "scope": semantic.id.NominalId(u32)(9), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":7,"scope":12,"node":"identifier","identifier":"a","flags":["read"]}, 
+        {"symbol":7,"scope":9,"node":"identifier","identifier":"a","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -135,10 +135,10 @@
       "debugName": "", 
       "token": 64, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(15), 
+      "scope": semantic.id.NominalId(u32)(11), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":9,"scope":16,"node":"identifier","identifier":"a","flags":["read","write"]}, 
+        {"symbol":9,"scope":12,"node":"identifier","identifier":"a","flags":["read","write"]}, 
         
       ], 
       "members": [], 
@@ -150,10 +150,10 @@
       "debugName": "", 
       "token": 70, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(16), 
+      "scope": semantic.id.NominalId(u32)(12), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":10,"scope":16,"node":"identifier","identifier":"b","flags":["read"]}, 
+        {"symbol":10,"scope":12,"node":"identifier","identifier":"b","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -165,10 +165,10 @@
       "debugName": "", 
       "token": 75, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(16), 
+      "scope": semantic.id.NominalId(u32)(12), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":11,"scope":16,"node":"identifier","identifier":"c","flags":["read"]}, 
+        {"symbol":11,"scope":12,"node":"identifier","identifier":"c","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -180,10 +180,10 @@
       "debugName": "", 
       "token": 80, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(16), 
+      "scope": semantic.id.NominalId(u32)(12), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":12,"scope":16,"node":"identifier","identifier":"d","flags":["read"]}, 
+        {"symbol":12,"scope":12,"node":"identifier","identifier":"d","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -195,10 +195,10 @@
       "debugName": "", 
       "token": 85, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(16), 
+      "scope": semantic.id.NominalId(u32)(12), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":13,"scope":16,"node":"identifier","identifier":"e","flags":["read"]}, 
+        {"symbol":13,"scope":12,"node":"identifier","identifier":"e","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -210,10 +210,10 @@
       "debugName": "", 
       "token": 90, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(16), 
+      "scope": semantic.id.NominalId(u32)(12), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":14,"scope":16,"node":"identifier","identifier":"f","flags":["read"]}, 
+        {"symbol":14,"scope":12,"node":"identifier","identifier":"f","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -236,15 +236,16 @@
     "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
-        "flags": [], 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
-            "flags": ["function"], 
+            "flags": ["function", "block"], 
             "bindings": {
+              "x": 2, 
               
             }, 
             "children": [
@@ -252,20 +253,9 @@
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": ["block"], 
                 "bindings": {
-                  "x": 2, 
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(4), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 
@@ -274,37 +264,27 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(5), 
-        "flags": [], 
+        "id": semantic.id.NominalId(u32)(4), 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(6), 
-            "flags": ["function"], 
+            "id": semantic.id.NominalId(u32)(5), 
+            "flags": ["function", "block"], 
             "bindings": {
+              "y": 4, 
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(7), 
+                "id": semantic.id.NominalId(u32)(6), 
                 "flags": ["block"], 
                 "bindings": {
-                  "y": 4, 
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(8), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 
@@ -313,38 +293,28 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(9), 
-        "flags": [], 
+        "id": semantic.id.NominalId(u32)(7), 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(10), 
-            "flags": ["function"], 
+            "id": semantic.id.NominalId(u32)(8), 
+            "flags": ["function", "block"], 
             "bindings": {
+              "z": 6, 
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(11), 
+                "id": semantic.id.NominalId(u32)(9), 
                 "flags": ["block"], 
                 "bindings": {
-                  "z": 6, 
+                  "a": 7, 
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(12), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      "a": 7, 
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 
@@ -353,42 +323,32 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(13), 
-        "flags": [], 
+        "id": semantic.id.NominalId(u32)(10), 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(14), 
-            "flags": ["function"], 
+            "id": semantic.id.NominalId(u32)(11), 
+            "flags": ["function", "block"], 
             "bindings": {
+              "a": 9, 
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(15), 
+                "id": semantic.id.NominalId(u32)(12), 
                 "flags": ["block"], 
                 "bindings": {
-                  "a": 9, 
+                  "b": 10, 
+                  "c": 11, 
+                  "d": 12, 
+                  "e": 13, 
+                  "f": 14, 
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(16), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      "b": 10, 
-                      "c": 11, 
-                      "d": 12, 
-                      "e": 13, 
-                      "f": 14, 
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/cond_if.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/cond_if.zig.snap
@@ -22,9 +22,9 @@
       "scope": semantic.id.NominalId(u32)(0), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":1,"scope":7,"node":"identifier","identifier":"std","flags":["call"]}, 
-        {"symbol":1,"scope":23,"node":"identifier","identifier":"std","flags":["call"]}, 
-        {"symbol":1,"scope":25,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":6,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":20,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":22,"node":"identifier","identifier":"std","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -40,7 +40,7 @@
       "flags": ["variable", "const"], 
       "references": [
         {"symbol":2,"scope":0,"node":"identifier","identifier":"builtin","flags":["read"]}, 
-        {"symbol":2,"scope":15,"node":"identifier","identifier":"builtin","flags":["read"]}, 
+        {"symbol":2,"scope":13,"node":"identifier","identifier":"builtin","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -80,15 +80,15 @@
       "debugName": "", 
       "token": 39, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(5), 
+      "scope": semantic.id.NominalId(u32)(4), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":5,"scope":5,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":5,"scope":5,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":5,"scope":10,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":5,"scope":10,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":5,"scope":10,"node":"identifier","identifier":"i","flags":["write"]}, 
-        {"symbol":5,"scope":12,"node":"identifier","identifier":"i","flags":["write"]}, 
+        {"symbol":5,"scope":4,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":5,"scope":4,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":5,"scope":9,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":5,"scope":9,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":5,"scope":9,"node":"identifier","identifier":"i","flags":["write"]}, 
+        {"symbol":5,"scope":11,"node":"identifier","identifier":"i","flags":["write"]}, 
         
       ], 
       "members": [], 
@@ -100,10 +100,10 @@
       "debugName": "", 
       "token": 76, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(10), 
+      "scope": semantic.id.NominalId(u32)(9), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":6,"scope":10,"node":"identifier","identifier":"pow","flags":["read"]}, 
+        {"symbol":6,"scope":9,"node":"identifier","identifier":"pow","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -143,10 +143,10 @@
       "debugName": "", 
       "token": 129, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(21), 
+      "scope": semantic.id.NominalId(u32)(18), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":9,"scope":21,"node":"identifier","identifier":"res","flags":["read"]}, 
+        {"symbol":9,"scope":18,"node":"identifier","identifier":"res","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -158,10 +158,10 @@
       "debugName": "", 
       "token": 142, 
       "declNode": "block_two_semicolon", 
-      "scope": semantic.id.NominalId(u32)(22), 
+      "scope": semantic.id.NominalId(u32)(19), 
       "flags": ["payload", "const"], 
       "references": [
-        {"symbol":10,"scope":23,"node":"identifier","identifier":"x","flags":["read"]}, 
+        {"symbol":10,"scope":20,"node":"identifier","identifier":"x","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -173,10 +173,10 @@
       "debugName": "", 
       "token": 162, 
       "declNode": "block_two_semicolon", 
-      "scope": semantic.id.NominalId(u32)(24), 
+      "scope": semantic.id.NominalId(u32)(21), 
       "flags": ["payload", "const"], 
       "references": [
-        {"symbol":11,"scope":25,"node":"identifier","identifier":"err","flags":["read"]}, 
+        {"symbol":11,"scope":22,"node":"identifier","identifier":"err","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -217,140 +217,74 @@
         
       }, {
         "id": semantic.id.NominalId(u32)(3), 
-        "flags": [], 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
             "id": semantic.id.NominalId(u32)(4), 
-            "flags": ["function"], 
+            "flags": ["function", "block"], 
             "bindings": {
+              "i": 5, 
               
             }, 
             "children": [
               {
                 "id": semantic.id.NominalId(u32)(5), 
-                "flags": ["block"], 
+                "flags": [], 
                 "bindings": {
-                  "i": 5, 
                   
                 }, 
                 "children": [
                   {
                     "id": semantic.id.NominalId(u32)(6), 
-                    "flags": [], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [
-                      {
-                        "id": semantic.id.NominalId(u32)(7), 
-                        "flags": ["block"], 
-                        "bindings": {
-                          
-                        }, 
-                        "children": [], 
-                        
-                      }, 
-                    ], 
-                    
-                  }, {
-                    "id": semantic.id.NominalId(u32)(8), 
-                    "flags": [], 
+                    "flags": ["block"], 
                     "bindings": {
                       
                     }, 
                     "children": [], 
                     
-                  }, {
-                    "id": semantic.id.NominalId(u32)(9), 
-                    "flags": [], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [
-                      {
-                        "id": semantic.id.NominalId(u32)(10), 
-                        "flags": ["block"], 
-                        "bindings": {
-                          "pow": 6, 
-                          
-                        }, 
-                        "children": [], 
-                        
-                      }, 
-                    ], 
-                    
-                  }, {
-                    "id": semantic.id.NominalId(u32)(11), 
-                    "flags": [], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [
-                      {
-                        "id": semantic.id.NominalId(u32)(12), 
-                        "flags": ["block"], 
-                        "bindings": {
-                          
-                        }, 
-                        "children": [], 
-                        
-                      }, 
-                    ], 
-                    
                   }, 
                 ], 
                 
-              }, 
-            ], 
-            
-          }, 
-        ], 
-        
-      }, {
-        "id": semantic.id.NominalId(u32)(13), 
-        "flags": [], 
-        "bindings": {
-          
-        }, 
-        "children": [
-          {
-            "id": semantic.id.NominalId(u32)(14), 
-            "flags": ["function"], 
-            "bindings": {
-              
-            }, 
-            "children": [
-              {
-                "id": semantic.id.NominalId(u32)(15), 
-                "flags": ["block"], 
+              }, {
+                "id": semantic.id.NominalId(u32)(7), 
+                "flags": [], 
+                "bindings": {
+                  
+                }, 
+                "children": [], 
+                
+              }, {
+                "id": semantic.id.NominalId(u32)(8), 
+                "flags": [], 
                 "bindings": {
                   
                 }, 
                 "children": [
                   {
-                    "id": semantic.id.NominalId(u32)(16), 
-                    "flags": ["comptime"], 
+                    "id": semantic.id.NominalId(u32)(9), 
+                    "flags": ["block"], 
                     "bindings": {
+                      "pow": 6, 
                       
                     }, 
-                    "children": [
-                      {
-                        "id": semantic.id.NominalId(u32)(17), 
-                        "flags": ["block", "comptime"], 
-                        "bindings": {
-                          
-                        }, 
-                        "children": [], 
-                        
-                      }, 
-                    ], 
+                    "children": [], 
                     
-                  }, {
-                    "id": semantic.id.NominalId(u32)(18), 
-                    "flags": ["comptime"], 
+                  }, 
+                ], 
+                
+              }, {
+                "id": semantic.id.NominalId(u32)(10), 
+                "flags": [], 
+                "bindings": {
+                  
+                }, 
+                "children": [
+                  {
+                    "id": semantic.id.NominalId(u32)(11), 
+                    "flags": ["block"], 
                     "bindings": {
                       
                     }, 
@@ -366,64 +300,100 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(19), 
-        "flags": [], 
+        "id": semantic.id.NominalId(u32)(12), 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(20), 
-            "flags": ["function"], 
+            "id": semantic.id.NominalId(u32)(13), 
+            "flags": ["function", "block"], 
             "bindings": {
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(21), 
-                "flags": ["block"], 
+                "id": semantic.id.NominalId(u32)(14), 
+                "flags": ["comptime"], 
                 "bindings": {
-                  "res": 9, 
+                  
+                }, 
+                "children": [
+                  {
+                    "id": semantic.id.NominalId(u32)(15), 
+                    "flags": ["block", "comptime"], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [], 
+                    
+                  }, 
+                ], 
+                
+              }, {
+                "id": semantic.id.NominalId(u32)(16), 
+                "flags": ["comptime"], 
+                "bindings": {
+                  
+                }, 
+                "children": [], 
+                
+              }, 
+            ], 
+            
+          }, 
+        ], 
+        
+      }, {
+        "id": semantic.id.NominalId(u32)(17), 
+        "flags": ["function"], 
+        "bindings": {
+          
+        }, 
+        "children": [
+          {
+            "id": semantic.id.NominalId(u32)(18), 
+            "flags": ["function", "block"], 
+            "bindings": {
+              "res": 9, 
+              
+            }, 
+            "children": [
+              {
+                "id": semantic.id.NominalId(u32)(19), 
+                "flags": [], 
+                "bindings": {
+                  "x": 10, 
+                  
+                }, 
+                "children": [
+                  {
+                    "id": semantic.id.NominalId(u32)(20), 
+                    "flags": ["block"], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [], 
+                    
+                  }, 
+                ], 
+                
+              }, {
+                "id": semantic.id.NominalId(u32)(21), 
+                "flags": [], 
+                "bindings": {
+                  "err": 11, 
                   
                 }, 
                 "children": [
                   {
                     "id": semantic.id.NominalId(u32)(22), 
-                    "flags": [], 
+                    "flags": ["block"], 
                     "bindings": {
-                      "x": 10, 
                       
                     }, 
-                    "children": [
-                      {
-                        "id": semantic.id.NominalId(u32)(23), 
-                        "flags": ["block"], 
-                        "bindings": {
-                          
-                        }, 
-                        "children": [], 
-                        
-                      }, 
-                    ], 
-                    
-                  }, {
-                    "id": semantic.id.NominalId(u32)(24), 
-                    "flags": [], 
-                    "bindings": {
-                      "err": 11, 
-                      
-                    }, 
-                    "children": [
-                      {
-                        "id": semantic.id.NominalId(u32)(25), 
-                        "flags": ["block"], 
-                        "bindings": {
-                          
-                        }, 
-                        "children": [], 
-                        
-                      }, 
-                    ], 
+                    "children": [], 
                     
                   }, 
                 ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
@@ -23,7 +23,7 @@
       "flags": ["variable", "const"], 
       "references": [
         {"symbol":1,"scope":2,"node":"identifier","identifier":"Foo","flags":["read"]}, 
-        {"symbol":1,"scope":4,"node":"identifier","identifier":"Foo","flags":["read"]}, 
+        {"symbol":1,"scope":3,"node":"identifier","identifier":"Foo","flags":["read"]}, 
         
       ], 
       "members": [2,3,4,5,6], 
@@ -108,7 +108,7 @@
       "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":7,"scope":4,"node":"identifier","identifier":"self","flags":["read"]}, 
+        {"symbol":7,"scope":3,"node":"identifier","identifier":"self","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -140,7 +140,7 @@
         "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
-            "flags": [], 
+            "flags": ["function"], 
             "bindings": {
               "self": 7, 
               
@@ -148,21 +148,11 @@
             "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
-                "flags": ["function"], 
+                "flags": ["function", "block"], 
                 "bindings": {
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(4), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
@@ -23,9 +23,9 @@
       "flags": ["variable", "const"], 
       "references": [
         {"symbol":1,"scope":0,"node":"identifier","identifier":"std","flags":["read"]}, 
-        {"symbol":1,"scope":3,"node":"identifier","identifier":"std","flags":["read"]}, 
-        {"symbol":1,"scope":3,"node":"identifier","identifier":"std","flags":["read"]}, 
-        {"symbol":1,"scope":3,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":2,"node":"identifier","identifier":"std","flags":["read"]}, 
+        {"symbol":1,"scope":2,"node":"identifier","identifier":"std","flags":["read"]}, 
+        {"symbol":1,"scope":2,"node":"identifier","identifier":"std","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -40,9 +40,9 @@
       "scope": semantic.id.NominalId(u32)(0), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":2,"scope":3,"node":"identifier","identifier":"Managed","flags":["call"]}, 
-        {"symbol":2,"scope":3,"node":"identifier","identifier":"Managed","flags":["call"]}, 
-        {"symbol":2,"scope":3,"node":"identifier","identifier":"Managed","flags":["call"]}, 
+        {"symbol":2,"scope":2,"node":"identifier","identifier":"Managed","flags":["call"]}, 
+        {"symbol":2,"scope":2,"node":"identifier","identifier":"Managed","flags":["call"]}, 
+        {"symbol":2,"scope":2,"node":"identifier","identifier":"Managed","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -68,14 +68,14 @@
       "debugName": "", 
       "token": 31, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":4,"scope":3,"node":"identifier","identifier":"allocator","flags":["read"]}, 
-        {"symbol":4,"scope":3,"node":"identifier","identifier":"allocator","flags":["read"]}, 
-        {"symbol":4,"scope":3,"node":"identifier","identifier":"allocator","flags":["read"]}, 
-        {"symbol":4,"scope":3,"node":"identifier","identifier":"allocator","flags":["read"]}, 
-        {"symbol":4,"scope":3,"node":"identifier","identifier":"allocator","flags":["call"]}, 
+        {"symbol":4,"scope":2,"node":"identifier","identifier":"allocator","flags":["read"]}, 
+        {"symbol":4,"scope":2,"node":"identifier","identifier":"allocator","flags":["read"]}, 
+        {"symbol":4,"scope":2,"node":"identifier","identifier":"allocator","flags":["read"]}, 
+        {"symbol":4,"scope":2,"node":"identifier","identifier":"allocator","flags":["read"]}, 
+        {"symbol":4,"scope":2,"node":"identifier","identifier":"allocator","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -87,13 +87,13 @@
       "debugName": "", 
       "token": 40, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["variable"], 
       "references": [
+        {"symbol":5,"scope":2,"node":"identifier","identifier":"a","flags":["call"]}, 
         {"symbol":5,"scope":3,"node":"identifier","identifier":"a","flags":["call"]}, 
-        {"symbol":5,"scope":4,"node":"identifier","identifier":"a","flags":["call"]}, 
-        {"symbol":5,"scope":4,"node":"identifier","identifier":"a","flags":["call"]}, 
         {"symbol":5,"scope":3,"node":"identifier","identifier":"a","flags":["call"]}, 
+        {"symbol":5,"scope":2,"node":"identifier","identifier":"a","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -105,13 +105,13 @@
       "debugName": "", 
       "token": 60, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["variable"], 
       "references": [
+        {"symbol":6,"scope":2,"node":"identifier","identifier":"b","flags":["call"]}, 
         {"symbol":6,"scope":3,"node":"identifier","identifier":"b","flags":["call"]}, 
-        {"symbol":6,"scope":4,"node":"identifier","identifier":"b","flags":["call"]}, 
-        {"symbol":6,"scope":4,"node":"identifier","identifier":"b","flags":["read"]}, 
-        {"symbol":6,"scope":4,"node":"identifier","identifier":"b","flags":["call"]}, 
+        {"symbol":6,"scope":3,"node":"identifier","identifier":"b","flags":["read"]}, 
+        {"symbol":6,"scope":3,"node":"identifier","identifier":"b","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -123,11 +123,11 @@
       "debugName": "", 
       "token": 80, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":7,"scope":3,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":7,"scope":3,"node":"identifier","identifier":"i","flags":["read","write"]}, 
+        {"symbol":7,"scope":2,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":7,"scope":2,"node":"identifier","identifier":"i","flags":["read","write"]}, 
         
       ], 
       "members": [], 
@@ -139,12 +139,12 @@
       "debugName": "", 
       "token": 87, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["variable"], 
       "references": [
+        {"symbol":8,"scope":2,"node":"identifier","identifier":"c","flags":["call"]}, 
         {"symbol":8,"scope":3,"node":"identifier","identifier":"c","flags":["call"]}, 
-        {"symbol":8,"scope":4,"node":"identifier","identifier":"c","flags":["call"]}, 
-        {"symbol":8,"scope":4,"node":"identifier","identifier":"c","flags":["read"]}, 
+        {"symbol":8,"scope":3,"node":"identifier","identifier":"c","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -156,11 +156,11 @@
       "debugName": "", 
       "token": 153, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":9,"scope":3,"node":"identifier","identifier":"as","flags":["read"]}, 
-        {"symbol":9,"scope":3,"node":"identifier","identifier":"as","flags":["read"]}, 
+        {"symbol":9,"scope":2,"node":"identifier","identifier":"as","flags":["read"]}, 
+        {"symbol":9,"scope":2,"node":"identifier","identifier":"as","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -182,15 +182,21 @@
     "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
-        "flags": [], 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
-            "flags": ["function"], 
+            "flags": ["function", "block"], 
             "bindings": {
+              "allocator": 4, 
+              "a": 5, 
+              "b": 6, 
+              "i": 7, 
+              "c": 8, 
+              "as": 9, 
               
             }, 
             "children": [
@@ -198,25 +204,9 @@
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": ["block"], 
                 "bindings": {
-                  "allocator": 4, 
-                  "a": 5, 
-                  "b": 6, 
-                  "i": 7, 
-                  "c": 8, 
-                  "as": 9, 
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(4), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
@@ -47,7 +47,7 @@
       "debugName": "", 
       "token": 12, 
       "declNode": "container_field_init", 
-      "scope": semantic.id.NominalId(u32)(4), 
+      "scope": semantic.id.NominalId(u32)(3), 
       "flags": ["member"], 
       "references": [
         
@@ -61,10 +61,10 @@
       "debugName": "", 
       "token": 18, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(4), 
+      "scope": semantic.id.NominalId(u32)(3), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":4,"scope":5,"node":"identifier","identifier":"Self","flags":["read"]}, 
+        {"symbol":4,"scope":4,"node":"identifier","identifier":"Self","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -76,7 +76,7 @@
       "debugName": "", 
       "token": 26, 
       "declNode": "fn_decl", 
-      "scope": semantic.id.NominalId(u32)(4), 
+      "scope": semantic.id.NominalId(u32)(3), 
       "flags": ["fn"], 
       "references": [
         
@@ -90,10 +90,10 @@
       "debugName": "", 
       "token": 28, 
       "declNode": "ptr_type_aligned", 
-      "scope": semantic.id.NominalId(u32)(5), 
+      "scope": semantic.id.NominalId(u32)(4), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":6,"scope":7,"node":"identifier","identifier":"self","flags":["read"]}, 
+        {"symbol":6,"scope":5,"node":"identifier","identifier":"self","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -119,7 +119,7 @@
       "debugName": "", 
       "token": 49, 
       "declNode": "identifier", 
-      "scope": semantic.id.NominalId(u32)(8), 
+      "scope": semantic.id.NominalId(u32)(6), 
       "flags": ["comptime", "const", "fn_param"], 
       "references": [
         
@@ -133,11 +133,11 @@
       "debugName": "", 
       "token": 56, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(10), 
+      "scope": semantic.id.NominalId(u32)(7), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":9,"scope":10,"node":"identifier","identifier":"l","flags":["read","write"]}, 
-        {"symbol":9,"scope":10,"node":"identifier","identifier":"l","flags":["read"]}, 
+        {"symbol":9,"scope":7,"node":"identifier","identifier":"l","flags":["read","write"]}, 
+        {"symbol":9,"scope":7,"node":"identifier","identifier":"l","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -149,7 +149,7 @@
       "debugName": "", 
       "token": 80, 
       "declNode": "container_field_init", 
-      "scope": semantic.id.NominalId(u32)(14), 
+      "scope": semantic.id.NominalId(u32)(11), 
       "flags": ["member"], 
       "references": [
         
@@ -177,11 +177,11 @@
       "debugName": "", 
       "token": 94, 
       "declNode": "identifier", 
-      "scope": semantic.id.NominalId(u32)(15), 
+      "scope": semantic.id.NominalId(u32)(12), 
       "flags": ["comptime", "const", "fn_param"], 
       "references": [
-        {"symbol":12,"scope":18,"node":"identifier","identifier":"a","flags":["read"]}, 
-        {"symbol":12,"scope":17,"node":"identifier","identifier":"a","flags":["read"]}, 
+        {"symbol":12,"scope":14,"node":"identifier","identifier":"a","flags":["read"]}, 
+        {"symbol":12,"scope":13,"node":"identifier","identifier":"a","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -193,10 +193,10 @@
       "debugName": "", 
       "token": 98, 
       "declNode": "identifier", 
-      "scope": semantic.id.NominalId(u32)(15), 
+      "scope": semantic.id.NominalId(u32)(12), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":13,"scope":17,"node":"identifier","identifier":"b","flags":["read"]}, 
+        {"symbol":13,"scope":13,"node":"identifier","identifier":"b","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -208,10 +208,10 @@
       "debugName": "", 
       "token": 107, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(18), 
+      "scope": semantic.id.NominalId(u32)(14), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":14,"scope":18,"node":"identifier","identifier":"c","flags":["read"]}, 
+        {"symbol":14,"scope":14,"node":"identifier","identifier":"c","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -223,10 +223,10 @@
       "debugName": "", 
       "token": 126, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(17), 
+      "scope": semantic.id.NominalId(u32)(13), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":15,"scope":17,"node":"identifier","identifier":"a2","flags":["read"]}, 
+        {"symbol":15,"scope":13,"node":"identifier","identifier":"a2","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -236,9 +236,9 @@
   ], 
   "unresolvedReferences": [
     {"symbol":null,"scope":1,"node":"identifier","identifier":"type","flags":["read"]}, 
-    {"symbol":null,"scope":8,"node":"identifier","identifier":"usize","flags":["read"]}, 
-    {"symbol":null,"scope":15,"node":"identifier","identifier":"isize","flags":["read"]}, 
-    {"symbol":null,"scope":15,"node":"identifier","identifier":"usize","flags":["read"]}, 
+    {"symbol":null,"scope":6,"node":"identifier","identifier":"usize","flags":["read"]}, 
+    {"symbol":null,"scope":12,"node":"identifier","identifier":"isize","flags":["read"]}, 
+    {"symbol":null,"scope":12,"node":"identifier","identifier":"usize","flags":["read"]}, 
     
   ], 
   "scopes": {
@@ -254,7 +254,7 @@
     "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
-        "flags": ["comptime"], 
+        "flags": ["function", "comptime"], 
         "bindings": {
           "T": 2, 
           
@@ -262,7 +262,7 @@
         "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
-            "flags": ["function", "comptime"], 
+            "flags": ["function", "block", "comptime"], 
             "bindings": {
               
             }, 
@@ -271,47 +271,27 @@
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": ["block", "comptime"], 
                 "bindings": {
+                  "inner": 3, 
+                  "Self": 4, 
+                  "deref": 5, 
                   
                 }, 
                 "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
-                    "flags": ["block", "comptime"], 
+                    "flags": ["function"], 
                     "bindings": {
-                      "inner": 3, 
-                      "Self": 4, 
-                      "deref": 5, 
+                      "self": 6, 
                       
                     }, 
                     "children": [
                       {
                         "id": semantic.id.NominalId(u32)(5), 
-                        "flags": [], 
+                        "flags": ["function", "block"], 
                         "bindings": {
-                          "self": 6, 
                           
                         }, 
-                        "children": [
-                          {
-                            "id": semantic.id.NominalId(u32)(6), 
-                            "flags": ["function"], 
-                            "bindings": {
-                              
-                            }, 
-                            "children": [
-                              {
-                                "id": semantic.id.NominalId(u32)(7), 
-                                "flags": ["block"], 
-                                "bindings": {
-                                  
-                                }, 
-                                "children": [], 
-                                
-                              }, 
-                            ], 
-                            
-                          }, 
-                        ], 
+                        "children": [], 
                         
                       }, 
                     ], 
@@ -326,37 +306,96 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(8), 
-        "flags": ["comptime"], 
+        "id": semantic.id.NominalId(u32)(6), 
+        "flags": ["function", "comptime"], 
         "bindings": {
           "size": 8, 
           
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(9), 
-            "flags": ["function", "comptime"], 
+            "id": semantic.id.NominalId(u32)(7), 
+            "flags": ["function", "block", "comptime"], 
             "bindings": {
+              "l": 9, 
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(10), 
-                "flags": ["block", "comptime"], 
+                "id": semantic.id.NominalId(u32)(8), 
+                "flags": ["comptime"], 
                 "bindings": {
-                  "l": 9, 
                   
                 }, 
                 "children": [
                   {
-                    "id": semantic.id.NominalId(u32)(11), 
+                    "id": semantic.id.NominalId(u32)(9), 
+                    "flags": ["block", "comptime"], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [], 
+                    
+                  }, 
+                ], 
+                
+              }, {
+                "id": semantic.id.NominalId(u32)(10), 
+                "flags": ["comptime"], 
+                "bindings": {
+                  
+                }, 
+                "children": [], 
+                
+              }, {
+                "id": semantic.id.NominalId(u32)(11), 
+                "flags": ["block", "comptime"], 
+                "bindings": {
+                  "inner": 10, 
+                  
+                }, 
+                "children": [], 
+                
+              }, 
+            ], 
+            
+          }, 
+        ], 
+        
+      }, {
+        "id": semantic.id.NominalId(u32)(12), 
+        "flags": ["function"], 
+        "bindings": {
+          "a": 12, 
+          "b": 13, 
+          
+        }, 
+        "children": [
+          {
+            "id": semantic.id.NominalId(u32)(13), 
+            "flags": ["function", "block"], 
+            "bindings": {
+              "a2": 15, 
+              
+            }, 
+            "children": [
+              {
+                "id": semantic.id.NominalId(u32)(14), 
+                "flags": ["block", "comptime"], 
+                "bindings": {
+                  "c": 14, 
+                  
+                }, 
+                "children": [
+                  {
+                    "id": semantic.id.NominalId(u32)(15), 
                     "flags": ["comptime"], 
                     "bindings": {
                       
                     }, 
                     "children": [
                       {
-                        "id": semantic.id.NominalId(u32)(12), 
+                        "id": semantic.id.NominalId(u32)(16), 
                         "flags": ["block", "comptime"], 
                         "bindings": {
                           
@@ -367,91 +406,12 @@
                     ], 
                     
                   }, {
-                    "id": semantic.id.NominalId(u32)(13), 
+                    "id": semantic.id.NominalId(u32)(17), 
                     "flags": ["comptime"], 
                     "bindings": {
                       
                     }, 
                     "children": [], 
-                    
-                  }, {
-                    "id": semantic.id.NominalId(u32)(14), 
-                    "flags": ["block", "comptime"], 
-                    "bindings": {
-                      "inner": 10, 
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
-                
-              }, 
-            ], 
-            
-          }, 
-        ], 
-        
-      }, {
-        "id": semantic.id.NominalId(u32)(15), 
-        "flags": [], 
-        "bindings": {
-          "a": 12, 
-          "b": 13, 
-          
-        }, 
-        "children": [
-          {
-            "id": semantic.id.NominalId(u32)(16), 
-            "flags": ["function"], 
-            "bindings": {
-              
-            }, 
-            "children": [
-              {
-                "id": semantic.id.NominalId(u32)(17), 
-                "flags": ["block"], 
-                "bindings": {
-                  "a2": 15, 
-                  
-                }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(18), 
-                    "flags": ["block", "comptime"], 
-                    "bindings": {
-                      "c": 14, 
-                      
-                    }, 
-                    "children": [
-                      {
-                        "id": semantic.id.NominalId(u32)(19), 
-                        "flags": ["comptime"], 
-                        "bindings": {
-                          
-                        }, 
-                        "children": [
-                          {
-                            "id": semantic.id.NominalId(u32)(20), 
-                            "flags": ["block", "comptime"], 
-                            "bindings": {
-                              
-                            }, 
-                            "children": [], 
-                            
-                          }, 
-                        ], 
-                        
-                      }, {
-                        "id": semantic.id.NominalId(u32)(21), 
-                        "flags": ["comptime"], 
-                        "bindings": {
-                          
-                        }, 
-                        "children": [], 
-                        
-                      }, 
-                    ], 
                     
                   }, 
                 ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
@@ -36,7 +36,7 @@
       "scope": semantic.id.NominalId(u32)(1), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":2,"scope":3,"node":"identifier","identifier":"a","flags":["read"]}, 
+        {"symbol":2,"scope":2,"node":"identifier","identifier":"a","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -48,10 +48,10 @@
       "debugName": "", 
       "token": 11, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":3,"scope":3,"node":"identifier","identifier":"inner","flags":["call"]}, 
+        {"symbol":3,"scope":2,"node":"identifier","identifier":"inner","flags":["call"]}, 
         
       ], 
       "members": [4], 
@@ -63,7 +63,7 @@
       "debugName": "", 
       "token": 16, 
       "declNode": "fn_decl", 
-      "scope": semantic.id.NominalId(u32)(4), 
+      "scope": semantic.id.NominalId(u32)(3), 
       "flags": ["fn"], 
       "references": [
         
@@ -77,10 +77,10 @@
       "debugName": "", 
       "token": 18, 
       "declNode": "identifier", 
-      "scope": semantic.id.NominalId(u32)(5), 
+      "scope": semantic.id.NominalId(u32)(4), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":5,"scope":7,"node":"identifier","identifier":"b","flags":["read"]}, 
+        {"symbol":5,"scope":5,"node":"identifier","identifier":"b","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -90,7 +90,7 @@
   ], 
   "unresolvedReferences": [
     {"symbol":null,"scope":1,"node":"identifier","identifier":"u32","flags":["read"]}, 
-    {"symbol":null,"scope":5,"node":"identifier","identifier":"u32","flags":["read"]}, 
+    {"symbol":null,"scope":4,"node":"identifier","identifier":"u32","flags":["read"]}, 
     
   ], 
   "scopes": {
@@ -104,7 +104,7 @@
     "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
-        "flags": [], 
+        "flags": ["function"], 
         "bindings": {
           "a": 2, 
           
@@ -112,8 +112,9 @@
         "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
-            "flags": ["function"], 
+            "flags": ["function", "block"], 
             "bindings": {
+              "inner": 3, 
               
             }, 
             "children": [
@@ -121,46 +122,25 @@
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": ["block"], 
                 "bindings": {
-                  "inner": 3, 
+                  "bar": 4, 
                   
                 }, 
                 "children": [
                   {
                     "id": semantic.id.NominalId(u32)(4), 
-                    "flags": ["block"], 
+                    "flags": ["function"], 
                     "bindings": {
-                      "bar": 4, 
+                      "b": 5, 
                       
                     }, 
                     "children": [
                       {
                         "id": semantic.id.NominalId(u32)(5), 
-                        "flags": [], 
+                        "flags": ["function", "block"], 
                         "bindings": {
-                          "b": 5, 
                           
                         }, 
-                        "children": [
-                          {
-                            "id": semantic.id.NominalId(u32)(6), 
-                            "flags": ["function"], 
-                            "bindings": {
-                              
-                            }, 
-                            "children": [
-                              {
-                                "id": semantic.id.NominalId(u32)(7), 
-                                "flags": ["block"], 
-                                "bindings": {
-                                  
-                                }, 
-                                "children": [], 
-                                
-                              }, 
-                            ], 
-                            
-                          }, 
-                        ], 
+                        "children": [], 
                         
                       }, 
                     ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
@@ -22,7 +22,7 @@
       "scope": semantic.id.NominalId(u32)(0), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":1,"scope":4,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":3,"node":"identifier","identifier":"std","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -122,7 +122,7 @@
       "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":8,"scope":4,"node":"identifier","identifier":"self","flags":["read"]}, 
+        {"symbol":8,"scope":3,"node":"identifier","identifier":"self","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -160,7 +160,7 @@
         "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
-            "flags": [], 
+            "flags": ["function"], 
             "bindings": {
               "self": 8, 
               
@@ -168,21 +168,11 @@
             "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
-                "flags": ["function"], 
+                "flags": ["function", "block"], 
                 "bindings": {
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(4), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_for.zig.snap
@@ -22,8 +22,8 @@
       "scope": semantic.id.NominalId(u32)(0), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":1,"scope":4,"node":"identifier","identifier":"std","flags":["call"]}, 
-        {"symbol":1,"scope":11,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":3,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":9,"node":"identifier","identifier":"std","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -49,10 +49,10 @@
       "debugName": "", 
       "token": 15, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":3,"scope":3,"node":"identifier","identifier":"arr","flags":["read"]}, 
+        {"symbol":3,"scope":2,"node":"identifier","identifier":"arr","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -64,10 +64,10 @@
       "debugName": "", 
       "token": 42, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(4), 
+      "scope": semantic.id.NominalId(u32)(3), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":4,"scope":4,"node":"identifier","identifier":"power_of_two","flags":["read"]}, 
+        {"symbol":4,"scope":3,"node":"identifier","identifier":"power_of_two","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -93,10 +93,10 @@
       "debugName": "", 
       "token": 73, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(7), 
+      "scope": semantic.id.NominalId(u32)(5), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":6,"scope":7,"node":"identifier","identifier":"mat4x4","flags":["read"]}, 
+        {"symbol":6,"scope":5,"node":"identifier","identifier":"mat4x4","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -105,12 +105,12 @@
     }, 
   ], 
   "unresolvedReferences": [
-    {"symbol":null,"scope":4,"node":"identifier","identifier":"i","flags":["read"]}, 
-    {"symbol":null,"scope":4,"node":"identifier","identifier":"i","flags":["read"]}, 
-    {"symbol":null,"scope":8,"node":"identifier","identifier":"row","flags":["read"]}, 
-    {"symbol":null,"scope":9,"node":"identifier","identifier":"row_index","flags":["read"]}, 
-    {"symbol":null,"scope":9,"node":"identifier","identifier":"column_index","flags":["read"]}, 
-    {"symbol":null,"scope":11,"node":"identifier","identifier":"cell","flags":["read"]}, 
+    {"symbol":null,"scope":3,"node":"identifier","identifier":"i","flags":["read"]}, 
+    {"symbol":null,"scope":3,"node":"identifier","identifier":"i","flags":["read"]}, 
+    {"symbol":null,"scope":6,"node":"identifier","identifier":"row","flags":["read"]}, 
+    {"symbol":null,"scope":7,"node":"identifier","identifier":"row_index","flags":["read"]}, 
+    {"symbol":null,"scope":7,"node":"identifier","identifier":"column_index","flags":["read"]}, 
+    {"symbol":null,"scope":9,"node":"identifier","identifier":"cell","flags":["read"]}, 
     
   ], 
   "scopes": {
@@ -126,15 +126,16 @@
     "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
-        "flags": [], 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
-            "flags": ["function"], 
+            "flags": ["function", "block"], 
             "bindings": {
+              "arr": 3, 
               
             }, 
             "children": [
@@ -142,21 +143,10 @@
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": ["block"], 
                 "bindings": {
-                  "arr": 3, 
+                  "power_of_two": 4, 
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(4), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      "power_of_two": 4, 
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 
@@ -165,62 +155,44 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(5), 
-        "flags": [], 
+        "id": semantic.id.NominalId(u32)(4), 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(6), 
-            "flags": ["function"], 
+            "id": semantic.id.NominalId(u32)(5), 
+            "flags": ["function", "block"], 
             "bindings": {
+              "mat4x4": 6, 
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(7), 
+                "id": semantic.id.NominalId(u32)(6), 
                 "flags": ["block"], 
                 "bindings": {
-                  "mat4x4": 6, 
                   
                 }, 
                 "children": [
                   {
-                    "id": semantic.id.NominalId(u32)(8), 
+                    "id": semantic.id.NominalId(u32)(7), 
                     "flags": ["block"], 
                     "bindings": {
                       
                     }, 
                     "children": [
                       {
-                        "id": semantic.id.NominalId(u32)(9), 
-                        "flags": ["block"], 
+                        "id": semantic.id.NominalId(u32)(8), 
+                        "flags": [], 
                         "bindings": {
                           
                         }, 
                         "children": [
                           {
-                            "id": semantic.id.NominalId(u32)(10), 
-                            "flags": [], 
-                            "bindings": {
-                              
-                            }, 
-                            "children": [
-                              {
-                                "id": semantic.id.NominalId(u32)(11), 
-                                "flags": ["block"], 
-                                "bindings": {
-                                  
-                                }, 
-                                "children": [], 
-                                
-                              }, 
-                            ], 
-                            
-                          }, {
-                            "id": semantic.id.NominalId(u32)(12), 
-                            "flags": [], 
+                            "id": semantic.id.NominalId(u32)(9), 
+                            "flags": ["block"], 
                             "bindings": {
                               
                             }, 
@@ -228,6 +200,14 @@
                             
                           }, 
                         ], 
+                        
+                      }, {
+                        "id": semantic.id.NominalId(u32)(10), 
+                        "flags": [], 
+                        "bindings": {
+                          
+                        }, 
+                        "children": [], 
                         
                       }, 
                     ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
@@ -22,9 +22,9 @@
       "scope": semantic.id.NominalId(u32)(0), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":1,"scope":4,"node":"identifier","identifier":"std","flags":["call"]}, 
-        {"symbol":1,"scope":8,"node":"identifier","identifier":"std","flags":["call"]}, 
-        {"symbol":1,"scope":13,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":3,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":6,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":10,"node":"identifier","identifier":"std","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -50,13 +50,13 @@
       "debugName": "", 
       "token": 15, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(3), 
+      "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["variable"], 
       "references": [
+        {"symbol":3,"scope":2,"node":"identifier","identifier":"i","flags":["read"]}, 
         {"symbol":3,"scope":3,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":3,"scope":4,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":3,"scope":4,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":3,"scope":4,"node":"identifier","identifier":"i","flags":["read","write"]}, 
+        {"symbol":3,"scope":3,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":3,"scope":3,"node":"identifier","identifier":"i","flags":["read","write"]}, 
         
       ], 
       "members": [], 
@@ -68,10 +68,10 @@
       "debugName": "", 
       "token": 29, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(4), 
+      "scope": semantic.id.NominalId(u32)(3), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":4,"scope":4,"node":"identifier","identifier":"power_of_two","flags":["read"]}, 
+        {"symbol":4,"scope":3,"node":"identifier","identifier":"power_of_two","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -97,12 +97,12 @@
       "debugName": "", 
       "token": 64, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(7), 
+      "scope": semantic.id.NominalId(u32)(5), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":6,"scope":7,"node":"identifier","identifier":"map","flags":["call"]}, 
-        {"symbol":6,"scope":7,"node":"identifier","identifier":"map","flags":["call"]}, 
-        {"symbol":6,"scope":7,"node":"identifier","identifier":"map","flags":["call"]}, 
+        {"symbol":6,"scope":5,"node":"identifier","identifier":"map","flags":["call"]}, 
+        {"symbol":6,"scope":5,"node":"identifier","identifier":"map","flags":["call"]}, 
+        {"symbol":6,"scope":5,"node":"identifier","identifier":"map","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -114,10 +114,10 @@
       "debugName": "", 
       "token": 96, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(7), 
+      "scope": semantic.id.NominalId(u32)(5), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":7,"scope":7,"node":"identifier","identifier":"iter","flags":["call"]}, 
+        {"symbol":7,"scope":5,"node":"identifier","identifier":"iter","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -129,10 +129,10 @@
       "debugName": "", 
       "token": 117, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(8), 
+      "scope": semantic.id.NominalId(u32)(6), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":8,"scope":8,"node":"identifier","identifier":"k","flags":["read"]}, 
+        {"symbol":8,"scope":6,"node":"identifier","identifier":"k","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -144,10 +144,10 @@
       "debugName": "", 
       "token": 125, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(8), 
+      "scope": semantic.id.NominalId(u32)(6), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":9,"scope":8,"node":"identifier","identifier":"v","flags":["read"]}, 
+        {"symbol":9,"scope":6,"node":"identifier","identifier":"v","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -173,12 +173,12 @@
       "debugName": "", 
       "token": 157, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(11), 
+      "scope": semantic.id.NominalId(u32)(8), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":11,"scope":11,"node":"identifier","identifier":"x","flags":["read"]}, 
-        {"symbol":11,"scope":12,"node":"identifier","identifier":"x","flags":["read","write"]}, 
-        {"symbol":11,"scope":13,"node":"identifier","identifier":"x","flags":["read"]}, 
+        {"symbol":11,"scope":8,"node":"identifier","identifier":"x","flags":["read"]}, 
+        {"symbol":11,"scope":9,"node":"identifier","identifier":"x","flags":["read","write"]}, 
+        {"symbol":11,"scope":10,"node":"identifier","identifier":"x","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -190,12 +190,12 @@
       "debugName": "", 
       "token": 164, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(11), 
+      "scope": semantic.id.NominalId(u32)(8), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":12,"scope":11,"node":"identifier","identifier":"y","flags":["read"]}, 
-        {"symbol":12,"scope":12,"node":"identifier","identifier":"y","flags":["read","write"]}, 
-        {"symbol":12,"scope":13,"node":"identifier","identifier":"y","flags":["read"]}, 
+        {"symbol":12,"scope":8,"node":"identifier","identifier":"y","flags":["read"]}, 
+        {"symbol":12,"scope":9,"node":"identifier","identifier":"y","flags":["read","write"]}, 
+        {"symbol":12,"scope":10,"node":"identifier","identifier":"y","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -207,10 +207,10 @@
       "debugName": "", 
       "token": 193, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(13), 
+      "scope": semantic.id.NominalId(u32)(10), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":13,"scope":13,"node":"identifier","identifier":"my_xy","flags":["read"]}, 
+        {"symbol":13,"scope":10,"node":"identifier","identifier":"my_xy","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -236,10 +236,10 @@
       "debugName": "", 
       "token": 216, 
       "declNode": "identifier", 
-      "scope": semantic.id.NominalId(u32)(14), 
+      "scope": semantic.id.NominalId(u32)(11), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":15,"scope":16,"node":"identifier","identifier":"begin","flags":["read"]}, 
+        {"symbol":15,"scope":12,"node":"identifier","identifier":"begin","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -251,10 +251,10 @@
       "debugName": "", 
       "token": 220, 
       "declNode": "identifier", 
-      "scope": semantic.id.NominalId(u32)(14), 
+      "scope": semantic.id.NominalId(u32)(11), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":16,"scope":16,"node":"identifier","identifier":"end","flags":["read"]}, 
+        {"symbol":16,"scope":12,"node":"identifier","identifier":"end","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -266,10 +266,10 @@
       "debugName": "", 
       "token": 224, 
       "declNode": "identifier", 
-      "scope": semantic.id.NominalId(u32)(14), 
+      "scope": semantic.id.NominalId(u32)(11), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":17,"scope":17,"node":"identifier","identifier":"number","flags":["read"]}, 
+        {"symbol":17,"scope":13,"node":"identifier","identifier":"number","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -281,12 +281,12 @@
       "debugName": "", 
       "token": 231, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(16), 
+      "scope": semantic.id.NominalId(u32)(12), 
       "flags": ["variable"], 
       "references": [
-        {"symbol":18,"scope":16,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":18,"scope":16,"node":"identifier","identifier":"i","flags":["read","write"]}, 
-        {"symbol":18,"scope":17,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":18,"scope":12,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":18,"scope":12,"node":"identifier","identifier":"i","flags":["read","write"]}, 
+        {"symbol":18,"scope":13,"node":"identifier","identifier":"i","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -295,13 +295,13 @@
     }, 
   ], 
   "unresolvedReferences": [
-    {"symbol":null,"scope":8,"node":"identifier","identifier":"ent","flags":["read"]}, 
-    {"symbol":null,"scope":8,"node":"identifier","identifier":"ent","flags":["read"]}, 
-    {"symbol":null,"scope":14,"node":"identifier","identifier":"usize","flags":["read"]}, 
-    {"symbol":null,"scope":14,"node":"identifier","identifier":"usize","flags":["read"]}, 
-    {"symbol":null,"scope":14,"node":"identifier","identifier":"usize","flags":["read"]}, 
-    {"symbol":null,"scope":19,"node":"identifier","identifier":"true","flags":["read"]}, 
-    {"symbol":null,"scope":16,"node":"identifier","identifier":"false","flags":["read"]}, 
+    {"symbol":null,"scope":6,"node":"identifier","identifier":"ent","flags":["read"]}, 
+    {"symbol":null,"scope":6,"node":"identifier","identifier":"ent","flags":["read"]}, 
+    {"symbol":null,"scope":11,"node":"identifier","identifier":"usize","flags":["read"]}, 
+    {"symbol":null,"scope":11,"node":"identifier","identifier":"usize","flags":["read"]}, 
+    {"symbol":null,"scope":11,"node":"identifier","identifier":"usize","flags":["read"]}, 
+    {"symbol":null,"scope":15,"node":"identifier","identifier":"true","flags":["read"]}, 
+    {"symbol":null,"scope":12,"node":"identifier","identifier":"false","flags":["read"]}, 
     
   ], 
   "scopes": {
@@ -319,15 +319,16 @@
     "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
-        "flags": [], 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
-            "flags": ["function"], 
+            "flags": ["function", "block"], 
             "bindings": {
+              "i": 3, 
               
             }, 
             "children": [
@@ -335,21 +336,10 @@
                 "id": semantic.id.NominalId(u32)(3), 
                 "flags": ["block"], 
                 "bindings": {
-                  "i": 3, 
+                  "power_of_two": 4, 
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(4), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      "power_of_two": 4, 
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 
@@ -358,40 +348,30 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(5), 
-        "flags": [], 
+        "id": semantic.id.NominalId(u32)(4), 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(6), 
-            "flags": ["function"], 
+            "id": semantic.id.NominalId(u32)(5), 
+            "flags": ["function", "block"], 
             "bindings": {
+              "map": 6, 
+              "iter": 7, 
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(7), 
+                "id": semantic.id.NominalId(u32)(6), 
                 "flags": ["block"], 
                 "bindings": {
-                  "map": 6, 
-                  "iter": 7, 
+                  "k": 8, 
+                  "v": 9, 
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(8), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      "k": 8, 
-                      "v": 9, 
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 
@@ -400,47 +380,37 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(9), 
-        "flags": [], 
+        "id": semantic.id.NominalId(u32)(7), 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(10), 
-            "flags": ["function"], 
+            "id": semantic.id.NominalId(u32)(8), 
+            "flags": ["function", "block"], 
             "bindings": {
+              "x": 11, 
+              "y": 12, 
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(11), 
+                "id": semantic.id.NominalId(u32)(9), 
                 "flags": ["block"], 
                 "bindings": {
-                  "x": 11, 
-                  "y": 12, 
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(12), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, {
-                    "id": semantic.id.NominalId(u32)(13), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      "my_xy": 13, 
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
+                
+              }, {
+                "id": semantic.id.NominalId(u32)(10), 
+                "flags": ["block"], 
+                "bindings": {
+                  "my_xy": 13, 
+                  
+                }, 
+                "children": [], 
                 
               }, 
             ], 
@@ -449,8 +419,8 @@
         ], 
         
       }, {
-        "id": semantic.id.NominalId(u32)(14), 
-        "flags": [], 
+        "id": semantic.id.NominalId(u32)(11), 
+        "flags": ["function"], 
         "bindings": {
           "begin": 15, 
           "end": 16, 
@@ -459,48 +429,30 @@
         }, 
         "children": [
           {
-            "id": semantic.id.NominalId(u32)(15), 
-            "flags": ["function"], 
+            "id": semantic.id.NominalId(u32)(12), 
+            "flags": ["function", "block"], 
             "bindings": {
+              "i": 18, 
               
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(16), 
+                "id": semantic.id.NominalId(u32)(13), 
                 "flags": ["block"], 
                 "bindings": {
-                  "i": 18, 
                   
                 }, 
                 "children": [
                   {
-                    "id": semantic.id.NominalId(u32)(17), 
-                    "flags": ["block"], 
+                    "id": semantic.id.NominalId(u32)(14), 
+                    "flags": [], 
                     "bindings": {
                       
                     }, 
                     "children": [
                       {
-                        "id": semantic.id.NominalId(u32)(18), 
-                        "flags": [], 
-                        "bindings": {
-                          
-                        }, 
-                        "children": [
-                          {
-                            "id": semantic.id.NominalId(u32)(19), 
-                            "flags": ["block"], 
-                            "bindings": {
-                              
-                            }, 
-                            "children": [], 
-                            
-                          }, 
-                        ], 
-                        
-                      }, {
-                        "id": semantic.id.NominalId(u32)(20), 
-                        "flags": [], 
+                        "id": semantic.id.NominalId(u32)(15), 
+                        "flags": ["block"], 
                         "bindings": {
                           
                         }, 
@@ -508,6 +460,14 @@
                         
                       }, 
                     ], 
+                    
+                  }, {
+                    "id": semantic.id.NominalId(u32)(16), 
+                    "flags": [], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [], 
                     
                   }, 
                 ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
@@ -86,28 +86,18 @@
     "children": [
       {
         "id": semantic.id.NominalId(u32)(1), 
-        "flags": [], 
+        "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
-            "flags": ["function"], 
+            "flags": ["function", "block"], 
             "bindings": {
               
             }, 
-            "children": [
-              {
-                "id": semantic.id.NominalId(u32)(3), 
-                "flags": ["block"], 
-                "bindings": {
-                  
-                }, 
-                "children": [], 
-                
-              }, 
-            ], 
+            "children": [], 
             
           }, 
         ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
@@ -22,7 +22,7 @@
       "scope": semantic.id.NominalId(u32)(0), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":1,"scope":9,"node":"identifier","identifier":"Writer","flags":["read"]}, 
+        {"symbol":1,"scope":7,"node":"identifier","identifier":"Writer","flags":["read"]}, 
         
       ], 
       "members": [2,3,4,6,7,8,13], 
@@ -79,8 +79,8 @@
       "scope": semantic.id.NominalId(u32)(2), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":5,"scope":4,"node":"identifier","identifier":"ptr","flags":["read"]}, 
-        {"symbol":5,"scope":4,"node":"identifier","identifier":"ptr","flags":["read"]}, 
+        {"symbol":5,"scope":3,"node":"identifier","identifier":"ptr","flags":["read"]}, 
+        {"symbol":5,"scope":3,"node":"identifier","identifier":"ptr","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -92,10 +92,10 @@
       "debugName": "", 
       "token": 42, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(4), 
+      "scope": semantic.id.NominalId(u32)(3), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":6,"scope":4,"node":"identifier","identifier":"T","flags":["read"]}, 
+        {"symbol":6,"scope":3,"node":"identifier","identifier":"T","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -107,10 +107,10 @@
       "debugName": "", 
       "token": 50, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(4), 
+      "scope": semantic.id.NominalId(u32)(3), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":7,"scope":8,"node":"identifier","identifier":"ptr_info","flags":["call"]}, 
+        {"symbol":7,"scope":6,"node":"identifier","identifier":"ptr_info","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -122,10 +122,10 @@
       "debugName": "", 
       "token": 58, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(4), 
+      "scope": semantic.id.NominalId(u32)(3), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":8,"scope":4,"node":"identifier","identifier":"gen","flags":["read"]}, 
+        {"symbol":8,"scope":3,"node":"identifier","identifier":"gen","flags":["read"]}, 
         
       ], 
       "members": [9,12], 
@@ -137,7 +137,7 @@
       "debugName": "", 
       "token": 64, 
       "declNode": "fn_decl", 
-      "scope": semantic.id.NominalId(u32)(5), 
+      "scope": semantic.id.NominalId(u32)(4), 
       "flags": ["fn"], 
       "references": [
         
@@ -151,10 +151,10 @@
       "debugName": "", 
       "token": 66, 
       "declNode": "ptr_type_aligned", 
-      "scope": semantic.id.NominalId(u32)(6), 
+      "scope": semantic.id.NominalId(u32)(5), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":10,"scope":8,"node":"identifier","identifier":"pointer","flags":["read"]}, 
+        {"symbol":10,"scope":6,"node":"identifier","identifier":"pointer","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -166,10 +166,10 @@
       "debugName": "", 
       "token": 71, 
       "declNode": "ptr_type_aligned", 
-      "scope": semantic.id.NominalId(u32)(6), 
+      "scope": semantic.id.NominalId(u32)(5), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":11,"scope":8,"node":"identifier","identifier":"data","flags":["read"]}, 
+        {"symbol":11,"scope":6,"node":"identifier","identifier":"data","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -181,10 +181,10 @@
       "debugName": "", 
       "token": 83, 
       "declNode": "simple_var_decl", 
-      "scope": semantic.id.NominalId(u32)(8), 
+      "scope": semantic.id.NominalId(u32)(6), 
       "flags": ["variable", "const"], 
       "references": [
-        {"symbol":12,"scope":8,"node":"identifier","identifier":"self","flags":["read"]}, 
+        {"symbol":12,"scope":6,"node":"identifier","identifier":"self","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -210,11 +210,11 @@
       "debugName": "", 
       "token": 134, 
       "declNode": "identifier", 
-      "scope": semantic.id.NominalId(u32)(9), 
+      "scope": semantic.id.NominalId(u32)(7), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":14,"scope":11,"node":"identifier","identifier":"self","flags":["call"]}, 
-        {"symbol":14,"scope":11,"node":"identifier","identifier":"self","flags":["read"]}, 
+        {"symbol":14,"scope":8,"node":"identifier","identifier":"self","flags":["call"]}, 
+        {"symbol":14,"scope":8,"node":"identifier","identifier":"self","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -226,10 +226,10 @@
       "debugName": "", 
       "token": 138, 
       "declNode": "ptr_type_aligned", 
-      "scope": semantic.id.NominalId(u32)(9), 
+      "scope": semantic.id.NominalId(u32)(7), 
       "flags": ["const", "fn_param"], 
       "references": [
-        {"symbol":15,"scope":11,"node":"identifier","identifier":"data","flags":["read"]}, 
+        {"symbol":15,"scope":8,"node":"identifier","identifier":"data","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -238,9 +238,9 @@
     }, 
   ], 
   "unresolvedReferences": [
-    {"symbol":null,"scope":6,"node":"identifier","identifier":"anyopaque","flags":["read"]}, 
-    {"symbol":null,"scope":6,"node":"identifier","identifier":"u8","flags":["read"]}, 
-    {"symbol":null,"scope":9,"node":"identifier","identifier":"u8","flags":["read"]}, 
+    {"symbol":null,"scope":5,"node":"identifier","identifier":"anyopaque","flags":["read"]}, 
+    {"symbol":null,"scope":5,"node":"identifier","identifier":"u8","flags":["read"]}, 
+    {"symbol":null,"scope":7,"node":"identifier","identifier":"u8","flags":["read"]}, 
     
   ], 
   "scopes": {
@@ -265,7 +265,7 @@
         "children": [
           {
             "id": semantic.id.NominalId(u32)(2), 
-            "flags": [], 
+            "flags": ["function"], 
             "bindings": {
               "ptr": 5, 
               
@@ -273,8 +273,11 @@
             "children": [
               {
                 "id": semantic.id.NominalId(u32)(3), 
-                "flags": ["function"], 
+                "flags": ["function", "block"], 
                 "bindings": {
+                  "T": 6, 
+                  "ptr_info": 7, 
+                  "gen": 8, 
                   
                 }, 
                 "children": [
@@ -282,50 +285,27 @@
                     "id": semantic.id.NominalId(u32)(4), 
                     "flags": ["block"], 
                     "bindings": {
-                      "T": 6, 
-                      "ptr_info": 7, 
-                      "gen": 8, 
+                      "writeAll": 9, 
                       
                     }, 
                     "children": [
                       {
                         "id": semantic.id.NominalId(u32)(5), 
-                        "flags": ["block"], 
+                        "flags": ["function"], 
                         "bindings": {
-                          "writeAll": 9, 
+                          "pointer": 10, 
+                          "data": 11, 
                           
                         }, 
                         "children": [
                           {
                             "id": semantic.id.NominalId(u32)(6), 
-                            "flags": [], 
+                            "flags": ["function", "block"], 
                             "bindings": {
-                              "pointer": 10, 
-                              "data": 11, 
+                              "self": 12, 
                               
                             }, 
-                            "children": [
-                              {
-                                "id": semantic.id.NominalId(u32)(7), 
-                                "flags": ["function"], 
-                                "bindings": {
-                                  
-                                }, 
-                                "children": [
-                                  {
-                                    "id": semantic.id.NominalId(u32)(8), 
-                                    "flags": ["block"], 
-                                    "bindings": {
-                                      "self": 12, 
-                                      
-                                    }, 
-                                    "children": [], 
-                                    
-                                  }, 
-                                ], 
-                                
-                              }, 
-                            ], 
+                            "children": [], 
                             
                           }, 
                         ], 
@@ -340,8 +320,8 @@
             ], 
             
           }, {
-            "id": semantic.id.NominalId(u32)(9), 
-            "flags": [], 
+            "id": semantic.id.NominalId(u32)(7), 
+            "flags": ["function"], 
             "bindings": {
               "self": 14, 
               "data": 15, 
@@ -349,22 +329,12 @@
             }, 
             "children": [
               {
-                "id": semantic.id.NominalId(u32)(10), 
-                "flags": ["function"], 
+                "id": semantic.id.NominalId(u32)(8), 
+                "flags": ["function", "block"], 
                 "bindings": {
                   
                 }, 
-                "children": [
-                  {
-                    "id": semantic.id.NominalId(u32)(11), 
-                    "flags": ["block"], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [], 
-                    
-                  }, 
-                ], 
+                "children": [], 
                 
               }, 
             ], 


### PR DESCRIPTION
- feat: add and populate `Scope.node`. It stores the ID of the AST node that creates it.
- fix: function bodies create two scopes for the same block node.
- feat: record flags to apply on the next-encountered block scope