### PR TITLE
feat: add `--quiet` cli flag

### DIFF
--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -2,6 +2,8 @@
 
 /// Enable verbose logging.
 verbose: bool = false,
+/// Only display errors. Warnings are counted but not shown.
+quiet: bool = false,
 /// Instead of linting a file, print its AST as JSON to stdout.
 ///
 /// This is primarily for debugging purposes.
@@ -23,16 +25,16 @@ fn parse(alloc: Allocator, args_iter: anytype) ParseError!Options {
     var argv = args_iter;
 
     // skip binary name
-    _ = argv.next() orelse {
-        return opts;
-    };
+    _ = argv.next() orelse return opts;
     while (argv.next()) |arg| {
         if (arg.len == 0) continue;
         if (arg[0] != '-') {
             try opts.args.append(alloc, arg);
             continue;
         }
-        if (eq(arg, "-V") or eq(arg, "--verbose")) {
+        if (eq(arg, "-q") or eq(arg, "--quiet")) {
+            opts.quiet = true;
+        } else if (eq(arg, "-V") or eq(arg, "--verbose")) {
             opts.verbose = true;
         } else if (eq(arg, "--print-ast")) {
             opts.print_ast = true;

--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -20,7 +20,7 @@ const Error = @import("../Error.zig");
 const Linter = _lint.Linter;
 const Options = @import("../cli/Options.zig");
 
-pub fn lint(alloc: Allocator, _: Options) !void {
+pub fn lint(alloc: Allocator, options: Options) !void {
     const stdout = std.io.getStdOut().writer();
     var arena = std.heap.ArenaAllocator.init(alloc);
     const config = blk: {
@@ -28,6 +28,7 @@ pub fn lint(alloc: Allocator, _: Options) !void {
         break :blk try lint_config.resolveLintConfig(arena, fs.cwd(), "zlint.json");
     };
     var reporter = GraphicalReporter.init(stdout, .{ .alloc = alloc });
+    reporter.opts = .{ .quiet = options.quiet };
 
     const start = std.time.milliTimestamp();
 

--- a/src/reporter.zig
+++ b/src/reporter.zig
@@ -1,4 +1,6 @@
-pub const Reporter = @import("./reporter/Reporter.zig").Reporter;
+const reporter = @import("./reporter/Reporter.zig");
+pub const Reporter = reporter.Reporter;
+pub const Options = reporter.Options;
 pub const GraphicalFormatter = @import("./reporter/formatters/GraphicalFormatter.zig");
 
 // shorthands


### PR DESCRIPTION
`-q,--quiet` suppresses all non error-level diagnostics. They're still recorded and shown in the stats summary, but their descriptions aren't rendered.