### PR TITLE
fix(semantic): binding function return types

### DIFF
--- a/src/semantic/test/symbol_decl_test.zig
+++ b/src/semantic/test/symbol_decl_test.zig
@@ -27,14 +27,6 @@ test "Symbol flags for various declarations of `x`" {
             .{ .s_const = false, .s_variable = true },
         },
         .{
-            "fn foo(x: u32) u32 { return x; }",
-            .{ .s_fn_param = true, .s_const = true },
-        },
-        .{
-            "fn foo(comptime x: u32) u32 { return x; }",
-            .{ .s_fn_param = true, .s_const = true, .s_comptime = true },
-        },
-        .{
             "fn foo() u32 { comptime var x = 1; return x; }",
             .{ .s_variable = true, .s_comptime = true },
         },
@@ -75,7 +67,7 @@ test "Symbol flags for various declarations of `x`" {
             .{ .s_error = true, .s_member = true },
         },
 
-        // variables inside containers
+        // non-member symbols inside containers
         .{
             "const Foo = struct { fn x() void {} };",
             .{ .s_fn = true },
@@ -89,6 +81,26 @@ test "Symbol flags for various declarations of `x`" {
         .{
             "fn x() void {}",
             .{ .s_fn = true },
+        },
+        .{
+            "const Foo = fn(x: u32) void;",
+            .{ .s_fn_param = true, .s_const = true },
+        },
+        .{
+            "const Foo = *const fn(x: u32) void;",
+            .{ .s_fn_param = true, .s_const = true },
+        },
+        .{
+            "fn foo(x: u32) u32 { return x; }",
+            .{ .s_fn_param = true, .s_const = true },
+        },
+        .{
+            "fn foo(comptime x: u32) u32 { return x; }",
+            .{ .s_fn_param = true, .s_const = true, .s_comptime = true },
+        },
+        .{
+            "fn foo(x: type) x { @panic(\"not implemented\"); }",
+            .{ .s_fn_param = true, .s_const = true },
         },
 
         // payloads

--- a/src/semantic/test/symbol_ref_test.zig
+++ b/src/semantic/test/symbol_ref_test.zig
@@ -109,6 +109,13 @@ test "simple references where `x` is referenced a single time" {
             .{ .read = true },
         },
         .{
+            \\fn foo(x: type) x {
+            \\  @panic("unreachable");
+            \\}
+            ,
+            .{ .type = true },
+        },
+        .{
             \\fn x() u32 {
             \\  return 1;
             \\}

--- a/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fn_comptime.zig.snap
@@ -36,6 +36,7 @@
       "scope": semantic.id.NominalId(u32)(1), 
       "flags": ["const", "fn_param"], 
       "references": [
+        {"symbol":2,"scope":4,"node":"identifier","identifier":"T","flags":["type"]}, 
         
       ], 
       "members": [], 

--- a/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
@@ -50,6 +50,7 @@
       "scope": semantic.id.NominalId(u32)(0), 
       "flags": ["variable", "const"], 
       "references": [
+        {"symbol":3,"scope":1,"node":"identifier","identifier":"Foo","flags":["type"]}, 
         
       ], 
       "members": [], 

--- a/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/writer_interface.zig.snap
@@ -22,6 +22,7 @@
       "scope": semantic.id.NominalId(u32)(0), 
       "flags": ["variable", "const", "struct"], 
       "references": [
+        {"symbol":1,"scope":2,"node":"identifier","identifier":"Writer","flags":["type"]}, 
         {"symbol":1,"scope":7,"node":"identifier","identifier":"Writer","flags":["read"]}, 
         
       ], 


### PR DESCRIPTION
Part of #42 

- fix: visit return types in function declarations
- fix: add `type` reference flags to returned identifiers
- fix: return types are in same scope as the rest of the function's prototype
- fix: simple function prototype nodes not being visited