### PR TITLE
feat(reporter): add github formatter

### DIFF
--- a/src/Error.zig
+++ b/src/Error.zig
@@ -25,6 +25,10 @@ const ArcStr = Arc([:0]u8);
 pub const PossiblyStaticStr = struct {
     static: bool = true,
     str: string,
+
+    pub fn format(this: PossiblyStaticStr, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+        return writer.writeAll(this.str);
+    }
 };
 
 pub fn new(message: string) Error {

--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -46,7 +46,7 @@ fn parse(alloc: Allocator, args_iter: anytype) ParseError!Options {
             // TODO: comptime string concat on format names
             const fmt = argv.next() orelse std.debug.panic("Missing format name. Valid names are {s}.", .{FORMAT_NAMES});
             opts.format = formatter.Kind.fromString(fmt) orelse {
-                std.debug.panic("Invalid format name: {s}. Valid names are {s}.", .{arg, FORMAT_NAMES});
+                std.debug.panic("Invalid format name: {s}. Valid names are {s}.", .{ arg, FORMAT_NAMES });
             };
         } else if (eq(arg, "--print-ast")) {
             opts.print_ast = true;

--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -31,7 +31,7 @@ pub fn lint(alloc: Allocator, options: Options) !u8 {
         errdefer arena.deinit();
         break :blk try lint_config.resolveLintConfig(arena, fs.cwd(), "zlint.json");
     };
-    var reporter = try reporters._Reporter.initKind(options.format, stdout, alloc);
+    var reporter = try reporters.Reporter.initKind(options.format, stdout, alloc);
     defer reporter.deinit();
     reporter.opts = .{ .quiet = options.quiet };
 
@@ -59,11 +59,11 @@ const LintWalker = walk.Walker(LintVisitor);
 
 const LintVisitor = struct {
     linter: Linter,
-    reporter: *reporters._Reporter,
+    reporter: *reporters.Reporter,
     pool: *Thread.Pool,
     allocator: Allocator,
 
-    fn init(allocator: Allocator, reporter: *reporters._Reporter, config: _lint.Config.Managed, n_threads: ?u32) !LintVisitor {
+    fn init(allocator: Allocator, reporter: *reporters.Reporter, config: _lint.Config.Managed, n_threads: ?u32) !LintVisitor {
         errdefer config.arena.deinit();
         var linter = try Linter.init(allocator, config);
         errdefer linter.deinit();

--- a/src/linter.zig
+++ b/src/linter.zig
@@ -60,8 +60,7 @@ pub const Linter = struct {
     }
 
     pub fn deinit(self: *Linter) void {
-        // NOTE: rules are arena-allocated and do not need to be deinitialized
-        // directly.
+        self.rules.deinit(self.arena.allocator());
         self.arena.deinit();
     }
 

--- a/src/linter/tester.zig
+++ b/src/linter/tester.zig
@@ -237,7 +237,7 @@ const Error = @import("../Error.zig");
 const Linter = @import("../linter.zig").Linter;
 const Rule = @import("rule.zig").Rule;
 const Source = @import("../source.zig").Source;
-const GraphicalFormatter = @import("../reporter.zig").GraphicalFormatter;
+const GraphicalFormatter = @import("../reporter.zig").formatter.Graphical;
 
 const BooStr = util.Boo(string);
 const string = util.string;

--- a/src/reporter.zig
+++ b/src/reporter.zig
@@ -1,13 +1,8 @@
 const reporter = @import("./reporter/Reporter.zig");
 pub const Reporter = reporter.Reporter;
-pub const _Reporter = reporter._Reporter;
 pub const Options = reporter.Options;
 
 pub const formatter = @import("./reporter/formatter.zig");
-
-// shorthands
-pub const GraphicalReporter = Reporter(formatter.Graphical, formatter.Graphical.format);
-pub const GithubReporter = Reporter(formatter.Github, formatter.Github.format);
 
 const std = @import("std");
 const assert = std.debug.assert;

--- a/src/reporter.zig
+++ b/src/reporter.zig
@@ -1,12 +1,31 @@
 const reporter = @import("./reporter/Reporter.zig");
 pub const Reporter = reporter.Reporter;
 pub const Options = reporter.Options;
-pub const GraphicalFormatter = @import("./reporter/formatters/GraphicalFormatter.zig");
+
+/// Formatters process diagnostics for a `Reporter`.
+pub const formatter = struct {
+    pub const Github = @import("./reporter/formatters/GithubFormatter.zig");
+    pub const Graphical = @import("./reporter/formatters/GraphicalFormatter.zig");
+
+    pub const Error = reporter.FormatError;
+};
 
 // shorthands
-pub const GraphicalReporter = Reporter(GraphicalFormatter, GraphicalFormatter.format);
+pub const GraphicalReporter = Reporter(formatter.Graphical, formatter.Graphical.format);
 
-const IS_WINDOWS = builtin.target.os.tag == .windows;
+/// Get a reporter by name. Names are case-insensitive.
+pub fn fromName(name: []const u8) ?type {
+    return reporters.get(name);
+}
+const reporters = std.StaticStringMapWithEql(
+    type,
+    std.static_string_map.eqlAsciiIgnoreCase,
+){
+    .{ "github", formatter.Github },
+    .{ "gh", formatter.Github },
+    .{ "graphical", formatter.Graphical },
+    .{ "default", formatter.Graphical },
+};
 
 const std = @import("std");
 const assert = std.debug.assert;

--- a/src/reporter.zig
+++ b/src/reporter.zig
@@ -1,31 +1,13 @@
 const reporter = @import("./reporter/Reporter.zig");
 pub const Reporter = reporter.Reporter;
+pub const _Reporter = reporter._Reporter;
 pub const Options = reporter.Options;
 
-/// Formatters process diagnostics for a `Reporter`.
-pub const formatter = struct {
-    pub const Github = @import("./reporter/formatters/GithubFormatter.zig");
-    pub const Graphical = @import("./reporter/formatters/GraphicalFormatter.zig");
-
-    pub const Error = reporter.FormatError;
-};
+pub const formatter = @import("./reporter/formatter.zig");
 
 // shorthands
 pub const GraphicalReporter = Reporter(formatter.Graphical, formatter.Graphical.format);
-
-/// Get a reporter by name. Names are case-insensitive.
-pub fn fromName(name: []const u8) ?type {
-    return reporters.get(name);
-}
-const reporters = std.StaticStringMapWithEql(
-    type,
-    std.static_string_map.eqlAsciiIgnoreCase,
-){
-    .{ "github", formatter.Github },
-    .{ "gh", formatter.Github },
-    .{ "graphical", formatter.Graphical },
-    .{ "default", formatter.Graphical },
-};
+pub const GithubReporter = Reporter(formatter.Github, formatter.Github.format);
 
 const std = @import("std");
 const assert = std.debug.assert;

--- a/src/reporter/Reporter.zig
+++ b/src/reporter/Reporter.zig
@@ -5,6 +5,158 @@ pub const Options = struct {
     quiet: bool = false,
 };
 
+pub const _Reporter = struct {
+    writer: Writer,
+    writer_lock: Mutex = .{},
+    stats: Stats = .{},
+    opts: Options = .{},
+    alloc: Allocator,
+    /// pointer to formatter impl. Allocation is owned.
+    ptr: *anyopaque,
+    vtable: struct {
+        format: *const fn (ctx: *anyopaque, writer: *Writer, e: Error) FormatError!void,
+        deinit: *const fn (ctx: *anyopaque, allocator: Allocator) void,
+        destroy: *const fn (ctx: *anyopaque, allocator: Allocator) void,
+    },
+
+    /// Shorthand for creating a `Reporter` with a `GraphicalFormtter`, since
+    /// this is so common.
+    pub fn graphical(writer: Writer, allocator: Allocator) Allocator.Error!_Reporter {
+        const ptr = try allocator.create(formatters.Graphical);
+        ptr.* = formatters.Graphical{ .alloc = allocator };
+
+        return .{
+            .writer = writer,
+            .alloc = allocator,
+            .ptr = @ptrCast(ptr),
+            .vtable = .{
+                .format = formatters.Graphical.format,
+                .deinit = formatters.Graphical.deinit,
+            },
+        };
+    }
+
+    pub fn initKind(kind: formatters.Kind, writer: Writer, allocator: Allocator) Allocator.Error!_Reporter {
+        switch (kind) {
+            formatters.Kind.graphical => {
+                const f = formatters.Graphical{ .alloc = allocator };
+                return init(formatters.Graphical, f, writer, allocator);
+            },
+            formatters.Kind.github => {
+                const f = formatters.Github{};
+                return init(formatters.Github, f, writer, allocator);
+            },
+        }
+    }
+
+    /// Create a new reporter. `formatter` is moved.
+    pub fn init(
+        comptime Formatter: type,
+        formatter: Formatter,
+        writer: Writer,
+        allocator: Allocator,
+    ) Allocator.Error!_Reporter {
+        const fmt = try allocator.create(Formatter);
+        fmt.* = formatter;
+
+        const gen = struct {
+            fn format(ctx: *anyopaque, _writer: *Writer, e: Error) FormatError!void {
+                const this: *Formatter = @alignCast(@ptrCast(ctx));
+                return Formatter.format(this, _writer, e);
+            }
+            fn deinit(ctx: *anyopaque, alloc: Allocator) void {
+                if (!@hasDecl(Formatter, "deinit")) return;
+                const this: *Formatter = @alignCast(@ptrCast(ctx));
+                const info = @typeInfo(Formatter.deinit);
+                switch (info.Fn.params.len) {
+                    1 => this.deinit(),
+                    2 => this.deinit(alloc),
+                    else => @compileError("Formatter.deinit must take (this) or (this, allocator) as parameters."),
+                }
+            }
+            fn destroy(ctx: *anyopaque, alloc: Allocator) void {
+                const this: *Formatter = @alignCast(@ptrCast(ctx));
+                alloc.destroy(this);
+            }
+        };
+
+        return .{
+            .writer = writer,
+            .alloc = allocator,
+            .ptr = @ptrCast(fmt),
+            .vtable = .{
+                .format = &gen.format,
+                .deinit = &gen.deinit,
+                .destroy = &gen.destroy,
+            },
+        };
+    }
+
+    pub fn reportErrors(self: *_Reporter, errors: std.ArrayList(Error)) void {
+        defer errors.deinit();
+        self.reportErrorSlice(errors.allocator, errors.items);
+    }
+
+    pub fn reportErrorSlice(self: *_Reporter, alloc: std.mem.Allocator, errors: []Error) void {
+        self.stats.recordErrors(errors);
+        if (errors.len == 0) return;
+        self.writer_lock.lock();
+        defer self.writer_lock.unlock();
+
+        for (errors) |err| {
+            var e = err;
+            defer e.deinit(alloc);
+            if (self.opts.quiet and err.severity != .err) continue;
+            self.vtable.format(self.ptr, &self.writer, err) catch @panic("Failed to write error.");
+            self.writer.writeByte('\n') catch @panic("failed to write newline.");
+        }
+    }
+
+    pub fn printStats(self: *_Reporter, duration: i64) void {
+        const yellow, const yd = comptime blk: {
+            var c = Chameleon.initComptime();
+            const yellow = c.yellow().createPreset();
+            // Yellow {d} format string
+            const yd = yellow.open ++ "{d}" ++ yellow.close;
+            break :blk .{ yellow, yd };
+        };
+
+        const errors = self.stats.numErrorsSync();
+        const warnings = self.stats.numWarningsSync();
+        const files = self.stats.numFilesSync();
+        self.writer.print(
+            "\tFound " ++ yd ++ " errors and " ++ yd ++ " warnings across " ++ yd ++ " files in " ++ yellow.open ++ "{d}ms" ++ yellow.close ++ ".\n",
+            .{ errors, warnings, files, duration },
+        ) catch {};
+    }
+
+    /// Deinitialize the underlying formatter. Only frees memory if the reporter
+    /// owns this formatter.
+    /// 1. The formatter has a `deinit()` method
+    /// 2. This reporter owns the formatter.
+    pub fn deinit(self: *_Reporter) void {
+        self.vtable.deinit(self.ptr, self.alloc);
+        self.vtable.destroy(self.ptr, self.alloc);
+
+        if (comptime util.IS_DEBUG) {
+            self.vtable.format = &PanicForamtter.format;
+            self.vtable.deinit = &PanicForamtter.deinit;
+        }
+    }
+};
+
+/// Formater that always panics. Used to check for use-after-free bugs.
+/// 
+/// Only used in debug builds.
+const PanicForamtter = struct {
+    fn format(_: *anyopaque, _: *Writer, _: Error) FormatError!void {
+        std.debug.panic("Attempted to format an error after this Reporter was freed.", .{});
+    }
+    fn deinit(_: *anyopaque, _: Allocator) void {
+        std.debug.panic("Attempted to deinitialize the same Reporter twice. This is a bug.", .{});
+    }
+};
+
 pub fn Reporter(
     Formatter: type,
     FormatFn: fn (ctx: *Formatter, writer: *Writer, e: Error) FormatError!void,
@@ -31,7 +183,7 @@ pub fn Reporter(
             self.reportErrorSlice(errors.allocator, errors.items);
         }
 
-        pub fn reportErrorSlice(self: *Self, alloc: std.mem.Allocator, errors: []Error) void {
+        fn reportErrorSlice(self: *Self, alloc: std.mem.Allocator, errors: []Error) void {
             self.stats.recordErrors(errors);
             if (errors.len == 0) return;
             self.writer_lock.lock();
@@ -65,6 +217,37 @@ pub fn Reporter(
         }
     };
 }
+
+pub const AnyReporter = struct {
+    ptr: *anyopaque,
+    reportErrorsFn: *const fn (ptr: *anyopaque, errors: std.ArrayList(Error)) void,
+    printStatsFn: *const fn (ptr: *anyopaque, duration: i64) void,
+
+    pub fn from(comptime R: type, reporter: *R) AnyReporter {
+        const gen = struct {
+            fn reportErrors(ptr: *anyopaque, errors: std.ArrayList(Error)) void {
+                const this: *R = @ptrCast(ptr);
+                @call(.auto, R.reportErrors, .{ this, errors });
+            }
+            fn printStats(ptr: *anyopaque, duration: i64) void {
+                const this: *R = @ptrCast(ptr);
+                @call(.auto, R.printStats, .{ this, duration });
+            }
+        };
+
+        return .{
+            .ptr = @ptrCast(reporter),
+            .reportErrorsFn = &gen.reportErrors,
+            .printStatsFn = &gen.printStats,
+        };
+    }
+    pub fn reportErrors(self: *AnyReporter, errors: std.ArrayList(Error)) void {
+        return self.reportErrorsFn(self.ptr, errors);
+    }
+    pub fn printStats(self: *AnyReporter, duration: i64) void {
+        return self.printStatsFn(self.ptr, duration);
+    }
+};
 
 const Stats = struct {
     num_files: AtomicUsize = AtomicUsize.init(0),
@@ -110,9 +293,17 @@ const Stats = struct {
 };
 
 const std = @import("std");
+const util = @import("util");
 const Error = @import("../Error.zig");
 const Span = @import("../span.zig").Span;
+const Allocator = std.mem.Allocator;
+const formatters = @import("./formatter.zig");
 
 const AtomicUsize = std.atomic.Value(usize);
 const Mutex = std.Thread.Mutex;
 const Writer = std.fs.File.Writer; // TODO: use std.io.Writer?
+
+test {
+    std.testing.refAllDecls(@This());
+    std.testing.refAllDecls(AnyReporter);
+}

--- a/src/reporter/formatter.zig
+++ b/src/reporter/formatter.zig
@@ -1,0 +1,35 @@
+//! Formatters process diagnostics for a `Reporter`.
+
+pub const Github = @import("./formatters/GithubFormatter.zig");
+pub const Graphical = @import("./formatters/GraphicalFormatter.zig");
+
+pub const Kind = enum {
+    graphical,
+    github,
+
+    const FormatMap = std.StaticStringMapWithEql(
+        Kind,
+        std.static_string_map.eqlAsciiIgnoreCase,
+    );
+    const formats = FormatMap.initComptime(&[_]struct { []const u8, Kind }{
+        .{ "github", .github },
+        .{ "gh", .github },
+        .{ "graphical", .graphical },
+        .{ "default", .graphical },
+    });
+
+    /// Get a formatter kind by name. Names are case-insensitive.
+    pub fn fromString(str: []const u8) ?Kind {
+        return formats.get(str);
+    }
+};
+pub const Formatter = union(Kind) {
+    graphical: Graphical,
+    github: Github,
+};
+
+pub const FormatError = Writer.Error || Allocator.Error;
+
+const std = @import("std");
+const Writer = std.fs.File.Writer;
+const Allocator = std.mem.Allocator;

--- a/src/reporter/formatters/GithubFormatter.zig
+++ b/src/reporter/formatters/GithubFormatter.zig
@@ -1,0 +1,53 @@
+//! Formats diagnostics in a such a way that they appear as annotations in 
+//! Github Actions.
+//! 
+//! e.g.
+//! ```
+//! ::error file={name},line={line},endLine={endLine},title={title}::{message}
+//! ```
+
+const GithubFormatter = @This();
+pub fn format(_: *GithubFormatter, w: *Writer, e: Error) FormatError!void {
+    const level: []const u8 = switch (e.severity) {
+        .err => "error",
+        .warning => "warning",
+        .note => "notice",
+        .off => @panic("disabled error passed to formatter"),
+    };
+
+    const primary: ?LabeledSpan = blk: {
+        if (e.labels.items.len == 0) break :blk null;
+        for (e.labels.items) |label| {
+            if (label.primary) break :blk label;
+        }
+        break :blk e.labels.items[0];
+    };
+
+    const line, const col = blk: {
+        if (primary) |p| {
+            if (e.source) |source| {
+                const loc = Location.fromSpan(source.deref(), p.span);
+                break :blk .{ loc.line, loc.column };
+            }
+        }
+        break :blk .{ 1, 1 };
+    };
+
+    // TODO: endLine, endCol
+    w.print("::{s} file={s},line={d},col={d},title={s}::{s}\n", .{
+        level,
+        e.source_name orelse "<unknown>",
+        line,
+        col,
+        e.code,
+        e.message,
+    });
+}
+
+const std = @import("std");
+const FormatError = @import("../Reporter.zig").FormatError;
+const Writer = std.fs.File.Writer;
+const Error = @import("../../Error.zig");
+const _span = @import("../../span.zig");
+const LabeledSpan = _span.LabeledSpan;
+const Location = _span.Location;

--- a/src/reporter/formatters/GithubFormatter.zig
+++ b/src/reporter/formatters/GithubFormatter.zig
@@ -11,7 +11,7 @@ pub fn format(_: *GithubFormatter, w: *Writer, e: Error) FormatError!void {
     const level: []const u8 = switch (e.severity) {
         .err => "error",
         .warning => "warning",
-        .note => "notice",
+        .notice => "notice",
         .off => @panic("disabled error passed to formatter"),
     };
 
@@ -26,7 +26,7 @@ pub fn format(_: *GithubFormatter, w: *Writer, e: Error) FormatError!void {
     const line, const col = blk: {
         if (primary) |p| {
             if (e.source) |source| {
-                const loc = Location.fromSpan(source.deref(), p.span);
+                const loc = Location.fromSpan(source.deref().*, p.span);
                 break :blk .{ loc.line, loc.column };
             }
         }
@@ -34,7 +34,7 @@ pub fn format(_: *GithubFormatter, w: *Writer, e: Error) FormatError!void {
     };
 
     // TODO: endLine, endCol
-    w.print("::{s} file={s},line={d},col={d},title={s}::{s}\n", .{
+    try w.print("::{s} file={s},line={d},col={d},title={s}::{s}\n", .{
         level,
         e.source_name orelse "<unknown>",
         line,

--- a/src/reporter/formatters/GraphicalFormatter.zig
+++ b/src/reporter/formatters/GraphicalFormatter.zig
@@ -5,6 +5,7 @@ alloc: std.mem.Allocator,
 const MAX_CONTEXT_LINES: u32 = 3;
 
 pub const FormatError = Writer.Error || std.mem.Allocator.Error;
+pub const Theme = GraphicalTheme;
 
 pub fn unicode(alloc: std.mem.Allocator, comptime color: bool) GraphicalFormatter {
     // NOTE: must be comptime, otherwise none() returns a reference to a stack

--- a/src/reporter/formatters/GraphicalFormatter.zig
+++ b/src/reporter/formatters/GraphicalFormatter.zig
@@ -41,6 +41,7 @@ pub fn format(self: *GraphicalFormatter, w: *Writer, e: Error) FormatError!void 
     try w.writeByte('\n');
 }
 
+/// `𝙭  some-code: a message here`
 fn renderHeader(self: *GraphicalFormatter, w: *Writer, e: *const Error) FormatError!void {
     const icon = self.iconFor(e.severity);
     const color = self.styleFor(e.severity);

--- a/src/semantic/test/util.zig
+++ b/src/semantic/test/util.zig
@@ -17,7 +17,13 @@ const AnalysisError = error{
 };
 
 pub fn build(src: [:0]const u8) !Semantic {
-    var r = report.GraphicalReporter.init(std.io.getStdErr().writer(), report.formatter.Graphical.unicode(t.allocator, false));
+
+    var r = try report.Reporter.graphical(
+        std.io.getStdErr().writer(),
+        t.allocator,
+        report.formatter.Graphical.Theme.unicodeNoColor(),
+    );
+    defer r.deinit();
     var builder = SemanticBuilder.init(t.allocator);
     var source = try _source.Source.fromString(
         t.allocator,

--- a/src/semantic/test/util.zig
+++ b/src/semantic/test/util.zig
@@ -17,7 +17,7 @@ const AnalysisError = error{
 };
 
 pub fn build(src: [:0]const u8) !Semantic {
-    var r = report.GraphicalReporter.init(std.io.getStdErr().writer(), report.GraphicalFormatter.unicode(t.allocator, false));
+    var r = report.GraphicalReporter.init(std.io.getStdErr().writer(), report.formatter.Graphical.unicode(t.allocator, false));
     var builder = SemanticBuilder.init(t.allocator);
     var source = try _source.Source.fromString(
         t.allocator,

--- a/test/semantic/snapshot_coverage.zig
+++ b/test/semantic/snapshot_coverage.zig
@@ -94,7 +94,7 @@ fn runPass(alloc: Allocator, source: *const zlint.Source) anyerror!void {
 }
 
 fn runFail(alloc: Allocator, source: *const zlint.Source) anyerror!void {
-    const formatter = zlint.report.GraphicalFormatter.unicode(alloc, false);
+    const formatter = zlint.report.formatter.Graphical.unicode(alloc, false);
 
     // open (and maybe create) source-local snapshot file
     if (source.pathname == null) return Error.SourceMissingFilename;

--- a/test/semantic/snapshot_coverage.zig
+++ b/test/semantic/snapshot_coverage.zig
@@ -105,7 +105,7 @@ fn runFail(alloc: Allocator, source: *const zlint.Source) anyerror!void {
     defer snapshot.close();
 
     const formatter = zlint.report.formatter.Graphical.unicode(alloc, false);
-    var reporter = try zlint.report._Reporter.init(@TypeOf(formatter), formatter, snapshot.writer(), alloc);
+    var reporter = try zlint.report.Reporter.init(@TypeOf(formatter), formatter, snapshot.writer(), alloc);
     defer reporter.deinit();
 
     // run analysis

--- a/test/semantic/snapshot_coverage.zig
+++ b/test/semantic/snapshot_coverage.zig
@@ -94,7 +94,6 @@ fn runPass(alloc: Allocator, source: *const zlint.Source) anyerror!void {
 }
 
 fn runFail(alloc: Allocator, source: *const zlint.Source) anyerror!void {
-    const formatter = zlint.report.formatter.Graphical.unicode(alloc, false);
 
     // open (and maybe create) source-local snapshot file
     if (source.pathname == null) return Error.SourceMissingFilename;
@@ -104,7 +103,10 @@ fn runFail(alloc: Allocator, source: *const zlint.Source) anyerror!void {
 
     const snapshot = try TestFolders.openSnapshotFile(alloc, "snapshot-coverage/simple/fail", utils.cleanStrSlice(source_name));
     defer snapshot.close();
-    var reporter = zlint.report.GraphicalReporter.init(snapshot.writer(), formatter);
+
+    const formatter = zlint.report.formatter.Graphical.unicode(alloc, false);
+    var reporter = try zlint.report._Reporter.init(@TypeOf(formatter), formatter, snapshot.writer(), alloc);
+    defer reporter.deinit();
 
     // run analysis
     var builder = SemanticBuilder.init(alloc);


### PR DESCRIPTION
## What This PR Does

ZLint can now print error messages using GitHub Action's annotation log format. Run `zlint --format github` in your CI and any problems found will be attached as reviews on your PR.

## Changes
- feat(report): add `GithubFormater`
- feat(cli): add `-f,--format` flag to choose a formatter. Defaults to `default` (graphical formatter)
- refactor(report): Reporter takes runtime-known formatters

Formatters can no longer be specified at comptime since `-f,--format` is runtime known.