### PR TITLE
fix(linter/homeless-try): allow `try` in comptime blocks

### DIFF
--- a/docs/rules/homeless-try.md
+++ b/docs/rules/homeless-try.md
@@ -38,3 +38,35 @@ fn foo() !void {
   var my_str = try std.heap.page_allocator.alloc(u8, 8);
 }
 ```
+
+Zig allows `try` in comptime scopes in or nested within functions. This rule
+does not flag these cases.
+
+```zig
+const std = @import("std");
+fn foo(x: u32) void {
+  comptime {
+    // valid
+    try bar(x);
+  }
+}
+fn bar(x: u32) !void {
+  return if (x == 0) error.Unreachable else void;
+}
+```
+
+Zig also allows `try` on functions whose error union sets are empty. ZLint
+does _not_ respect this case. Please refactor such functions to not return
+an error union.
+
+```zig
+const std = @import("std");
+fn foo() !u32 {
+  // compiles, but treated as a violation. `bar` should return `u32`.
+  const x = try bar();
+  return x + 1;
+}
+fn bar() u32 {
+  return 1;
+}
+```


### PR DESCRIPTION
Allow `try` in non-root `comptime` scopes.

```zig
const std = @import("std");

fn foo(x: u32) void {
    comptime {
        try bar(x);
    }
}

fn bar(x: u32) !void {
    if (x == 0) {
        return error.Unreachable;
    }
}

test {
    foo(1);
}
```