### PR TITLE
feat(linter): parse disable directives

### DIFF
--- a/src/linter.zig
+++ b/src/linter.zig
@@ -148,5 +148,6 @@ pub const Linter = struct {
 test {
     std.testing.refAllDecls(@This());
     std.testing.refAllDecls(@import("linter/tester.zig"));
+    std.testing.refAllDecls(@import("linter/disable_directives/Parser.zig"));
     std.testing.refAllDeclsRecursive(rules);
 }

--- a/src/linter/disable_directives.zig
+++ b/src/linter/disable_directives.zig
@@ -1,0 +1,2 @@
+pub const Comment = @import("./disable_directives/Comment.zig");
+pub const Parser = @import("./disable_directives/Parser.zig");

--- a/src/linter/disable_directives/Comment.zig
+++ b/src/linter/disable_directives/Comment.zig
@@ -1,5 +1,5 @@
 //! A disable directive parsed from a comment.
-//! 
+//!
 //! ## Examples
 //! ```zig
 //! // zlint-disable

--- a/src/linter/disable_directives/Comment.zig
+++ b/src/linter/disable_directives/Comment.zig
@@ -1,0 +1,53 @@
+//! A disable directive parsed from a comment.
+//! 
+//! ## Examples
+//! ```zig
+//! // zlint-disable
+//! // zlint-disable no undefined
+//! // zlint-disable-next-line
+//! // zlint-disable-next-line foo bar baz
+//! ```
+
+/// An empty set means all rules are disabled.
+disabled_rules: []Span = ALL_RULES_DISABLED,
+/// I'm not really sure what this should be the span _of_. The entire comment?
+/// Just the directive? Which is more useful?
+span: Span,
+kind: Kind,
+
+pub const DisableDirectiveComment = @This();
+const ALL_RULES_DISABLED = &[_]Span{};
+
+pub const Kind = enum {
+    /// Disables a set of rules for an entire file.
+    ///
+    /// `zlint-disable`
+    global,
+    /// Just disable the next line.
+    ///
+    /// `zlint-disable-next-line`
+    line,
+};
+
+pub fn eql(self: DisableDirectiveComment, other: DisableDirectiveComment) bool {
+    if (self.kind != other.kind or !self.span.eql(other.span)) return false;
+    if (self.disabled_rules == other.disabled_rules) return true;
+    if (self.disabled_rules.len != other.disabled_rules.len) return false;
+
+    for (self.disabled_rules, 0..) |rule, i| {
+        if (!rule.eql(other.disabled_rules[i])) return false;
+    }
+
+    return true;
+}
+
+pub fn deinit(self: *DisableDirectiveComment, allocator: Allocator) void {
+    if (self.disabled_rules.len > 0) allocator.free(self.disabled_rules);
+    self.disabled_rules.ptr = undefined;
+    self.* = undefined;
+}
+
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+const Span = @import("../../span.zig").Span;

--- a/src/linter/disable_directives/Parser.zig
+++ b/src/linter/disable_directives/Parser.zig
@@ -128,10 +128,10 @@ fn eatWhitespace(self: *DisableDirectivesParser) void {
 /// Move the cursor forward if the next character is `expected`. Otherwise
 /// the cursor is not modified and `null` is returned.
 fn eat(self: *DisableDirectivesParser, expected: u8) ?void {
-    const next = self.cursor + 1;
-    if (next >= self.span.end) return null;
-    if (self.source[next] == expected) {
-        self.cursor = next;
+    if (self.cursor >= self.span.end) return null;
+
+    if (self.curr() == expected) {
+        self.cursor += 1;
         return;
     } else {
         return null;

--- a/src/linter/disable_directives/Parser.zig
+++ b/src/linter/disable_directives/Parser.zig
@@ -184,7 +184,7 @@ test parse {
             "// zlint-disable no-undefined",
             .{
                 .kind = .global,
-                .span = .{ .start = 0, .end = 19 },
+                .span = .{ .start = 0, .end = 29 },
                 .disabled_rules = @constCast(&[_]Span{Span.new(17, 29)}),
             },
         },

--- a/src/linter/disable_directives/Parser.zig
+++ b/src/linter/disable_directives/Parser.zig
@@ -1,0 +1,263 @@
+//! Parses disable directives from comments.
+
+/// Full source text
+source: []const u8,
+
+// All fields below here are private and not initialized until parse() is
+// called. No touchy.
+
+/// Cursor pointer to current char in source code. This is a u32 index
+/// instead of a pointer type as a size optimization.
+///
+/// @internal
+cursor: usize,
+/// @internal
+span: Span,
+/// @internal
+kind: DisableDirectiveComment.Kind,
+/// Stack allocated. Must be copied into newly-allocated directives.
+///
+/// @internal
+rules: std.ArrayListUnmanaged(Span) = .{},
+
+const DisableDirectivesParser = @This();
+const MIN_LEN: u32 = "//zlint-disable".len;
+/// Amount of stack space to reserve when parsing.
+const STACK_FALLBACK_SIZE: usize = 2048;
+
+fn new(source: []const u8) DisableDirectivesParser {
+    assert(source.len > 0);
+    // SAFETY: initialized at beginning of parsed(). These are private fields
+    // that shouldn't be accessed externally: fuck around with abstraction
+    // leaks and find out.
+    return .{
+        .source = source,
+        .cursor = undefined,
+        .kind = undefined,
+        .span = undefined,
+    };
+}
+/// ### Examples
+/// - `// zlint-disable` - disable all rules for this file
+/// - `// zlint-disable -- some comment` - same as above
+/// - `// zlint-disable no-undefined` - disable "no-undefined" for the entire file
+/// - `// zlint-disable foo bar baz` - disable "foo", "bar", and  "baz" for entire fil
+/// - `// `ZLint-disable foo, bar, baz` - let user do their thing, if they want commas and caps that's fine
+///
+/// Disabling only on the next line works basically the same way
+/// - `// zlint-disable-next-line` - disable violations for all rules on next line
+/// - `// zlint-disable-next-line  -- no-undefined` same as above. `no-undefined` is treated as a comment
+/// - `// zlint-disable-next-line no-undefined`
+fn parse(self: *DisableDirectivesParser, allocator: Allocator, line_comment: Span) Allocator.Error!?DisableDirectiveComment {
+    assert(self.source.len >= line_comment.end); // ensure line comment is within source code
+    defer if (comptime util.IS_DEBUG) self.reset();
+
+    // "//zlint-disable" is the smallest possible disable directive.
+    if (line_comment.len() < MIN_LEN) return null;
+    self.cursor = line_comment.start;
+    self.span = line_comment;
+
+    var fb = std.heap.stackFallback(STACK_FALLBACK_SIZE, allocator);
+    const alloc = fb.get();
+    defer self.rules.deinit(alloc);
+
+    // consume /\s*//[/!]?\s*/
+    self.eatWhitespace(); // "\s*"
+    self.eatMany("//", false) orelse return null; // "//"
+    self.eat('!') orelse {}; // maybe '!' for module doc comments
+    self.eat('/') orelse {}; // maybe '/' for 'normal' doc comments
+    self.eatWhitespace(); // "\s*"
+
+    // consume /zlint-disable[-next-line]/. determines directive kind.
+    self.eatMany("zlint-disable", true) orelse return null;
+    // returning .build() before this line is UB.
+    self.kind = if (self.eatMany("-next-line", true)) |_| .line else .global;
+    const ckpt = self.cursor;
+    self.eatWhitespace();
+    // short-circuit for global directives that disable all rules
+    if (self.cursor >= self.span.end) {
+        self.cursor = ckpt;
+        return self.build(allocator);
+    }
+    // everything past '--' is a comment
+    if (self.eatMany("--", false)) |_| {
+        self.cursor = ckpt;
+        return self.build(allocator);
+    }
+
+    while (self.cursor < self.span.end) {
+        const start = self.cursor;
+        while (self.cursor < self.span.end) : (self.cursor += 1) {
+            switch (self.curr()) {
+                'a'...'z', 'A'...'Z', '-' => {},
+                else => break,
+            }
+        }
+        self.cursor = @min(self.cursor + 1, self.span.end);
+        // try self.rules.append(alloc, self.source[start..self.cursor]);
+        try self.rules.append(alloc, Span.new(@intCast(start), @intCast(self.cursor)));
+        self.eat(',') orelse {};
+        self.eatWhitespace();
+    }
+    return self.build(allocator);
+}
+
+fn build(self: *const DisableDirectivesParser, allocator: Allocator) Allocator.Error!?DisableDirectiveComment {
+    var comment: DisableDirectiveComment = .{
+        .kind = self.kind,
+        .span = Span.new(self.span.start, @intCast(self.cursor)),
+    };
+    if (self.rules.items.len > 0) {
+        comment.disabled_rules = try allocator.alloc(Span, self.rules.items.len);
+        @memcpy(comment.disabled_rules, self.rules.items);
+    }
+
+    return comment;
+}
+
+/// Trim leading whitespace c`haracters starting from the cursor.
+fn eatWhitespace(self: *DisableDirectivesParser) void {
+    const whitespace = std.ascii.whitespace;
+    while (self.cursor < self.span.end and std.mem.indexOfScalar(u8, &whitespace, self.curr()) != null) : (self.cursor += 1) {}
+}
+
+/// Move the cursor forward if the next character is `expected`. Otherwise
+/// the cursor is not modified and `null` is returned.
+fn eat(self: *DisableDirectivesParser, expected: u8) ?void {
+    const next = self.cursor + 1;
+    if (next >= self.span.end) return null;
+    if (self.source[next] == expected) {
+        self.cursor = next;
+        return;
+    } else {
+        return null;
+    }
+}
+
+/// Try to consume a slice. If found, the cursor is moved past `expected`,
+/// otherwise returns `null`.
+fn eatMany(self: *DisableDirectivesParser, comptime expected: []const u8, comptime ignore_case: bool) ?void {
+    if (self.cursor + expected.len > self.span.end) return null;
+
+    const actual = self.source[self.cursor..(self.cursor + expected.len)];
+    const is_match = if (comptime ignore_case) ascii.eqlIgnoreCase(actual, expected) else mem.eql(u8, actual, expected);
+    return if (is_match) {
+        self.cursor += expected.len;
+    } else null;
+}
+
+inline fn curr(self: *const DisableDirectivesParser) u8 {
+    return self.source[self.cursor];
+}
+
+fn remaining(self: *const DisableDirectivesParser) []const u8 {
+    self.assertInRange();
+    return self.source[self.cursor..self.span.end];
+}
+
+/// Inlined so LLVM can optimize away bounds-related safety checks.
+inline fn assertInRange(self: *const DisableDirectivesParser) void {
+    assert(self.cursor < self.source.len);
+    assert(self.cursor < self.span.end);
+}
+
+fn reset(self: *DisableDirectivesParser) void {
+    self.cursor = undefined;
+    self.kind = undefined;
+    self.span = undefined;
+}
+
+const t = std.testing;
+const Tuple = std.meta.Tuple;
+test {
+    t.refAllDecls(DisableDirectivesParser);
+}
+
+test parse {
+    const TestCase = Tuple(&[_]type{ []const u8, ?DisableDirectiveComment });
+    const cases = &[_]TestCase{
+        // global directives
+        TestCase{ "//zlint-disable", .{ .kind = .global, .span = .{ .start = 0, .end = 15 } } },
+        TestCase{ "// zlint-disable", .{ .kind = .global, .span = .{ .start = 0, .end = 16 } } },
+        TestCase{ "// zlint-disable -- no-undefined", .{ .kind = .global, .span = .{ .start = 0, .end = 16 } } },
+        TestCase{
+            "// zlint-disable no-undefined",
+            .{
+                .kind = .global,
+                .span = .{ .start = 0, .end = 19 },
+                .disabled_rules = @constCast(&[_]Span{Span.new(17, 29)}),
+            },
+        },
+        TestCase{
+            "// zlint-disable foo bar baz",
+            .{
+                .kind = .global,
+                .span = .{ .start = 0, .end = 28 },
+                .disabled_rules = @constCast(&[_]Span{
+                    Span.new(17, 21),
+                    Span.new(21, 25),
+                    Span.new(25, 28),
+                }),
+            },
+        },
+    };
+
+    for (cases) |case| {
+        const source, const expected = case;
+        var parser = DisableDirectivesParser.new(source);
+        var actual = try parser.parse(t.allocator, Span.new(0, @intCast(source.len)));
+        if (actual) |*a| {
+            defer a.deinit(t.allocator);
+            const e: DisableDirectiveComment = expected.?;
+            try t.expectEqual(e.kind, a.kind);
+            try t.expectEqual(e.span, a.span);
+            try t.expectEqualSlices(Span, e.disabled_rules, a.disabled_rules);
+
+            // try t.expectEqual(expected, a);
+        } else {
+            try t.expectEqual(expected, actual);
+        }
+        // defer if (actual) |*a| a.deinit(t.allocator);
+        // try t.expectEqual(expected.kind, actual.k);
+        // try t.expectEqual(expected, actual);
+    }
+}
+
+test eatWhitespace {
+    const TestCase = Tuple(&[_]type{ []const u8, []const u8 });
+    const cases: []const TestCase = &[_]TestCase{
+        TestCase{ "", "" },
+        TestCase{ " ", "" },
+        TestCase{ "\n", "" },
+        TestCase{ "foo", "foo" },
+        TestCase{ "bar  ", "bar  " },
+        TestCase{ "\n\tbaz", "baz" },
+        TestCase{ "    baz", "baz" },
+        TestCase{ "foo bar", "foo bar" },
+    };
+
+    for (cases) |case| {
+        const source, const expected = case;
+
+        var p: DisableDirectivesParser = undefined;
+        p.source = source;
+        p.span = Span.new(0, @intCast(source.len));
+        p.cursor = 0;
+        p.eatWhitespace();
+        try t.expect(p.cursor <= p.span.end);
+        try t.expectEqualStrings(expected, p.source[p.cursor..p.span.end]);
+    }
+}
+
+const std = @import("std");
+const util = @import("util");
+const heap = std.heap;
+const ascii = std.ascii;
+const mem = std.mem;
+
+const Span = @import("../../span.zig").Span;
+const Allocator = mem.Allocator;
+
+const assert = std.debug.assert;
+
+pub const DisableDirectiveComment = @import("./Comment.zig");

--- a/src/linter/disable_directives/Parser_test.zig
+++ b/src/linter/disable_directives/Parser_test.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+const DisableDirectivesParser = @import("./Parser.zig");
+const DisableDirectiveComment = @import("./Comment.zig");
+const Span = @import("../../span.zig").Span;
+
+const Tuple = std.meta.Tuple;
+const t = std.testing;
+const print = std.debug.print;
+
+const TestCase = struct {
+    src: []const u8,
+    expected: ?DisableDirectiveComment,
+    /// When `false`, `actual.span` is not compared to `expected.span`.
+    check_span: bool = false,
+};
+
+/// For when you don't care about the parsed comment's span
+const NULL_SPAN = Span{ .start = 0, .end = 0 };
+
+fn runTests(cases: []const TestCase) !void {
+    for (cases) |case| {
+        // const source, const expected = case;
+        const source = case.src;
+        const expected = case.expected;
+        const check_span = case.check_span;
+
+        var parser = DisableDirectivesParser.new(source);
+        var actual = try parser.parse(t.allocator, Span.new(0, @intCast(source.len)));
+        if (actual) |*a| {
+            defer a.deinit(t.allocator);
+            const e: DisableDirectiveComment = expected.?;
+
+            t.expectEqual(e.kind, a.kind) catch |err| {
+                print("\nSource: '{s}'\n", .{source});
+                return err;
+            };
+
+            if (check_span) {
+                t.expectEqual(e.span, a.span) catch |err| {
+                    print("\nSource: '{s}'\n", .{source});
+                    return err;
+                };
+            }
+
+            t.expectEqualSlices(Span, e.disabled_rules, a.disabled_rules) catch |err| {
+                print("\nSource: '{s}'\n", .{source});
+                return err;
+            };
+        } else {
+            t.expectEqual(expected, actual) catch |err| {
+                print("\nSource: '{s}'\n", .{source});
+                return err;
+            };
+        }
+    }
+}
+
+test "global directives that disable all rules" {
+    const cases = &[_]TestCase{
+        .{ .src = "//zlint-disable", .expected = .{ .kind = .global, .span = .{ .start = 0, .end = 15 } }, .check_span = true },
+        .{ .src = "// zlint-disable", .expected = .{ .kind = .global, .span = .{ .start = 0, .end = 16 } }, .check_span = true },
+        .{ .src = "// zlint-disable            ", .expected = .{ .kind = .global, .span = .{ .start = 0, .end = 16 } }, .check_span = true },
+        .{ .src = "   //     zlint-disable", .expected = .{ .kind = .global, .span = .{ .start = 0, .end = 23 } }, .check_span = true },
+    };
+    try runTests(cases);
+}
+
+test "line directives that disable all rules" {
+    const cases = &[_]TestCase{
+        .{ .src = "// zlint-disable-next-line", .expected = .{ .kind = .line, .span = .{ .start = 0, .end = 26 } }, .check_span = true },
+        .{ .src = "// zlint-disable-next-line            ", .expected = .{ .kind = .line, .span = .{ .start = 0, .end = 26 } }, .check_span = true },
+        .{ .src = "   //     zlint-disable-next-line", .expected = .{ .kind = .line, .span = .{ .start = 0, .end = 33 } }, .check_span = true },
+    };
+    try runTests(cases);
+}
+
+test "comments" {
+    const global: DisableDirectiveComment = .{ .kind = .global, .span = NULL_SPAN };
+    const line: DisableDirectiveComment = .{ .kind = .line, .span = NULL_SPAN };
+
+    const cases = &[_]TestCase{
+        .{ .src = "// zlint-disable -- no-undefined", .expected = global },
+        .{ .src = "// zlint-disable-next-line -- no-undefined", .expected = line },
+        .{ .src = "// zlint-disable --", .expected = global },
+        .{ .src = "// zlint-disable -- foo bar baz", .expected = global },
+        .{ .src = "// zlint-disable     --   foo bar baz", .expected = global },
+    };
+
+    try runTests(cases);
+}
+
+test "not a disable directive" {
+    const cases = &[_]TestCase{
+        .{ .src = "//", .expected = null },
+        .{ .src = "// foo", .expected = null },
+        .{ .src = "// foo foo foo foo foo foo foo foo foo foo", .expected = null },
+        .{ .src = "// foo zlint-disable", .expected = null },
+        .{ .src = "zlint-disable no-undefined", .expected = null },
+    };
+    try runTests(cases);
+}

--- a/src/linter/disable_directives/Parser_test.zig
+++ b/src/linter/disable_directives/Parser_test.zig
@@ -99,3 +99,33 @@ test "not a disable directive" {
     };
     try runTests(cases);
 }
+
+test "disabling specific rules" {
+    const cases = &[_]TestCase{
+        .{
+            .src = "// zlint-disable foo bar baz",
+            .expected = .{
+                .kind = .global,
+                .span = NULL_SPAN,
+                .disabled_rules = @constCast(&[_]Span{
+                    Span.new(17, 21),
+                    Span.new(21, 25),
+                    Span.new(25, 28),
+                }),
+            },
+        },
+        .{
+            .src = "// zlint-disable foo, bar, baz",
+            .expected = .{
+                .kind = .global,
+                .span = NULL_SPAN,
+                .disabled_rules = @constCast(&[_]Span{
+                    Span.new(17, 21),
+                    Span.new(22, 26),
+                    Span.new(27, 30),
+                }),
+            },
+        },
+    };
+    try runTests(cases);
+}

--- a/src/linter/disable_directives/Parser_test.zig
+++ b/src/linter/disable_directives/Parser_test.zig
@@ -102,6 +102,7 @@ test "not a disable directive" {
 
 test "disable directives may be in doc comments" {
     const cases = &[_]TestCase{
+        .{ .src = "//  zlint-disable", .expected = .{ .kind = .global, .span = NULL_SPAN } },
         .{ .src = "/// zlint-disable", .expected = .{ .kind = .global, .span = NULL_SPAN } },
         .{ .src = "//! zlint-disable", .expected = .{ .kind = .global, .span = NULL_SPAN } },
     };

--- a/src/linter/disable_directives/Parser_test.zig
+++ b/src/linter/disable_directives/Parser_test.zig
@@ -100,6 +100,14 @@ test "not a disable directive" {
     try runTests(cases);
 }
 
+test "disable directives may be in doc comments" {
+    const cases = &[_]TestCase{
+        .{ .src = "/// zlint-disable", .expected = .{ .kind = .global, .span = NULL_SPAN } },
+        .{ .src = "//! zlint-disable", .expected = .{ .kind = .global, .span = NULL_SPAN } },
+    };
+    try runTests(cases);
+}
+
 test "disabling specific rules" {
     const cases = &[_]TestCase{
         .{

--- a/src/span.zig
+++ b/src/span.zig
@@ -9,6 +9,8 @@ const Arc = ptrs.Arc;
 const assert = std.debug.assert;
 const string = util.string;
 
+const t = std.testing;
+
 pub const LocationSpan = struct {
     span: LabeledSpan,
     location: Location,
@@ -69,10 +71,33 @@ pub const Span = struct {
         return contents[self.start..self.end];
     }
 
+    /// Translate a span towards the end of the file by `offset` characters.
+    ///
+    /// ## Example
+    /// ```zig
+    /// const span = Span.new(5, 7);
+    /// const moved = span.shiftRight(5);
+    /// try std.testing.expectEqual(Span.new(10, 12), moved);
+    /// ```
+    pub fn shiftRight(self: Span, offset: u32) Span {
+        return .{ .start = self.start + offset, .end = self.end + offset };
+    }
+
+    pub inline fn contains(self: Span, point: u32) bool {
+        self.start >= point and point < self.end;
+    }
+
     pub fn eql(self: Span, other: Span) bool {
         return self.start == other.start and self.end == other.end;
     }
 };
+
+test "Span.shiftRight" {
+    const span = Span.new(5, 7);
+    const moved = span.shiftRight(5);
+    try t.expectEqual(Span.new(10, 12), moved);
+    try t.expectEqual(Span.new(5, 7), span); // original span is not mutated
+}
 
 pub const LabeledSpan = struct {
     span: Span,
@@ -137,7 +162,6 @@ fn findLineColumn(source: []const u8, byte_offset: u32) Location {
 }
 
 test findLineColumn {
-    const t = std.testing;
     const source =
         \\Foo bar
         \\baz


### PR DESCRIPTION
## What This PR Does

Parse disable directives from regular and doc comments. A follow-up PR will update the linter to check for disabled rules and suppress diagnostics accordingly.