### PR TITLE
fix(reporter): only report summary stats for graphical format

### DIFF
--- a/src/reporter/formatter.zig
+++ b/src/reporter/formatter.zig
@@ -3,6 +3,10 @@
 pub const Github = @import("./formatters/GithubFormatter.zig");
 pub const Graphical = @import("./formatters/GraphicalFormatter.zig");
 
+pub const Meta = struct {
+    report_statistics: bool,
+};
+
 pub const Kind = enum {
     graphical,
     github,
@@ -22,10 +26,6 @@ pub const Kind = enum {
     pub fn fromString(str: []const u8) ?Kind {
         return formats.get(str);
     }
-};
-pub const Formatter = union(Kind) {
-    graphical: Graphical,
-    github: Github,
 };
 
 pub const FormatError = Writer.Error || Allocator.Error;

--- a/src/reporter/formatters/GithubFormatter.zig
+++ b/src/reporter/formatters/GithubFormatter.zig
@@ -7,6 +7,11 @@
 //! ```
 
 const GithubFormatter = @This();
+
+pub const meta: Meta = .{
+    .report_statistics = false,
+};
+
 pub fn format(_: *GithubFormatter, w: *Writer, e: Error) FormatError!void {
     const level: []const u8 = switch (e.severity) {
         .err => "error",
@@ -45,7 +50,9 @@ pub fn format(_: *GithubFormatter, w: *Writer, e: Error) FormatError!void {
 }
 
 const std = @import("std");
-const FormatError = @import("../Reporter.zig").FormatError;
+const formatter = @import("../formatter.zig");
+const Meta = formatter.Meta;
+const FormatError = formatter.FormatError;
 const Writer = std.fs.File.Writer;
 const Error = @import("../../Error.zig");
 const _span = @import("../../span.zig");

--- a/src/reporter/formatters/GraphicalFormatter.zig
+++ b/src/reporter/formatters/GraphicalFormatter.zig
@@ -4,8 +4,9 @@ alloc: std.mem.Allocator,
 
 const MAX_CONTEXT_LINES: u32 = 3;
 
-pub const FormatError = Writer.Error || std.mem.Allocator.Error;
 pub const Theme = GraphicalTheme;
+
+pub const meta: Meta = .{ .report_statistics = true };
 
 pub fn unicode(alloc: std.mem.Allocator, comptime color: bool) GraphicalFormatter {
     // NOTE: must be comptime, otherwise none() returns a reference to a stack
@@ -487,6 +488,10 @@ const Location = _span.Location;
 const LocationSpan = _span.LocationSpan;
 
 const Error = @import("../../Error.zig");
+
+const formatter = @import("../formatter.zig");
+const FormatError = formatter.FormatError;
+const Meta = formatter.Meta;
 
 const t = std.testing;
 


### PR DESCRIPTION
Only report summary statistics when reporting diagnostics with the graphical reporter. This will make CI runs with the github actions formatter cleaner. 