### PR TITLE
perf(semantic): store tokens in `Semantic`

### DIFF
--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -81,7 +81,7 @@ pub inline fn labelT(
     comptime fmt: []const u8,
     args: anytype,
 ) LabeledSpan {
-    const s = self.semantic.ast.tokenToSpan(token_id); //.tokenSlice(token_id);
+    const s = self.semantic.ast.tokenToSpan(token_id);
     return LabeledSpan{
         .span = .{ .start = s.start, .end = s.end },
         .label = util.Boo([]u8).fmt(self.gpa, fmt, args) catch @panic("OOM"),

--- a/src/linter/rules/homeless_try.zig
+++ b/src/linter/rules/homeless_try.zig
@@ -121,7 +121,7 @@ fn checkFnDecl(ctx: *LinterContext, scope: Scope.Id, try_node: Node.Index) void 
         "`try` cannot be used in functions that do not return errors.",
         .{
             if (proto.name_token) |name_token|
-                ctx.labelT(name_token, "function `{s}` is declared here.", .{ctx.ast().tokenSlice(name_token)})
+                ctx.labelT(name_token, "function `{s}` is declared here.", .{ctx.semantic.tokenSlice(name_token)})
             else
                 ctx.labelT(main_tokens[decl_node], "function is declared here.", .{}),
             ctx.labelT(ctx.ast().firstToken(try_node), "it cannot propagate error unions.", .{}),

--- a/src/linter/rules/no_catch_return.zig
+++ b/src/linter/rules/no_catch_return.zig
@@ -102,7 +102,7 @@ pub fn runOnNode(_: *const NoCatchReturn, wrapper: NodeWrapper, ctx: *LinterCont
     if (return_param == NULL_NODE or tags[return_param] != .identifier) return;
 
     // todo: add symbols to node links
-    const error_param = ctx.ast().tokenSlice(ident_tok);
+    const error_param = ctx.semantic.tokenSlice(ident_tok);
     const returned_ident = ctx.ast().getNodeSource(return_param);
     if (std.mem.eql(u8, error_param, returned_ident)) {
         // ctx.error(span, "returning the same error as caught");

--- a/src/linter/rules/no_unresolved.zig
+++ b/src/linter/rules/no_unresolved.zig
@@ -57,7 +57,7 @@ pub fn runOnNode(_: *const NoUnresolved, wrapper: NodeWrapper, ctx: *LinterConte
     if (ctx.source.pathname == null) return; //   anonymous source file
     if (node.tag != .builtin_call_two) return; // not a node we care about
 
-    const builtin_name = ctx.ast().tokenSlice(node.main_token);
+    const builtin_name = ctx.semantic.tokenSlice(node.main_token);
     if (!std.mem.eql(u8, builtin_name, "@import")) {
         return;
     }
@@ -76,7 +76,7 @@ pub fn runOnNode(_: *const NoUnresolved, wrapper: NodeWrapper, ctx: *LinterConte
         _ = ctx.diagnostic("@import operand must be a string literal", .{ctx.spanN(node.data.lhs)});
         return;
     }
-    const pathname_str = ctx.ast().tokenSlice(main_tokens[node.data.lhs]);
+    const pathname_str = ctx.semantic.tokenSlice(main_tokens[node.data.lhs]);
     var pathname = std.mem.trim(u8, pathname_str, "\"");
 
     // if it's not a .zig import, ignore it

--- a/src/semantic/ast.zig
+++ b/src/semantic/ast.zig
@@ -15,6 +15,8 @@ pub const RawToken = struct {
     pub const Tag = std.zig.Token.Tag;
 };
 
+pub const TokenList = std.MultiArrayList(Token).Slice;
+
 pub const TokenIndex = Ast.TokenIndex;
 pub const NodeIndex = Node.Index;
 pub const MaybeTokenId = NominalId(Ast.TokenIndex).Optional;


### PR DESCRIPTION
Lex and store tokens in `Semantic`. This prevents constant re-lexing with `ast.tokenSlice`.