### PR TITLE
feat(linter): support global disable directives

### DIFF
--- a/src/linter.zig
+++ b/src/linter.zig
@@ -65,12 +65,12 @@ pub const Linter = struct {
     }
 
     /// Lint a Zig source file.
-    /// 
+    ///
     /// ## Diagnostics
     /// Parse, semantic, and lint errors are stored in `errors`. Callers should
     /// pass a reference to a `null`-initialized error list. If any errors
     /// occur, that `null` value will be replaced with a list of errors, and a
-    /// `LintError` will be returned to indicate what stage the linter got to 
+    /// `LintError` will be returned to indicate what stage the linter got to
     /// before exiting.
     pub fn runOnSource(
         self: *Linter,
@@ -156,7 +156,7 @@ pub const Linter = struct {
     /// - When filtering occurs, remaining rules are stored in `rulebuf`, and
     ///   the slice of that buffer storing rules is returned.
     /// - A slice over `rulebuf` when at least one rule is filtered out. It contains
-    ///   the rules taht were not filtered.
+    ///   the rules that were not filtered.
     /// - `null` if all rules are filtered out;
     /// - A pointer to this linter's owned ruleset when no rules are filtered out.
     ///   `rulebuf` will be unmodified.
@@ -250,8 +250,8 @@ pub const Linter = struct {
                 i += 1;
             }
         }
-        // no rules will be matched if disable directives are misued or rule
-        // names are mispelled (e.g. `zlint-disable not-a-rule`). In this case,
+        // no rules will be matched if disable directives are misused or rule
+        // names are misspelled (e.g. `zlint-disable not-a-rule`). In this case,
         // no rules are disabled so we just run them all.
         return if (i == 0) configured_rules else rulebuf[0..i];
     }

--- a/src/linter.zig
+++ b/src/linter.zig
@@ -5,6 +5,7 @@ const _semantic = @import("semantic.zig");
 
 const _rule = @import("linter/rule.zig");
 const Context = @import("linter/lint_context.zig");
+const disable_directives = @import("linter/disable_directives.zig");
 const ErrorList = Context.ErrorList;
 
 const Arc = ptrs.Arc;
@@ -28,7 +29,6 @@ const RuleSet = @import("linter/RuleSet.zig");
 const NodeWrapper = _rule.NodeWrapper;
 const string = @import("util").string;
 
-const rules = @import("./linter/rules.zig");
 pub const Config = @import("./linter/Config.zig");
 
 pub const Linter = struct {
@@ -64,6 +64,14 @@ pub const Linter = struct {
         self.arena.deinit();
     }
 
+    /// Lint a Zig source file.
+    /// 
+    /// ## Diagnostics
+    /// Parse, semantic, and lint errors are stored in `errors`. Callers should
+    /// pass a reference to a `null`-initialized error list. If any errors
+    /// occur, that `null` value will be replaced with a list of errors, and a
+    /// `LintError` will be returned to indicate what stage the linter got to 
+    /// before exiting.
     pub fn runOnSource(
         self: *Linter,
         source: *Source,
@@ -86,8 +94,11 @@ pub const Linter = struct {
             return LintError.AnalysisFailed;
         }
         defer semantic_result.deinit();
-
         const semantic = semantic_result.value;
+
+        var rulebuf: [RuleSet.RULES_COUNT]Rule.WithSeverity = undefined;
+        const rules = try self.getRulesForFile(&rulebuf, &semantic) orelse return;
+
         var ctx = Context.init(self.gpa, &semantic, source);
         const nodes = ctx.semantic.ast.nodes;
         assert(nodes.len < std.math.maxInt(u32));
@@ -95,7 +106,7 @@ pub const Linter = struct {
         // Check each node in the AST
         // Note: rules are in outer loop for better cache locality. Nodes are
         // stored in an arena, so iterating has good cache-hit characteristics.
-        for (self.rules.rules.items) |rule_with_severity| {
+        for (rules) |rule_with_severity| {
             const rule = rule_with_severity.rule;
             ctx.updateForRule(&rule_with_severity);
             for (0..nodes.len) |i| {
@@ -116,7 +127,7 @@ pub const Linter = struct {
         }
 
         // Check each declared symbol
-        for (self.rules.rules.items) |rule_with_severity| {
+        for (rules) |rule_with_severity| {
             const rule = rule_with_severity.rule;
             ctx.updateForRule(&rule_with_severity);
             var symbols = ctx.semantic.symbols.iter();
@@ -138,6 +149,113 @@ pub const Linter = struct {
         }
     }
 
+    /// Get the list of rules that should be run on a file. Rules disabled
+    /// globally are filtered out.
+    ///
+    /// ## Returns
+    /// - When filtering occurs, remaining rules are stored in `rulebuf`, and
+    ///   the slice of that buffer storing rules is returned.
+    /// - A slice over `rulebuf` when at least one rule is filtered out. It contains
+    ///   the rules taht were not filtered.
+    /// - `null` if all rules are filtered out;
+    /// - A pointer to this linter's owned ruleset when no rules are filtered out.
+    ///   `rulebuf` will be unmodified.
+    fn getRulesForFile(
+        self: *Linter,
+        rulebuf: *[RuleSet.RULES_COUNT]Rule.WithSeverity,
+        semantic: *const Semantic,
+    ) Allocator.Error!?[]const Rule.WithSeverity {
+        const configured_rules = self.rules.rules.items;
+        const alloc = self.arena.allocator();
+        var parser = disable_directives.Parser.new(semantic.ast.source);
+        // global disable directives may be placed anywhere before the first
+        // non-doc comment token. Doc comments may have global disable directives.
+        var start_of_first_non_doc_tok: u32 = 0;
+
+        {
+            var toks = semantic.ast.tokens;
+            const tok_starts: []const u32 = toks.items(.start);
+            const tok_tags: []const Semantic.Token.Tag = toks.items(.tag);
+            for (0..toks.len) |i| {
+                switch (tok_tags[i]) {
+                    .doc_comment, .container_doc_comment => {
+                        const end: u32 = @truncate(semantic.tokens.items(.loc)[i].end);
+                        if (try parser.parse(alloc, .{ .start = tok_starts[i], .end = end })) |comment| {
+                            // TODO: support next-line diagnostics
+                            if (!comment.isGlobal()) continue;
+                            return if (comment.disablesAllRules()) null else filterDisabledRules(
+                                semantic.ast.source,
+                                rulebuf,
+                                configured_rules,
+                                &comment,
+                            );
+                        }
+                    },
+                    else => {
+                        start_of_first_non_doc_tok = tok_starts[i];
+                        break;
+                    },
+                }
+            }
+        }
+
+        // Look for global disable directives in normal comments by parsing
+        // comments up to the first non-comment token.
+        for (0..semantic.comments.len) |i| {
+            const comment = semantic.comments.get(i);
+            if (comment.start >= start_of_first_non_doc_tok) break;
+            const dd = try parser.parse(alloc, comment) orelse continue;
+            // TODO: support next-line diagnostics
+            if (!dd.isGlobal()) continue;
+            return if (dd.disablesAllRules()) null else filterDisabledRules(
+                semantic.ast.source,
+                rulebuf,
+                configured_rules,
+                &dd,
+            );
+        }
+
+        return configured_rules;
+    }
+
+    /// Filter out configured rules based on a disable directive that
+    /// _definitely_ has at least one named rule disabled.
+    fn filterDisabledRules(
+        source: []const u8,
+        rulebuf: *[RuleSet.RULES_COUNT]Rule.WithSeverity,
+        configured_rules: []const Rule.WithSeverity,
+        dd: *const disable_directives.Comment,
+    ) ?[]const Rule.WithSeverity {
+        assert(dd.disabled_rules.len > 0);
+        var disabled_rules_buf: [RuleSet.RULES_COUNT]Rule.Id = undefined;
+        const disabled_rules: []const Rule.Id = blk: {
+            var i: usize = 0;
+            for (dd.disabled_rules) |rule_span| {
+                const rule_name = source[rule_span.start..rule_span.end];
+                if (Rule.getIdFor(rule_name)) |id| {
+                    disabled_rules_buf[i] = id;
+                    i += 1;
+                }
+            }
+
+            if (i == 0) return configured_rules;
+            break :blk disabled_rules_buf[0..i];
+        };
+        assert(disabled_rules.len > 0); // for LLVM optimizations. TODO: check if needed.
+
+        var i: usize = 0;
+        for (configured_rules) |rule| {
+            if (std.mem.indexOfScalar(Rule.Id, disabled_rules, rule.rule.id) == null) {
+                rulebuf[i] = rule;
+                i += 1;
+            }
+        }
+        // no rules will be matched if disable directives are misued or rule
+        // names are mispelled (e.g. `zlint-disable not-a-rule`). In this case,
+        // no rules are disabled so we just run them all.
+        return if (i == 0) configured_rules else rulebuf[0..i];
+    }
+
     pub const LintError = error{
         ParseFailed,
         AnalysisFailed,
@@ -146,8 +264,12 @@ pub const Linter = struct {
 };
 
 test {
+    // ensure intellisense
     std.testing.refAllDecls(@This());
     std.testing.refAllDecls(@import("linter/tester.zig"));
     std.testing.refAllDecls(@import("linter/disable_directives/Parser.zig"));
-    std.testing.refAllDeclsRecursive(rules);
+    std.testing.refAllDeclsRecursive(@import("./linter/rules.zig"));
+
+    // test suites
+    _ = @import("./linter/test/disabling_rules_test.zig");
 }

--- a/src/linter/RuleSet.zig
+++ b/src/linter/RuleSet.zig
@@ -3,7 +3,7 @@ rules: std.ArrayListUnmanaged(Rule.WithSeverity) = .{},
 const RuleSet = @This();
 
 /// Total number of all lint rules.
-const RULES_COUNT: usize = @typeInfo(rules).Struct.decls.len;
+pub const RULES_COUNT: usize = @typeInfo(rules).Struct.decls.len;
 const ALL_RULE_IMPLS_SIZE: usize = Rule.MAX_SIZE * @typeInfo(rules).Struct.decls.len;
 const ALL_RULES_SIZE: usize = @sizeOf(Rule.WithSeverity) * @typeInfo(rules).Struct.decls.len;
 

--- a/src/linter/disable_directives/Comment.zig
+++ b/src/linter/disable_directives/Comment.zig
@@ -35,7 +35,7 @@ pub inline fn isGlobal(self: *const DisableDirectiveComment) bool {
 }
 
 /// Does this directive disable diagnostics for all rules?
-/// 
+///
 /// _(say that 3 times fast lol)_
 pub inline fn disablesAllRules(self: *const DisableDirectiveComment) bool {
     return self.disabled_rules.len == 0;

--- a/src/linter/disable_directives/Comment.zig
+++ b/src/linter/disable_directives/Comment.zig
@@ -29,6 +29,18 @@ pub const Kind = enum {
     line,
 };
 
+/// Returns `true` if this disable directive applies to an entire file.
+pub inline fn isGlobal(self: *const DisableDirectiveComment) bool {
+    return self.kind == .global;
+}
+
+/// Does this directive disable diagnostics for all rules?
+/// 
+/// _(say that 3 times fast lol)_
+pub inline fn disablesAllRules(self: *const DisableDirectiveComment) bool {
+    return self.disabled_rules.len == 0;
+}
+
 pub fn eql(self: DisableDirectiveComment, other: DisableDirectiveComment) bool {
     if (self.kind != other.kind or !self.span.eql(other.span)) return false;
     if (self.disabled_rules == other.disabled_rules) return true;

--- a/src/linter/rule.zig
+++ b/src/linter/rule.zig
@@ -116,6 +116,10 @@ pub const Rule = struct {
         return self.runOnSymbolFn(self.ptr, symbol, ctx);
     }
 
+    pub fn getIdFor(name: []const u8) ?Rule.Id {
+        return rule_ids.get(name);
+    }
+
     pub const Id = util.NominalId(u32);
 };
 

--- a/src/linter/test/disabling_rules_test.zig
+++ b/src/linter/test/disabling_rules_test.zig
@@ -1,0 +1,230 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+
+const rules = @import("../rules.zig");
+const Linter = @import("../../linter.zig").Linter;
+const Config = @import("../../linter.zig").Config;
+const Source = @import("../../source.zig").Source;
+const Error = @import("../../Error.zig");
+const ErrorList = std.ArrayList(Error);
+
+const t = std.testing;
+const expectEqual = t.expectEqual;
+
+const source =
+    \\const Unused = struct{
+    \\  uninitialized: u32 = undefined,
+    \\};
+;
+fn makeSource(arena: Allocator, source_text: []const u8) !Source {
+    const srctext = try arena.dupeZ(u8, source_text);
+    errdefer arena.free(srctext);
+
+    const path = try arena.dupe(u8, "test.zig");
+    errdefer arena.free(path);
+
+    return Source.fromString(arena, srctext, path);
+}
+
+test "Enabled rules have their violations reported" {
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
+    var src = try makeSource(t.allocator, source);
+    defer src.deinit();
+
+    var errors: ?ErrorList = null;
+    defer if (errors) |errs| {
+        for (errs.items) |*err| err.deinit(t.allocator);
+        errs.deinit();
+    };
+
+    const config = Config{
+        .rules = .{
+            .no_undefined = .{ .severity = .err },
+            .unused_decls = .{ .severity = .err },
+        },
+    };
+
+    {
+        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = config });
+        defer linter.deinit();
+        linter.runOnSource(&src, &errors) catch |e| {
+            switch (e) {
+                error.OutOfMemory => return e,
+                else => {},
+            }
+        };
+        try expectEqual(2, errors.?.items.len);
+    }
+}
+
+test "When no rules are enabled, no violations are reported" {
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
+    var src = try makeSource(t.allocator, source);
+    defer src.deinit();
+
+    var errors: ?ErrorList = null;
+    // only populated when linting fails, which should not happen (that's what's
+    // being tested).
+    errdefer if (errors) |errs| {
+        for (errs.items) |*err| err.deinit(t.allocator);
+        errs.deinit();
+    };
+
+    {
+        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = .{} });
+
+        defer linter.deinit();
+        try linter.runOnSource(&src, &errors);
+        try expectEqual(null, errors);
+    }
+}
+
+test "When a rule is configured to 'off', none of its violations are reported" {
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
+    var src = try makeSource(t.allocator, source);
+    defer src.deinit();
+
+    var errors: ?ErrorList = null;
+    defer if (errors) |errs| {
+        for (errs.items) |*err| err.deinit(t.allocator);
+        errs.deinit();
+    };
+
+    const config = Config{
+        .rules = .{
+            .no_undefined = .{ .severity = .err },
+        },
+    };
+
+    {
+        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = config });
+        defer linter.deinit();
+        linter.runOnSource(&src, &errors) catch |e| {
+            switch (e) {
+                error.OutOfMemory => return e,
+                else => {},
+            }
+        };
+        try expectEqual(1, errors.?.items.len);
+        try expectEqual("no-undefined", errors.?.items[0].code);
+    }
+}
+
+test "When rules are configured but a specific rule is disabled with 'zlint-disable', only non-disabled rules get reported" {
+    const source_with_global_disable =
+        \\// zlint-disable no-undefined
+        \\const Unused = struct{
+        \\  uninitialized: u32 = undefined,
+        \\};
+    ;
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
+    var src = try makeSource(t.allocator, source_with_global_disable);
+    defer src.deinit();
+
+    var errors: ?ErrorList = null;
+    defer if (errors) |errs| {
+        for (errs.items) |*err| err.deinit(t.allocator);
+        errs.deinit();
+    };
+
+    const config = Config{
+        .rules = .{
+            .no_undefined = .{ .severity = .err },
+            .unused_decls = .{ .severity = .err },
+        },
+    };
+
+    {
+        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = config });
+        defer linter.deinit();
+        linter.runOnSource(&src, &errors) catch |e| {
+            switch (e) {
+                error.OutOfMemory => return e,
+                else => {},
+            }
+        };
+        try expectEqual(1, errors.?.items.len);
+        try expectEqual("unused-decls", errors.?.items[0].code);
+    }
+}
+
+test "When rules are configured but disabled with 'zlint-disable', nothing gets reported" {
+    const source_with_global_disable =
+        \\// zlint-disable
+        \\const Unused = struct{
+        \\  uninitialized: u32 = undefined,
+        \\};
+    ;
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
+    var src = try makeSource(t.allocator, source_with_global_disable);
+    defer src.deinit();
+
+    var errors: ?ErrorList = null;
+    defer if (errors) |errs| {
+        for (errs.items) |*err| err.deinit(t.allocator);
+        errs.deinit();
+    };
+
+    const config = Config{
+        .rules = .{
+            .no_undefined = .{ .severity = .err },
+            .unused_decls = .{ .severity = .err },
+        },
+    };
+
+    {
+        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = config });
+        defer linter.deinit();
+        linter.runOnSource(&src, &errors) catch |e| {
+            switch (e) {
+                error.OutOfMemory => return e,
+                else => {},
+            }
+        };
+        try expectEqual(null, errors);
+    }
+}
+
+test "When the global disable directive is misplaced, violations still gets reported" {
+    const source_with_global_disable =
+        \\const Unused = struct{
+        \\  uninitialized: u32 = undefined,
+        \\};
+        \\// zlint-disable
+    ;
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
+    var src = try makeSource(t.allocator, source_with_global_disable);
+    defer src.deinit();
+
+    var errors: ?ErrorList = null;
+    defer if (errors) |errs| {
+        for (errs.items) |*err| err.deinit(t.allocator);
+        errs.deinit();
+    };
+
+    const config = Config{
+        .rules = .{
+            .no_undefined = .{ .severity = .err },
+            .unused_decls = .{ .severity = .err },
+        },
+    };
+
+    {
+        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = config });
+        defer linter.deinit();
+        linter.runOnSource(&src, &errors) catch |e| {
+            switch (e) {
+                error.OutOfMemory => return e,
+                else => {},
+            }
+        };
+        try expectEqual(2, errors.?.items.len);
+    }
+}

--- a/src/semantic/Semantic.zig
+++ b/src/semantic/Semantic.zig
@@ -94,7 +94,6 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const Ast = std.zig.Ast;
-const Token = std.zig.Token;
 const Type = std.builtin.Type;
 const assert = std.debug.assert;
 
@@ -103,6 +102,8 @@ const _tokenizer = @import("./tokenizer.zig");
 const TokenList = _tokenizer.TokenList;
 const CommentList = _tokenizer.CommentList;
 const TokenIndex = _ast.TokenIndex;
+
+pub const Token = _tokenizer.Token;
 
 pub const NodeLinks = @import("NodeLinks.zig");
 pub const Scope = @import("Scope.zig");


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the linter functionality in the Zig programming language. The most significant changes include adding support for disable directives, improving the rule filtering mechanism, and adding comprehensive tests for the new features.

### Enhancements to Linter Functionality:

* Added support for disable directives to the linter, allowing specific rules to be disabled globally or locally in the source code. (`src/linter.zig`, `src/linter/disable_directives.zig`, `src/linter/disable_directives/Comment.zig`) [[1]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9R8) [[2]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9L31) [[3]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9R67-R74) [[4]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9L89-R109) [[5]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9L119-R130) [[6]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9R152-R258) [[7]](diffhunk://#diff-6e15ac1303286e850975993919a2adad185ac1d1ad5a048ec62a7b67d872ae25R32-R43) [[8]](diffhunk://#diff-c1081df3f33f9211b84196d844bcbec110d72cd83888108a4131268684723c48R119-R122)

### Refactoring:

* Refactored the rule filtering mechanism to dynamically determine applicable rules based on disable directives and configuration. (`src/linter.zig`, `src/linter/RuleSet.zig`) [[1]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9L89-R109) [[2]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9L119-R130) [[3]](diffhunk://#diff-3cf1e7358964b262694db62ec01170f62e059713cfff9d24f3d888d08cc02df9R152-R258) [[4]](diffhunk://#diff-be9052dc6135e20ff41f440d941f46b9fc6896ac0a743c46c52eb2bd93a4f82dL6-R6)

### Testing:

* Added a comprehensive test suite for the new disable directive functionality, ensuring that the linter correctly handles various configurations and disable directive placements. (`src/linter/test/disabling_rules_test.zig`)