### PR TITLE
feat(linter/no-undefined): allow undefined-initialized arrays

### DIFF
--- a/docs/rules/no-undefined.md
+++ b/docs/rules/no-undefined.md
@@ -16,14 +16,20 @@ builds.
 ### Allowed Scenarios
 
 There are some cases where using `undefined` makes sense, such as array
-initialization. Such cases should be communicated to other programmers via a
-safety comment. Adding `SAFETY: <reason>` before the line using `undefined`
-will not trigger a rule violation.
+initialization. Some cases are implicitly allowed, but others should be
+communicated to other programmers via a safety comment. Adding `SAFETY:
+<reason>` before the line using `undefined` will not trigger a rule
+violation.
 
 ```zig
-// SAFETY: arr is immediately initialized after declaration.
+// arrays may be set to undefined without a safety comment
 var arr: [10]u8 = undefined;
 @memset(&arr, 0);
+
+// SAFETY: foo is written to by `initializeFoo`, so `undefined` is never
+// read.
+var foo: u32 = undefined
+initializeFoo(&foo);
 ```
 
 ## Examples

--- a/src/linter/rules/no_undefined.zig
+++ b/src/linter/rules/no_undefined.zig
@@ -18,7 +18,7 @@
 //! // arrays may be set to undefined without a safety comment
 //! var arr: [10]u8 = undefined;
 //! @memset(&arr, 0);
-//! 
+//!
 //! // SAFETY: foo is written to by `initializeFoo`, so `undefined` is never
 //! // read.
 //! var foo: u32 = undefined

--- a/src/linter/rules/snapshots/no-undefined.snap
+++ b/src/linter/rules/snapshots/no-undefined.snap
@@ -6,6 +6,34 @@
   help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
 
   𝙭 no-undefined: `undefined` is missing a safety comment
+   ╭─[no-undefined.zig:1:21]
+ 1 │ const slice: []u8 = undefined;
+   ·                     ─────────
+   ╰────
+  help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
+
+  𝙭 no-undefined: `undefined` is missing a safety comment
+   ╭─[no-undefined.zig:1:23]
+ 1 │ const slice: [:0]u8 = undefined;
+   ·                       ─────────
+   ╰────
+  help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
+
+  𝙭 no-undefined: `undefined` is missing a safety comment
+   ╭─[no-undefined.zig:1:25]
+ 1 │ const many_ptr: [*]u8 = undefined;
+   ·                         ─────────
+   ╰────
+  help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
+
+  𝙭 no-undefined: `undefined` is missing a safety comment
+   ╭─[no-undefined.zig:1:27]
+ 1 │ const many_ptr: [*:0]u8 = undefined;
+   ·                           ─────────
+   ╰────
+  help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
+
+  𝙭 no-undefined: `undefined` is missing a safety comment
    ╭─[no-undefined.zig:2:11]
  1 │ // This is not a safety comment
  2 │ const x = undefined;

--- a/src/semantic/NodeLinks.zig
+++ b/src/semantic/NodeLinks.zig
@@ -63,16 +63,16 @@ pub inline fn setParent(self: *NodeLinks, child_id: NodeIndex, parent_id: NodeIn
     self.parents.items[child_id] = parent_id;
 }
 
-pub inline fn getParent(self: *NodeLinks, node_id: NodeIndex) ?NodeIndex {
+pub inline fn getParent(self: *const NodeLinks, node_id: NodeIndex) ?NodeIndex {
     if (node_id == ROOT_NODE_ID) {
         return NULL_NODE;
     }
-    return self.parents[node_id];
+    return self.parents.items[node_id];
 }
 
 /// Iterate over a node's parents. The first element is the node itself, and
 /// the last will be the root node.
-pub fn iterParentIds(self: *NodeLinks, node_id: NodeIndex) ParentIdsIterator {
+pub fn iterParentIds(self: *const NodeLinks, node_id: NodeIndex) ParentIdsIterator {
     return ParentIdsIterator{
         .links = self,
         .curr_id = node_id,
@@ -80,7 +80,7 @@ pub fn iterParentIds(self: *NodeLinks, node_id: NodeIndex) ParentIdsIterator {
 }
 
 const ParentIdsIterator = struct {
-    links: *NodeLinks,
+    links: *const NodeLinks,
     curr_id: ?NodeIndex,
 
     pub fn next(self: *ParentIdsIterator) ?NodeIndex {


### PR DESCRIPTION
This will no longer be a violation, due to how common `@memset` and `@memcpy` initializations are:

```zig
const x: [1]u8 = undefined;
```