### PR TITLE
feat(semantic): add container symbol flags

### DIFF
--- a/src/semantic/Scope.zig
+++ b/src/semantic/Scope.zig
@@ -55,6 +55,17 @@ pub const Flags = packed struct(FLAGS_REPR) {
         return @bitCast(a | b);
     }
 
+    pub inline fn set(self: *Flags, flags: Flags, comptime enable: bool) void {
+        const a: FLAGS_REPR = @bitCast(self.*);
+        const b: FLAGS_REPR = @bitCast(flags);
+
+        if (enable) {
+            self.* = @bitCast(a | b);
+        } else {
+            self.* = @bitCast(a & ~b);
+        }
+    }
+
     /// Returns `true` if two sets of flags have exactly the same flags
     /// enabled/diabled.
     pub fn eq(self: Flags, other: Flags) bool {

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -13,6 +13,7 @@ _arena: ArenaAllocator,
 
 // states
 _curr_scope_flags: Scope.Flags = .{},
+_curr_symbol_flags: Symbol.Flags = .{},
 _curr_reference_flags: Reference.Flags = .{ .read = true },
 /// Flags added to the next block-created scope. Reset immediately after use.
 ///
@@ -489,15 +490,20 @@ fn visitContainer(self: *SemanticBuilder, node: NodeIndex, container: full.Conta
     const main_tokens: []const TokenIndex = self.AST().nodes.items(.main_token);
     const tags: []const Token.Tag = self.AST().tokens.items(.tag);
 
-    const flags: Scope.Flags = switch (tags[main_tokens[node]]) {
-        .keyword_enum => .{ .s_enum = true },
-        .keyword_struct => .{ .s_struct = true },
-        .keyword_union => .{ .s_union = true },
+    const scope_flags: Scope.Flags, const symbol_flags: Symbol.Flags = switch (tags[main_tokens[node]]) {
+        .keyword_enum => .{ .{ .s_enum = true }, .{ .s_enum = true } },
+        .keyword_struct => .{ .{ .s_struct = true }, .{ .s_struct = true } },
+        .keyword_union => .{ .{ .s_union = true }, .{ .s_union = true } },
         // e.g. opaque
-        else => .{},
+        else => .{ .{}, .{} },
     };
+
+    self.currentContainerSymbolFlags().set(symbol_flags, true);
+    self._curr_symbol_flags.set(symbol_flags, true);
+    defer self._curr_symbol_flags.set(symbol_flags, true);
+
     try self.enterScope(.{
-        .flags = flags.merge(.{ .s_block = true }),
+        .flags = scope_flags.merge(.{ .s_block = true }),
     });
     defer self.exitScope();
     for (container.ast.members) |member| {
@@ -515,8 +521,10 @@ fn visitErrorSetDecl(self: *SemanticBuilder, node_id: NodeIndex) !void {
 
     try self.enterScope(.{ .flags = .{ .s_error = true } });
     defer self.exitScope();
+    self.currentContainerSymbolFlags().s_error = true;
 
     while (true) : (curr_tok -= 1) {
+        util.assertUnsafe(curr_tok > 0); // should always encounter an l_brace.
         switch (tags[curr_tok]) {
             .identifier => {
                 _ = try self.declareMemberSymbol(.{
@@ -1138,6 +1146,10 @@ inline fn currentContainerSymbolUnwrap(self: *const SemanticBuilder) Symbol.Id {
         .{},
     );
     return self._symbol_stack.getLast();
+}
+
+inline fn currentContainerSymbolFlags(self: *SemanticBuilder) *Symbol.Flags {
+    return &self._semantic.symbols.symbols.items(.flags)[self.currentContainerSymbolUnwrap().int()];
 }
 
 /// Data used to declare a new symbol

--- a/src/semantic/Symbol.zig
+++ b/src/semantic/Symbol.zig
@@ -121,6 +121,7 @@ pub const Flags = packed struct(FLAGS_REPR) {
     _: u4 = 0,
 
     pub const Flag = std.meta.FieldEnum(Flags);
+    pub const s_container: Flags = .{ .s_struct = true, .s_enum = true, .s_union = true, .s_error = true };
 
     pub inline fn merge(self: Flags, other: Flags) Flags {
         const a: FLAGS_REPR = @bitCast(self);

--- a/src/semantic/Symbol.zig
+++ b/src/semantic/Symbol.zig
@@ -67,7 +67,8 @@ pub const Visibility = enum {
     private,
 };
 
-pub const Flags = packed struct {
+const FLAGS_REPR = u16;
+pub const Flags = packed struct(FLAGS_REPR) {
     /// A container-level or local variable.
     ///
     /// If it's declared with a `const` or `var` keyword, this is true. Note
@@ -114,8 +115,29 @@ pub const Flags = packed struct {
     s_fn_param: bool = false,
     s_catch_param: bool = false,
     s_error: bool = false,
+    s_struct: bool = false,
+    s_enum: bool = false,
+    s_union: bool = false,
+    _: u4 = 0,
 
     pub const Flag = std.meta.FieldEnum(Flags);
+
+    pub inline fn merge(self: Flags, other: Flags) Flags {
+        const a: FLAGS_REPR = @bitCast(self);
+        const b: FLAGS_REPR = @bitCast(other);
+        return @bitCast(a | b);
+    }
+
+    pub inline fn set(self: *Flags, flags: Flags, comptime enable: bool) void {
+        const a: FLAGS_REPR = @bitCast(self.*);
+        const b: FLAGS_REPR = @bitCast(flags);
+
+        if (enable) {
+            self.* = @bitCast(a | b);
+        } else {
+            self.* = @bitCast(a & ~b);
+        }
+    }
 };
 
 /// Stores symbols created and referenced within a Zig program.

--- a/src/semantic/test/symbol_decl_test.zig
+++ b/src/semantic/test/symbol_decl_test.zig
@@ -39,20 +39,33 @@ test "Symbol flags for various declarations of `x`" {
             .{ .s_variable = true, .s_comptime = true },
         },
 
+        // containers
+        .{
+            "const x = struct { y: u32 };",
+            .{ .s_struct = true, .s_variable = true, .s_const = true },
+        },
+        .{
+            "const x = enum { y };",
+            .{ .s_enum = true, .s_variable = true, .s_const = true },
+        },
+        .{
+            "const x = union(enum) { y };",
+            .{ .s_union = true, .s_variable = true, .s_const = true },
+        },
+
         // members
         .{
             "const Foo = struct { x: u32 };",
-            .{ .s_member = true },
+            .{ .s_struct = true, .s_member = true },
         },
         .{
             "const Foo = enum { x };",
-            .{ .s_member = true },
+            .{ .s_enum = true, .s_member = true },
         },
         .{
             "const Foo = union(enum) { x };",
-            .{ .s_member = true },
+            .{ .s_union = true, .s_member = true },
         },
-
         .{
             "const Foo = error { x };",
             .{ .s_error = true, .s_member = true },
@@ -60,6 +73,16 @@ test "Symbol flags for various declarations of `x`" {
         .{
             "const Foo = error { z, y, x };",
             .{ .s_error = true, .s_member = true },
+        },
+
+        // variables inside containers
+        .{
+            "const Foo = struct { fn x() void {} };",
+            .{ .s_fn = true },
+        },
+        .{
+            "const Foo = struct { a, b, fn x() void {} };",
+            .{ .s_fn = true },
         },
 
         // functions

--- a/test/snapshots/snapshot-coverage/simple/pass/container_error.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/container_error.zig.snap
@@ -20,7 +20,7 @@
       "token": 1, 
       "declNode": "simple_var_decl", 
       "scope": semantic.id.NominalId(u32)(0), 
-      "flags": ["variable", "const"], 
+      "flags": ["variable", "const", "error"], 
       "references": [
         
       ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
@@ -20,7 +20,7 @@
       "token": 2, 
       "declNode": "simple_var_decl", 
       "scope": semantic.id.NominalId(u32)(0), 
-      "flags": ["variable", "const"], 
+      "flags": ["variable", "const", "enum"], 
       "references": [
         {"symbol":1,"scope":2,"node":"identifier","identifier":"Foo","flags":["read"]}, 
         {"symbol":1,"scope":3,"node":"identifier","identifier":"Foo","flags":["read"]}, 

--- a/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/enum_members.zig.snap
@@ -36,7 +36,7 @@
       "token": 6, 
       "declNode": "container_field_init", 
       "scope": semantic.id.NominalId(u32)(1), 
-      "flags": ["member"], 
+      "flags": ["member", "enum"], 
       "references": [
         
       ], 
@@ -50,7 +50,7 @@
       "token": 8, 
       "declNode": "container_field_init", 
       "scope": semantic.id.NominalId(u32)(1), 
-      "flags": ["member"], 
+      "flags": ["member", "enum"], 
       "references": [
         
       ], 
@@ -64,7 +64,7 @@
       "token": 10, 
       "declNode": "container_field_init", 
       "scope": semantic.id.NominalId(u32)(1), 
-      "flags": ["member"], 
+      "flags": ["member", "enum"], 
       "references": [
         
       ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
@@ -48,7 +48,7 @@
       "token": 12, 
       "declNode": "container_field_init", 
       "scope": semantic.id.NominalId(u32)(3), 
-      "flags": ["member"], 
+      "flags": ["member", "struct"], 
       "references": [
         
       ], 
@@ -150,7 +150,7 @@
       "token": 80, 
       "declNode": "container_field_init", 
       "scope": semantic.id.NominalId(u32)(11), 
-      "flags": ["member"], 
+      "flags": ["member", "struct"], 
       "references": [
         
       ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
@@ -6,7 +6,7 @@
       "token": null, 
       "declNode": "root", 
       "scope": semantic.id.NominalId(u32)(0), 
-      "flags": ["const"], 
+      "flags": ["const", "struct"], 
       "references": [
         
       ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_in_fn.zig.snap
@@ -49,7 +49,7 @@
       "token": 11, 
       "declNode": "simple_var_decl", 
       "scope": semantic.id.NominalId(u32)(2), 
-      "flags": ["variable", "const"], 
+      "flags": ["variable", "const", "struct"], 
       "references": [
         {"symbol":3,"scope":2,"node":"identifier","identifier":"inner","flags":["call"]}, 
         

--- a/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
@@ -63,7 +63,7 @@
       "token": 31, 
       "declNode": "simple_var_decl", 
       "scope": semantic.id.NominalId(u32)(0), 
-      "flags": ["variable", "const"], 
+      "flags": ["variable", "const", "struct"], 
       "references": [
         {"symbol":4,"scope":2,"node":"identifier","identifier":"Foo","flags":["read"]}, 
         

--- a/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/foo.zig.snap
@@ -78,7 +78,7 @@
       "token": 35, 
       "declNode": "container_field_init", 
       "scope": semantic.id.NominalId(u32)(1), 
-      "flags": ["member"], 
+      "flags": ["member", "struct"], 
       "references": [
         
       ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/struct_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/struct_members.zig.snap
@@ -34,7 +34,7 @@
       "token": 6, 
       "declNode": "container_field_init", 
       "scope": semantic.id.NominalId(u32)(1), 
-      "flags": ["member"], 
+      "flags": ["member", "struct"], 
       "references": [
         
       ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/struct_members.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/struct_members.zig.snap
@@ -20,7 +20,7 @@
       "token": 2, 
       "declNode": "simple_var_decl", 
       "scope": semantic.id.NominalId(u32)(0), 
-      "flags": ["variable", "const"], 
+      "flags": ["variable", "const", "struct"], 
       "references": [
         
       ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
@@ -35,7 +35,7 @@
       "token": 5, 
       "declNode": "container_field_init", 
       "scope": semantic.id.NominalId(u32)(1), 
-      "flags": ["member"], 
+      "flags": ["member", "struct"], 
       "references": [
         
       ], 
@@ -49,7 +49,7 @@
       "token": 10, 
       "declNode": "container_field_init", 
       "scope": semantic.id.NominalId(u32)(1), 
-      "flags": ["member"], 
+      "flags": ["member", "struct"], 
       "references": [
         
       ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
@@ -20,7 +20,7 @@
       "token": 1, 
       "declNode": "simple_var_decl", 
       "scope": semantic.id.NominalId(u32)(0), 
-      "flags": ["variable", "const"], 
+      "flags": ["variable", "const", "struct"], 
       "references": [
         {"symbol":1,"scope":7,"node":"identifier","identifier":"Writer","flags":["read"]}, 
         
@@ -123,7 +123,7 @@
       "token": 58, 
       "declNode": "simple_var_decl", 
       "scope": semantic.id.NominalId(u32)(3), 
-      "flags": ["variable", "const"], 
+      "flags": ["variable", "const", "struct"], 
       "references": [
         {"symbol":8,"scope":3,"node":"identifier","identifier":"gen","flags":["read"]}, 
         


### PR DESCRIPTION
This pull request introduces several changes to improve flag handling and container symbol management in the `semantic` module. The changes include adding new flag types, modifying flag management methods, and updating various test cases to reflect these changes.

### Flag Handling Improvements:

* [`src/semantic/Scope.zig`](diffhunk://#diff-958d614f60e8a4dd6e7a624a5f2f9cfe400d23ebaf269ea7b3d3a483346f7594R58-R68): Added a new method `set` to the `Flags` struct to enable or disable specific flags.
* [`src/semantic/Symbol.zig`](diffhunk://#diff-ce5dcdaa242de029c9f716f363245d575bbd751ee3dc8fc2b857860aa2b4b20bL70-R71): Introduced new flags (`s_struct`, `s_enum`, `s_union`) and a `merge` method to combine flags. [[1]](diffhunk://#diff-ce5dcdaa242de029c9f716f363245d575bbd751ee3dc8fc2b857860aa2b4b20bL70-R71) [[2]](diffhunk://#diff-ce5dcdaa242de029c9f716f363245d575bbd751ee3dc8fc2b857860aa2b4b20bR118-R141)

### Container Symbol Management:

* [`src/semantic/SemanticBuilder.zig`](diffhunk://#diff-90deb90e7fc4997ace31018f8fe5f0679a177f3b6c0fa5c2455def405eaf0338L492-R506): Updated various methods to handle the new symbol flags and ensure proper flag management when entering and exiting scopes. [[1]](diffhunk://#diff-90deb90e7fc4997ace31018f8fe5f0679a177f3b6c0fa5c2455def405eaf0338L492-R506) [[2]](diffhunk://#diff-90deb90e7fc4997ace31018f8fe5f0679a177f3b6c0fa5c2455def405eaf0338R524-R527) [[3]](diffhunk://#diff-90deb90e7fc4997ace31018f8fe5f0679a177f3b6c0fa5c2455def405eaf0338R596-R600) [[4]](diffhunk://#diff-90deb90e7fc4997ace31018f8fe5f0679a177f3b6c0fa5c2455def405eaf0338R910-R914) [[5]](diffhunk://#diff-90deb90e7fc4997ace31018f8fe5f0679a177f3b6c0fa5c2455def405eaf0338R1161-R1164) [[6]](diffhunk://#diff-90deb90e7fc4997ace31018f8fe5f0679a177f3b6c0fa5c2455def405eaf0338L1206-R1228)

### Test Case Updates:

* [`src/semantic/test/symbol_decl_test.zig`](diffhunk://#diff-f57bb59ba688c57d254ac7ed57d2f194260c838815feaddaa2331c0b4ab67eb6R42-L55): Added new test cases for container declarations to validate the new flags. [[1]](diffhunk://#diff-f57bb59ba688c57d254ac7ed57d2f194260c838815feaddaa2331c0b4ab67eb6R42-L55) [[2]](diffhunk://#diff-f57bb59ba688c57d254ac7ed57d2f194260c838815feaddaa2331c0b4ab67eb6R78-R87)
* Various snapshot files: Updated expected flag values in several snapshot tests to reflect the new flag types and their combinations. [[1]](diffhunk://#diff-0720b2acc9b44e6d31b27b67d9b139c21a0235486186be82230c2043d072c65eL23-R23) [[2]](diffhunk://#diff-8523a8af04736ef0724c8a8a22ac65273cf44555c0673ebf7dcd80ee48897d1dL23-R23) [[3]](diffhunk://#diff-8523a8af04736ef0724c8a8a22ac65273cf44555c0673ebf7dcd80ee48897d1dL39-R39) [[4]](diffhunk://#diff-8523a8af04736ef0724c8a8a22ac65273cf44555c0673ebf7dcd80ee48897d1dL53-R53) [[5]](diffhunk://#diff-8523a8af04736ef0724c8a8a22ac65273cf44555c0673ebf7dcd80ee48897d1dL67-R67) [[6]](diffhunk://#diff-4686f0a7d7499ed379e13c923dbb971ca085e153aadc8364949f0be2289b8a7fL9-R9) [[7]](diffhunk://#diff-4686f0a7d7499ed379e13c923dbb971ca085e153aadc8364949f0be2289b8a7fL51-R51) [[8]](diffhunk://#diff-4686f0a7d7499ed379e13c923dbb971ca085e153aadc8364949f0be2289b8a7fL153-R153) [[9]](diffhunk://#diff-6f897b65b0597a05f289586eba52dd81fd228d0eb7aed76d14ee60561abec62fL52-R52) [[10]](diffhunk://#diff-1909ab99dce61c358e3cc3a183f69b2ba07afcce702cb31296b966080aa46c37L66-R66) [[11]](diffhunk://#diff-1909ab99dce61c358e3cc3a183f69b2ba07afcce702cb31296b966080aa46c37L81-R81) [[12]](diffhunk://#diff-066b748a980008a8bf67470ea4b1fc4915f548c39ea749f2495bfcff43e2b7fbL23-R23) [[13]](diffhunk://#diff-066b748a980008a8bf67470ea4b1fc4915f548c39ea749f2495bfcff43e2b7fbL37-R37) [[14]](diffhunk://#diff-8377450bf745014b047ca0429f36de32988f478368774cad556da6f203888d1dL23-R23) [[15]](diffhunk://#diff-8377450bf745014b047ca0429f36de32988f478368774cad556da6f203888d1dL38-R38) [[16]](diffhunk://#diff-8377450bf745014b047ca0429f36de32988f478368774cad556da6f203888d1dL52-R52) [[17]](diffhunk://#diff-8377450bf745014b047ca0429f36de32988f478368774cad556da6f203888d1dL126-R126)