### PR TITLE
fix(semantic): bind type identifiers in struct initialization nodes

### DIFF
--- a/docs/rules/suppressed-errors.md
+++ b/docs/rules/suppressed-errors.md
@@ -1,8 +1,8 @@
 # `suppressed-errors`
 
-> Category: correctness
+> Category: suspicious
 >
-> Enabled by default?: No
+> Enabled by default?: Yes (warning)
 
 ## What This Rule Does
 

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -797,6 +797,7 @@ fn visitArrayInit(self: *SemanticBuilder, _: NodeIndex, arr: full.ArrayInit) !vo
 }
 
 fn visitStructInit(self: *SemanticBuilder, _: NodeIndex, @"struct": full.StructInit) !void {
+    try self.visit(@"struct".ast.type_expr);
     for (@"struct".ast.fields) |field| {
         try self.visit(field);
     }

--- a/src/semantic/test/symbol_ref_test.zig
+++ b/src/semantic/test/symbol_ref_test.zig
@@ -439,6 +439,12 @@ test "Reference flags - `x` - containers" {
             ,
             .{ .read = true },
         },
+        .{
+            \\const x = struct {};
+            \\const y = x{};
+            ,
+            .{ .read = true },
+        },
     });
 }
 

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
@@ -23,6 +23,7 @@
       "flags": ["variable", "const"], 
       "references": [
         {"symbol":1,"scope":3,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":5,"node":"identifier","identifier":"std","flags":["call"]}, 
         {"symbol":1,"scope":6,"node":"identifier","identifier":"std","flags":["call"]}, 
         {"symbol":1,"scope":10,"node":"identifier","identifier":"std","flags":["call"]}, 
         

--- a/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/top_level_struct.zig.snap
@@ -51,6 +51,7 @@
       "flags": ["variable", "const"], 
       "references": [
         {"symbol":3,"scope":1,"node":"identifier","identifier":"Foo","flags":["type"]}, 
+        {"symbol":3,"scope":2,"node":"identifier","identifier":"Foo","flags":["read"]}, 
         
       ], 
       "members": [], 


### PR DESCRIPTION
```zig
const Foo = struct {};
const foo = Foo{};
//          ^^^
```