### PR TITLE
Fix `resolveLintConfig` test and bad arena move causing leak

### DIFF
--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -23,6 +23,10 @@ const Options = @import("../cli/Options.zig");
 pub fn lint(alloc: Allocator, options: Options) !u8 {
     const stdout = std.io.getStdOut().writer();
 
+    // NOTE: everything config related is stored in the same arena. This
+    // includes the config source string, the parsed Config object, and
+    // (eventually) whatever each rule needs to store. This lets all configs
+    // store slices to the config's source, avoiding allocations.
     var config = try lint_config.resolveLintConfig(alloc, fs.cwd(), "zlint.json");
     defer config.deinit();
 

--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -29,7 +29,7 @@ pub fn lint(alloc: Allocator, options: Options) !u8 {
     var arena = std.heap.ArenaAllocator.init(alloc);
     const config = blk: {
         errdefer arena.deinit();
-        break :blk try lint_config.resolveLintConfig(arena, fs.cwd(), "zlint.json");
+        break :blk try lint_config.resolveLintConfig(&arena, fs.cwd(), "zlint.json");
     };
     var reporter = try reporters.Reporter.initKind(options.format, stdout, alloc);
     defer reporter.deinit();

--- a/src/cli/lint_config.zig
+++ b/src/cli/lint_config.zig
@@ -29,9 +29,9 @@ pub fn resolveLintConfig(
         var scanner = json.Scanner.initCompleteInput(alloc, source);
         defer scanner.deinit();
         const config = try json.parseFromTokenSourceLeaky(lint.Config, alloc, &scanner, .{});
-        return config.intoManaged(arena);
+        return config.intoManaged(arena, try alloc.dupe(u8, maybe_path_to_config));
     }
-    return lint.Config.DEFAULT.intoManaged(arena);
+    return lint.Config.DEFAULT.intoManaged(arena, null);
 }
 
 const ParentIterError = error{
@@ -137,6 +137,8 @@ test resolveLintConfig {
     var arena = std.heap.ArenaAllocator.init(t.allocator);
     defer arena.deinit();
     const config = try resolveLintConfig(&arena, try cwd.openDir(fixtures_dir, .{}), "zlint.json");
+    try t.expect(config.path != null);
+    try t.expectStringEndsWith(config.path.?, "zlint/test/fixtures/config/zlint.json");
     try t.expectEqual(.warning, config.config.rules.no_undefined.severity);
 }
 

--- a/src/cli/lint_config.zig
+++ b/src/cli/lint_config.zig
@@ -8,7 +8,7 @@ const Dir = std.fs.Dir;
 const lint = @import("../linter.zig");
 
 pub fn resolveLintConfig(
-    arena: ArenaAllocator,
+    arena: *ArenaAllocator,
     cwd: Dir,
     config_filename: [:0]const u8,
 ) !lint.Config.Managed {
@@ -134,9 +134,9 @@ test resolveLintConfig {
         try cwd.realpathAlloc(t.allocator, "test/fixtures/config");
     defer t.allocator.free(fixtures_dir);
 
-    const arena = std.heap.ArenaAllocator.init(t.allocator);
+    var arena = std.heap.ArenaAllocator.init(t.allocator);
     defer arena.deinit();
-    const config = try resolveLintConfig(arena, cwd, "zlint.json");
+    const config = try resolveLintConfig(&arena, try cwd.openDir(fixtures_dir, .{}), "zlint.json");
     try t.expectEqual(.warning, config.config.rules.no_undefined.severity);
 }
 

--- a/src/linter.zig
+++ b/src/linter.zig
@@ -41,13 +41,14 @@ pub const Linter = struct {
     }
 
     pub fn init(gpa: Allocator, config: Config.Managed) !Linter {
+        var arena = ArenaAllocator.init(gpa);
+        errdefer arena.deinit();
         var ruleset = RuleSet{};
-        // FIXME: blergh two arenas
-        try ruleset.loadRulesFromConfig(config.arena.allocator(), &config.config.rules);
+        try ruleset.loadRulesFromConfig(arena.allocator(), &config.config.rules);
         const linter = Linter{
             .rules = ruleset,
             .gpa = gpa,
-            .arena = ArenaAllocator.init(gpa),
+            .arena = arena,
         };
         return linter;
     }

--- a/src/linter.zig
+++ b/src/linter.zig
@@ -42,12 +42,12 @@ pub const Linter = struct {
 
     pub fn init(gpa: Allocator, config: Config.Managed) !Linter {
         var ruleset = RuleSet{};
-        var arena = config.arena;
-        try ruleset.loadRulesFromConfig(arena.allocator(), &config.config.rules);
+        // FIXME: blergh two arenas
+        try ruleset.loadRulesFromConfig(config.arena.allocator(), &config.config.rules);
         const linter = Linter{
             .rules = ruleset,
             .gpa = gpa,
-            .arena = arena,
+            .arena = ArenaAllocator.init(gpa),
         };
         return linter;
     }

--- a/src/linter/Config.zig
+++ b/src/linter/Config.zig
@@ -6,11 +6,19 @@ pub const Managed = struct {
     /// should only be set if created from an on-disk config
     path: ?[]const u8 = null,
     config: Config,
-    arena: *std.heap.ArenaAllocator,
+    arena: std.heap.ArenaAllocator,
+
+    pub fn deinit(self: Managed) void {
+        self.arena.deinit();
+    }
 };
 
-pub fn intoManaged(self: Config, arena: *std.heap.ArenaAllocator, path: ?[]const u8) Managed {
-    return Managed{ .config = self, .arena = arena, .path = path };
+pub fn intoManaged(self: Config, alloc: std.mem.Allocator, path: ?[]const u8) Managed {
+    return Managed{
+        .config = self,
+        .arena = std.heap.ArenaAllocator.init(alloc),
+        .path = path,
+    };
 }
 
 pub const DEFAULT: Config = .{

--- a/src/linter/Config.zig
+++ b/src/linter/Config.zig
@@ -4,10 +4,10 @@ const Config = @This();
 
 pub const Managed = struct {
     config: Config,
-    arena: std.heap.ArenaAllocator,
+    arena: *std.heap.ArenaAllocator,
 };
 
-pub fn intoManaged(self: Config, arena: std.heap.ArenaAllocator) Managed {
+pub fn intoManaged(self: Config, arena: *std.heap.ArenaAllocator) Managed {
     return Managed{ .config = self, .arena = arena };
 }
 

--- a/src/linter/Config.zig
+++ b/src/linter/Config.zig
@@ -3,12 +3,14 @@ rules: RulesConfig = .{},
 const Config = @This();
 
 pub const Managed = struct {
+    /// should only be set if created from an on-disk config
+    path: ?[]const u8 = null,
     config: Config,
     arena: *std.heap.ArenaAllocator,
 };
 
-pub fn intoManaged(self: Config, arena: *std.heap.ArenaAllocator) Managed {
-    return Managed{ .config = self, .arena = arena };
+pub fn intoManaged(self: Config, arena: *std.heap.ArenaAllocator, path: ?[]const u8) Managed {
+    return Managed{ .config = self, .arena = arena, .path = path };
 }
 
 pub const DEFAULT: Config = .{

--- a/src/linter/Config.zig
+++ b/src/linter/Config.zig
@@ -6,17 +6,13 @@ pub const Managed = struct {
     /// should only be set if created from an on-disk config
     path: ?[]const u8 = null,
     config: Config,
-    arena: std.heap.ArenaAllocator,
-
-    pub fn deinit(self: Managed) void {
-        self.arena.deinit();
-    }
+    arena: *std.heap.ArenaAllocator,
 };
 
-pub fn intoManaged(self: Config, alloc: std.mem.Allocator, path: ?[]const u8) Managed {
+pub fn intoManaged(self: Config, arena: *std.heap.ArenaAllocator, path: ?[]const u8) Managed {
     return Managed{
         .config = self,
-        .arena = std.heap.ArenaAllocator.init(alloc),
+        .arena = arena,
         .path = path,
     };
 }

--- a/src/linter/test/disabling_rules_test.zig
+++ b/src/linter/test/disabling_rules_test.zig
@@ -28,6 +28,8 @@ fn makeSource(arena: Allocator, source_text: []const u8) !Source {
 }
 
 test "Enabled rules have their violations reported" {
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
     var src = try makeSource(t.allocator, source);
     defer src.deinit();
 
@@ -45,7 +47,7 @@ test "Enabled rules have their violations reported" {
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -58,6 +60,8 @@ test "Enabled rules have their violations reported" {
 }
 
 test "When no rules are enabled, no violations are reported" {
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
     var src = try makeSource(t.allocator, source);
     defer src.deinit();
 
@@ -70,7 +74,7 @@ test "When no rules are enabled, no violations are reported" {
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = .{} });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = .{} });
 
         defer linter.deinit();
         try linter.runOnSource(&src, &errors);
@@ -79,6 +83,8 @@ test "When no rules are enabled, no violations are reported" {
 }
 
 test "When a rule is configured to 'off', none of its violations are reported" {
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
     var src = try makeSource(t.allocator, source);
     defer src.deinit();
 
@@ -95,7 +101,7 @@ test "When a rule is configured to 'off', none of its violations are reported" {
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -115,6 +121,8 @@ test "When rules are configured but a specific rule is disabled with 'zlint-disa
         \\  uninitialized: u32 = undefined,
         \\};
     ;
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
     var src = try makeSource(t.allocator, source_with_global_disable);
     defer src.deinit();
 
@@ -132,7 +140,7 @@ test "When rules are configured but a specific rule is disabled with 'zlint-disa
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -152,6 +160,8 @@ test "When rules are configured but disabled with 'zlint-disable', nothing gets 
         \\  uninitialized: u32 = undefined,
         \\};
     ;
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
     var src = try makeSource(t.allocator, source_with_global_disable);
     defer src.deinit();
 
@@ -169,7 +179,7 @@ test "When rules are configured but disabled with 'zlint-disable', nothing gets 
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -188,6 +198,8 @@ test "When the global disable directive is misplaced, violations still gets repo
         \\};
         \\// zlint-disable
     ;
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
     var src = try makeSource(t.allocator, source_with_global_disable);
     defer src.deinit();
 
@@ -205,7 +217,7 @@ test "When the global disable directive is misplaced, violations still gets repo
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {

--- a/src/linter/test/disabling_rules_test.zig
+++ b/src/linter/test/disabling_rules_test.zig
@@ -28,8 +28,6 @@ fn makeSource(arena: Allocator, source_text: []const u8) !Source {
 }
 
 test "Enabled rules have their violations reported" {
-    var arena = ArenaAllocator.init(t.allocator);
-    defer arena.deinit();
     var src = try makeSource(t.allocator, source);
     defer src.deinit();
 
@@ -47,7 +45,7 @@ test "Enabled rules have their violations reported" {
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -60,8 +58,6 @@ test "Enabled rules have their violations reported" {
 }
 
 test "When no rules are enabled, no violations are reported" {
-    var arena = ArenaAllocator.init(t.allocator);
-    defer arena.deinit();
     var src = try makeSource(t.allocator, source);
     defer src.deinit();
 
@@ -74,7 +70,7 @@ test "When no rules are enabled, no violations are reported" {
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = .{} });
+        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = .{} });
 
         defer linter.deinit();
         try linter.runOnSource(&src, &errors);
@@ -83,8 +79,6 @@ test "When no rules are enabled, no violations are reported" {
 }
 
 test "When a rule is configured to 'off', none of its violations are reported" {
-    var arena = ArenaAllocator.init(t.allocator);
-    defer arena.deinit();
     var src = try makeSource(t.allocator, source);
     defer src.deinit();
 
@@ -101,7 +95,7 @@ test "When a rule is configured to 'off', none of its violations are reported" {
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -121,8 +115,6 @@ test "When rules are configured but a specific rule is disabled with 'zlint-disa
         \\  uninitialized: u32 = undefined,
         \\};
     ;
-    var arena = ArenaAllocator.init(t.allocator);
-    defer arena.deinit();
     var src = try makeSource(t.allocator, source_with_global_disable);
     defer src.deinit();
 
@@ -140,7 +132,7 @@ test "When rules are configured but a specific rule is disabled with 'zlint-disa
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -160,8 +152,6 @@ test "When rules are configured but disabled with 'zlint-disable', nothing gets 
         \\  uninitialized: u32 = undefined,
         \\};
     ;
-    var arena = ArenaAllocator.init(t.allocator);
-    defer arena.deinit();
     var src = try makeSource(t.allocator, source_with_global_disable);
     defer src.deinit();
 
@@ -179,7 +169,7 @@ test "When rules are configured but disabled with 'zlint-disable', nothing gets 
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -198,8 +188,6 @@ test "When the global disable directive is misplaced, violations still gets repo
         \\};
         \\// zlint-disable
     ;
-    var arena = ArenaAllocator.init(t.allocator);
-    defer arena.deinit();
     var src = try makeSource(t.allocator, source_with_global_disable);
     defer src.deinit();
 
@@ -217,7 +205,7 @@ test "When the global disable directive is misplaced, violations still gets repo
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = ArenaAllocator.init(t.allocator), .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {

--- a/src/linter/test/disabling_rules_test.zig
+++ b/src/linter/test/disabling_rules_test.zig
@@ -47,7 +47,7 @@ test "Enabled rules have their violations reported" {
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -74,7 +74,7 @@ test "When no rules are enabled, no violations are reported" {
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = .{} });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = .{} });
 
         defer linter.deinit();
         try linter.runOnSource(&src, &errors);
@@ -101,7 +101,7 @@ test "When a rule is configured to 'off', none of its violations are reported" {
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -140,7 +140,7 @@ test "When rules are configured but a specific rule is disabled with 'zlint-disa
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -179,7 +179,7 @@ test "When rules are configured but disabled with 'zlint-disable', nothing gets 
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {
@@ -217,7 +217,7 @@ test "When the global disable directive is misplaced, violations still gets repo
     };
 
     {
-        var linter = try Linter.init(t.allocator, .{ .arena = arena, .config = config });
+        var linter = try Linter.init(t.allocator, .{ .arena = &arena, .config = config });
         defer linter.deinit();
         linter.runOnSource(&src, &errors) catch |e| {
             switch (e) {

--- a/test/fixtures/config/zlint.json
+++ b/test/fixtures/config/zlint.json
@@ -1,3 +1,5 @@
 {
-    "no-undefined": "warn"
+    "rules": {
+        "no-undefined": "warn"
+    }
 }


### PR DESCRIPTION
- Fix resolve config test to actually resolve zlint.json and test that it does so
- fix a memory leak caused by moving an arena and only deiniting it in the outer scope
- arena wasn't even used in the outer scope so pushed it down into the lower scope
- removed a comment that I have some questions about @DonIsaac 