### PR TITLE
refactor(linter): give rules a unique numeric ID

### DIFF
--- a/src/linter/rule.zig
+++ b/src/linter/rule.zig
@@ -36,6 +36,7 @@ const RunOnSymbolFn = *const fn (ptr: *const anyopaque, symbol: Symbol.Id, ctx: 
 pub const Rule = struct {
     // name: string,
     meta: Meta,
+    id: Id,
     ptr: *anyopaque,
     runOnNodeFn: RunOnNodeFn,
     runOnSymbolFn: RunOnSymbolFn,
@@ -81,6 +82,8 @@ pub const Rule = struct {
             @compileError("Rule must have a `pub const " ++ META_FIELD_NAME ++ " Rule.Meta` field");
         };
 
+        const id = comptime rule_ids.get(meta.name) orelse @compileError("Could not find an id for rule '" ++ meta.name ++ "'.");
+
         const gen = struct {
             pub fn runOnNode(pointer: *const anyopaque, node: NodeWrapper, ctx: *LinterContext) anyerror!void {
                 if (@hasDecl(ptr_info.child, "runOnNode")) {
@@ -97,6 +100,7 @@ pub const Rule = struct {
         };
 
         return .{
+            .id = id,
             .meta = meta,
             .ptr = ptr,
             .runOnNodeFn = gen.runOnNode,
@@ -111,17 +115,33 @@ pub const Rule = struct {
     pub fn runOnSymbol(self: *const Rule, symbol: Symbol.Id, ctx: *LinterContext) !void {
         return self.runOnSymbolFn(self.ptr, symbol, ctx);
     }
+
+    pub const Id = util.NominalId(u32);
 };
 
-fn getRuleName(ty: std.builtin.Type) string {
-    switch (ty) {
-        .Pointer => {
-            const child = ty.Pointer.child;
-            if (!@hasDecl(child, "Name")) {
-                @panic("Rule must have a `pub const Name: []const u8` field");
-            }
-            return child.Name;
-        },
-        else => @panic("Rule must be a pointer"),
+const IdMap = std.StaticStringMap(Rule.Id);
+const rule_ids: IdMap = ids: {
+    const Type = std.builtin.Type;
+    const AllRules = @import("./rules.zig");
+    const RuleDecls: []const Type.Declaration = @typeInfo(AllRules).Struct.decls;
+    var ids: [RuleDecls.len]struct { []const u8, Rule.Id } = undefined;
+    for (RuleDecls, 0..) |decl, i| {
+        const RuleImpl = @field(AllRules, decl.name);
+        if (!@hasDecl(RuleImpl, "meta")) {
+            @compileError("Rule '" ++ decl.name ++ "' is missing a meta: Rule.Meta property.");
+        }
+        const name: []const u8 = @field(AllRules, decl.name).meta.name;
+        const id = Rule.Id.new(i);
+        ids[i] = .{ name, id };
     }
+    break :ids IdMap.initComptime(ids);
+};
+
+test rule_ids {
+    const t = std.testing;
+    try t.expectEqual(
+        @typeInfo(@import("./rules.zig")).Struct.decls.len,
+        rule_ids.kvs.len,
+    );
+    try t.expect(rule_ids.get("no-undefined") != null);
 }

--- a/src/linter/rules/unused_decls.zig
+++ b/src/linter/rules/unused_decls.zig
@@ -104,7 +104,7 @@ pub fn runOnSymbol(_: *const UnusedDecls, symbol: Symbol.Id, ctx: *LinterContext
     // are too many false positives for non-root constants. Once such references
     // are reliably resolved, remove this check.
     const scope: Scope.Id = slice.items(.scope)[s];
-    if (!scope.eq(semantic.Semantic.ROOT_SCOPE_ID)) return;
+    if (!scope.eql(semantic.Semantic.ROOT_SCOPE_ID)) return;
 
     if (flags.s_variable and flags.s_const) {
         _ = ctx.diagnosticFmt(

--- a/src/linter/tester.zig
+++ b/src/linter/tester.zig
@@ -248,7 +248,7 @@ const NodeWrapper = @import("rule.zig").NodeWrapper;
 const LinterContext = @import("lint_context.zig");
 const MockRule = struct {
     pub const meta: Rule.Meta = .{
-        .name = "my-rule",
+        .name = "no-undefined",
         .category = .correctness,
     };
     pub fn runOnNode(_: *const MockRule, _: NodeWrapper, _: *LinterContext) void {}

--- a/src/semantic/Reference.zig
+++ b/src/semantic/Reference.zig
@@ -192,7 +192,7 @@ pub const Flags = packed struct(FLAGS_REPR) {
 
 const std = @import("std");
 const _ast = @import("ast.zig");
-const NominalId = @import("id.zig").NominalId;
+const NominalId = @import("util").NominalId;
 
 const Node = _ast.Node;
 const TokenIndex = _ast.TokenIndex;

--- a/src/semantic/Scope.zig
+++ b/src/semantic/Scope.zig
@@ -216,7 +216,7 @@ const Allocator = std.mem.Allocator;
 const Ast = _ast.Ast;
 const NodeIndex = _ast.NodeIndex;
 const Symbol = @import("Symbol.zig");
-const NominalId = @import("id.zig").NominalId;
+const NominalId = util.NominalId;
 
 const string = util.string;
 const assert = std.debug.assert;

--- a/src/semantic/Symbol.zig
+++ b/src/semantic/Symbol.zig
@@ -355,11 +355,12 @@ pub const ReferenceIterator = struct {
 const Symbol = @This();
 
 const std = @import("std");
+const util = @import("util");
 const ast = @import("ast.zig");
 
 const Allocator = std.mem.Allocator;
 const Type = std.builtin.Type;
-const NominalId = @import("id.zig").NominalId;
+const NominalId = util.NominalId;
 
 const Node = ast.Node;
 const Scope = @import("Scope.zig");

--- a/src/semantic/ast.zig
+++ b/src/semantic/ast.zig
@@ -2,7 +2,7 @@
 //!
 //! Also includes additional types used in other semantic components.
 const std = @import("std");
-const NominalId = @import("id.zig").NominalId;
+const NominalId = @import("util").NominalId;
 
 pub const Ast = std.zig.Ast;
 pub const Node = Ast.Node;

--- a/src/util.zig
+++ b/src/util.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 
+pub const NominalId = @import("./util/id.zig").NominalId;
+
 pub const string = []const u8;
 pub const stringSlice = [:0]const u8;
 pub const stringMut = []u8;

--- a/src/util/id.zig
+++ b/src/util/id.zig
@@ -39,7 +39,7 @@ pub fn NominalId(TRepr: type) type {
         }
 
         /// Check if two Ids are equal.
-        pub inline fn eq(self: Id, other: Id) bool {
+        pub inline fn eql(self: Id, other: Id) bool {
             return self.int() == other.int();
         }
 


### PR DESCRIPTION
## What This PR Does
Adds `Rule.Id`, a nominal identifier type with a `u32` representation. All rules have a unique `Rule.Id` assigned at comptime. This is for quick rule equality checks.

## Changelog
- refactor: move `NominalId` from `semantic` to `util`
- refactor: add `Rule.Id`
- refactor: add comptime mapper of rule names -> `Rule.Id`