### PR TITLE
feat(linter): auto-fix lint rule violations with `--fix`

### DIFF
--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -18,6 +18,8 @@ format: formatter.Kind = .graphical,
 /// Instead of walking directories in cwd, read names of files to lint from stdin.
 /// If relative, paths are resolved from the cwd.
 stdin: bool = false,
+/// enable auto fixes
+fix: bool = false,
 /// Positional arguments
 args: std.ArrayListUnmanaged(util.string) = .{},
 
@@ -28,6 +30,7 @@ const help =
     \\--print-ast <file>  Parse a file and print its AST as JSON
     \\-f, --format <fmt>  Choose an output format (default, graphical, github, gh)
     \\-S, --stdin         Lint filepaths received from stdin (newline separated)
+    \\--fix               Apply automatic fixes where possible
     \\--deny-warnings     Warnings produce a non-zero exit code
     \\-q, --quiet         Only display error diagnostics
     \\-V, --verbose       Enable verbose logging   
@@ -59,7 +62,9 @@ fn parse(alloc: Allocator, args_iter: anytype, err: ?*Error) ParseError!Options 
             try opts.args.append(alloc, arg);
             continue;
         }
-        if (eq(arg, "-q") or eq(arg, "--quiet")) {
+        if (eq(arg, "--fix")) {
+            opts.fix = true;
+        } else if (eq(arg, "-q") or eq(arg, "--quiet")) {
             opts.quiet = true;
         } else if (eq(arg, "-V") or eq(arg, "--verbose")) {
             opts.verbose = true;
@@ -141,6 +146,7 @@ test parse {
         .{ "zlint", .{} },
         .{ "zlint --", .{} },
         .{ "zlint --print-ast", .{ .print_ast = true } },
+        .{ "zlint --fix", .{ .fix = true } },
         .{ "zlint --verbose", .{ .verbose = true } },
         .{ "zlint -V", .{ .verbose = true } },
         .{ "zlint --verbose --print-ast", .{ .verbose = true, .print_ast = true } },

--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -42,6 +42,7 @@ pub fn lint(alloc: Allocator, options: Options) !u8 {
         // TODO: use options to specify number of threads (if provided)
         var visitor = try LintVisitor.init(alloc, &reporter, config, null);
         defer visitor.deinit();
+        visitor.linter.options.fix = options.fix;
 
         if (!options.stdin) {
             var src = try fs.cwd().openDir(".", .{ .iterate = true });
@@ -142,7 +143,9 @@ const LintVisitor = struct {
     }
 
     fn lintFileImpl(self: *LintVisitor, filepath: []u8) !void {
-        const file = fs.cwd().openFile(filepath, .{}) catch |e| {
+        const file = fs.cwd().openFile(filepath, .{
+            .mode = if (self.linter.options.fix) .read_write else .read_only,
+        }) catch |e| {
             self.allocator.free(filepath);
             return e;
         };

--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -143,9 +143,7 @@ const LintVisitor = struct {
     }
 
     fn lintFileImpl(self: *LintVisitor, filepath: []u8) !void {
-        const file = fs.cwd().openFile(filepath, .{
-            .mode = if (self.linter.options.fix) .read_write else .read_only,
-        }) catch |e| {
+        const file = fs.cwd().openFile(filepath, .{}) catch |e| {
             self.allocator.free(filepath);
             return e;
         };

--- a/src/linter.zig
+++ b/src/linter.zig
@@ -274,4 +274,5 @@ test {
 
     // test suites
     _ = @import("./linter/test/disabling_rules_test.zig");
+    std.testing.refAllDeclsRecursive(@import("./linter/fix.zig"));
 }

--- a/src/linter/fix.zig
+++ b/src/linter/fix.zig
@@ -1,4 +1,7 @@
-pub const FixerFn = fn (builder: Fix.Builder) anyerror!Fix;
+// pub const FixerFn = fn (builder: Fix.Builder) anyerror!Fix;
+pub fn FixerFn(Ctx: type) type {
+    return fn (ctx: Ctx, builder: Fix.Builder) anyerror!Fix;
+}
 
 pub const Fix = struct {
     meta: Meta = .{},
@@ -46,6 +49,7 @@ pub const Fix = struct {
     pub const Builder = struct {
         meta: Meta = .{},
         allocator: Allocator,
+        ctx: *const LinterContext,
 
         const EMPTY = Cow.static("");
 
@@ -57,6 +61,7 @@ pub const Fix = struct {
                 .replacement = EMPTY,
             };
         }
+
         pub fn delete(self: Builder, span: Span) Fix {
             return Fix{
                 .meta = self.meta,
@@ -73,11 +78,28 @@ pub const Fix = struct {
             };
         }
 
-        pub fn replaceFmt(self: Builder, span: Span, comptime fmt: []const u8, args: anytype) Fix {
+        pub fn replacef(self: Builder, span: Span, comptime fmt: []const u8, args: anytype) Fix {
             return Fix{
                 .meta = self.meta,
                 .span = span,
                 .replacement = Cow.fmt(self.allocator, fmt, args) catch @panic("OOM"),
+            };
+        }
+
+        pub inline fn source(self: Builder) []const u8 {
+            return self.ctx.semantic.ast.source;
+        }
+
+        pub const Spanned = enum { node, token };
+
+        pub fn snippet(self: Builder, comptime kind: Spanned, id: u32) []const u8 {
+            return self.spanCovering(kind, id).snippet(self.ctx.ast().source);
+        }
+
+        pub fn spanCovering(self: Builder, comptime kind: Spanned, id: u32) Span {
+            return switch (kind) {
+                .node => Span.from(self.ctx.ast().nodeToSpan(id)),
+                .token => Span.from(self.ctx.semantic.tokens.items(.loc)[id]),
             };
         }
     };
@@ -87,7 +109,9 @@ pub const Fixer = struct {
     allocator: Allocator,
 
     const Diagnostic = @import("./lint_context.zig").Diagnostic;
-    // TODO: use a iterator yielding fixes
+    /// Take fixes in a set of diagnostics and apply them to a source file.
+    /// 
+    /// Diagnostics list is moved. Its items will be deinitialized.
     pub fn applyFixes(
         self: *Fixer,
         source: [:0]const u8,
@@ -101,7 +125,7 @@ pub const Fixer = struct {
         var stackfb = heap.stackFallback(STACK_SIZE * @sizeOf(Fix), self.allocator);
         const alloc = stackfb.get();
 
-        var fixes = std.ArrayList(Fix).init(alloc);
+        var fixes = std.ArrayList(Diagnostic).init(alloc);
         defer fixes.deinit();
         try fixes.ensureTotalCapacityPrecise(STACK_SIZE);
 
@@ -120,21 +144,24 @@ pub const Fixer = struct {
                 try unfixed_errors.append(self.allocator, diagnostic.err);
                 continue;
             }
-            try fixes.append(fix);
+            try fixes.append(diagnostic);
         }
         if (fixes.items.len == 0) return noFixes(unfixed_errors);
-        mem.sortUnstable(Fix, fixes.items, {}, spanStartLessThan);
+        mem.sortUnstable(Diagnostic, fixes.items, {}, spanStartLessThan);
 
         var fixed: std.ArrayListUnmanaged(u8) = .{};
         try fixed.ensureTotalCapacity(self.allocator, source.len);
         errdefer fixed.deinit(self.allocator);
 
         var last_end: u32 = 0;
-        for (fixes.items) |fix| {
+        for (fixes.items) |*diagnostic| {
+            var fix = &diagnostic.fix.?;
+            defer fix.replacement.deinit(self.allocator);
             if (fix.span.start < last_end) {
-                // FIXME: report diagnostic
+                try unfixed_errors.append(self.allocator, diagnostic.err);
                 continue;
             }
+            defer diagnostic.err.deinit(self.allocator);
             // append source up to the start of the fix
             try fixed.appendSlice(self.allocator, source[last_end..fix.span.start]);
             // append replacement, skipping the deleted/replaced section
@@ -150,8 +177,11 @@ pub const Fixer = struct {
     }
 
     pub const Result = struct {
+        /// Was at least one fix applied?
         did_fix: bool,
+        /// The fixed source code. Heap-allocated. Always empty if `did_fix` is `false`.
         source: std.ArrayListUnmanaged(u8),
+        /// Errors that could not be fixed.
         unfixed_errors: std.ArrayListUnmanaged(Error),
 
         pub fn deinit(self: *Result, allocator: Allocator) void {
@@ -184,8 +214,8 @@ pub const Fixer = struct {
         };
     }
 
-    fn spanStartLessThan(_: void, a: Fix, b: Fix) bool {
-        return a.span.start < b.span.start;
+    fn spanStartLessThan(_: void, a: Diagnostic, b: Diagnostic) bool {
+        return a.fix.?.span.start < b.fix.?.span.start;
     }
 };
 
@@ -202,4 +232,5 @@ const Allocator = std.mem.Allocator;
 const Span = @import("../span.zig").Span;
 const Cow = util.Cow(false);
 
+const LinterContext = @import("./lint_context.zig");
 const Error = @import("../Error.zig");

--- a/src/linter/fix.zig
+++ b/src/linter/fix.zig
@@ -1,0 +1,153 @@
+pub const FixerFn = fn (builder: Fix.Builder) anyerror!Fix;
+
+pub const Fix = struct {
+    meta: Meta = .{},
+    span: Span,
+    replacement: Cow,
+
+    pub fn isNoop(self: Fix) bool {
+        return self.replacement.borrow().len == 0 and self.span.eql(Span.EMPTY);
+    }
+
+    pub const Meta = packed struct {
+        kind: Kind = .fix,
+        safe: bool = true,
+    };
+
+    pub const Kind = enum(u1) {
+        fix,
+        suggestion,
+    };
+
+    pub const Builder = struct {
+        meta: Meta = .{},
+        allocator: Allocator,
+
+        const EMPTY = Cow.static("");
+
+        pub fn noop(_: Builder) Fix {
+            return Fix{
+                // SAFETY: noop fixes never have their meta field accessed
+                .meta = undefined,
+                .span = Span.EMPTY,
+                .replacement = EMPTY,
+            };
+        }
+        pub fn delete(self: Builder, span: Span) Fix {
+            return Fix{
+                .meta = self.meta,
+                .span = span,
+                .replacement = EMPTY,
+            };
+        }
+
+        pub fn replace(self: Builder, span: Span, replacement: Cow) Fix {
+            return Fix{
+                .meta = self.meta,
+                .span = span,
+                .replacement = replacement,
+            };
+        }
+
+        pub fn replaceFmt(self: Builder, span: Span, comptime fmt: []const u8, args: anytype) Fix {
+            return Fix{
+                .meta = self.meta,
+                .span = span,
+                .replacement = Cow.fmt(self.allocator, fmt, args) catch @panic("OOM"),
+            };
+        }
+    };
+};
+
+pub const Fixer = struct {
+    allocator: Allocator,
+
+    pub fn applyFixes(
+        self: *Fixer,
+        source: [:0]const u8,
+        reported_fixes: []const Fix,
+    ) Allocator.Error!Fixer.Result {
+        // number of fixes that can be put on the stack before a heap allocation is needed
+        const STACK_SIZE = 16;
+
+        util.assert(reported_fixes.len > 0, "Caller must check if fixes is empty", .{});
+
+        var stackfb = heap.stackFallback(STACK_SIZE * @sizeOf(Fix), self.allocator);
+        const alloc = stackfb.get();
+
+        var fixes = std.ArrayList(Fix).init(alloc);
+        defer fixes.deinit();
+        try fixes.ensureTotalCapacityPrecise(STACK_SIZE);
+
+        // filter out no-ops and sort by span start
+        for (reported_fixes) |fix| {
+            if (fix.isNoop()) continue;
+            try fixes.append(fix);
+        }
+        if (fixes.items.len == 0) return noFixes();
+        mem.sortUnstable(Fix, fixes.items, {}, spanStartLessThan);
+
+        var fixed: std.ArrayListUnmanaged(u8) = .{};
+        try fixed.ensureTotalCapacity(self.allocator, source.len);
+        errdefer fixed.deinit(self.allocator);
+
+        var last_end: u32 = 0;
+        for (fixes.items) |fix| {
+            if (fix.span.start < last_end) continue;
+            // append source up to the start of the fix
+            try fixed.appendSlice(self.allocator, source[last_end..fix.span.start]);
+            // append replacement, skipping the deleted/replaced section
+            try fixed.appendSlice(self.allocator, fix.replacement.borrow());
+
+            last_end = fix.span.end;
+        }
+        if (last_end < source.len) {
+            try fixed.appendSlice(self.allocator, source[last_end..source.len]);
+        }
+
+        return fromFixed(fixed);
+    }
+
+    pub const Result = struct {
+        did_fix: bool,
+        source: std.ArrayListUnmanaged(u8),
+
+        pub fn deinit(self: *Result, allocator: Allocator) void {
+            if (!self.did_fix) {
+                util.debugAssert(
+                    self.source.items.len == 0,
+                    "invariant violation: no-fix Result has non-empty fixed source.",
+                    .{},
+                );
+                return;
+            }
+
+            self.source.deinit(allocator);
+        }
+    };
+
+    inline fn noFixes() Result {
+        return .{ .did_fix = false, .source = .{} };
+    }
+
+    inline fn fromFixed(fixed_source: std.ArrayListUnmanaged(u8)) Result {
+        return .{ .did_fix = true, .source = fixed_source };
+    }
+
+    fn spanStartLessThan(_: void, a: Fix, b: Fix) bool {
+        return a.span.start < b.span.start;
+    }
+};
+
+test {
+    _ = @import("./test/fix_test.zig");
+}
+
+const std = @import("std");
+const heap = std.heap;
+const mem = std.mem;
+const util = @import("util");
+
+const Allocator = std.mem.Allocator;
+const Span = @import("../span.zig").Span;
+const Cow = util.Cow(false);

--- a/src/linter/fix.zig
+++ b/src/linter/fix.zig
@@ -110,7 +110,7 @@ pub const Fixer = struct {
 
     const Diagnostic = @import("./lint_context.zig").Diagnostic;
     /// Take fixes in a set of diagnostics and apply them to a source file.
-    /// 
+    ///
     /// Diagnostics list is moved. Its items will be deinitialized.
     pub fn applyFixes(
         self: *Fixer,

--- a/src/linter/fix.zig
+++ b/src/linter/fix.zig
@@ -11,10 +11,34 @@ pub const Fix = struct {
 
     pub const Meta = packed struct {
         kind: Kind = .fix,
-        safe: bool = true,
+        dangerous: bool = false,
+
+        pub const disabled = Meta{
+            .kind = Kind.none,
+            .dangerous = false,
+        };
+
+        pub inline fn fix() Meta {
+            return Meta{ .kind = Kind.fix, .dangerous = false };
+        }
+        pub inline fn suggestion() Meta {
+            return Meta{ .kind = Kind.suggestion, .dangerous = false };
+        }
+        pub inline fn dangerousFix() Meta {
+            return Meta{ .kind = Kind.fix, .dangerous = true };
+        }
+        pub inline fn dangerousSuggestion() Meta {
+            return Meta{ .kind = Kind.suggestion, .dangerous = true };
+        }
+
+        pub fn isDisabled(self: Meta) bool {
+            // TODO: check output assembly, check if `@bitcast(self) == 0` is faster.
+            return self.kind == Kind.none;
+        }
     };
 
-    pub const Kind = enum(u1) {
+    pub const Kind = enum(u2) {
+        none,
         fix,
         suggestion,
     };
@@ -62,15 +86,17 @@ pub const Fix = struct {
 pub const Fixer = struct {
     allocator: Allocator,
 
+    const Diagnostic = @import("./lint_context.zig").Diagnostic;
+    // TODO: use a iterator yielding fixes
     pub fn applyFixes(
         self: *Fixer,
         source: [:0]const u8,
-        reported_fixes: []const Fix,
+        diagnostics: []const Diagnostic,
     ) Allocator.Error!Fixer.Result {
         // number of fixes that can be put on the stack before a heap allocation is needed
         const STACK_SIZE = 16;
 
-        util.assert(reported_fixes.len > 0, "Caller must check if fixes is empty", .{});
+        util.assert(diagnostics.len > 0, "Caller must check if fixes is empty", .{});
 
         var stackfb = heap.stackFallback(STACK_SIZE * @sizeOf(Fix), self.allocator);
         const alloc = stackfb.get();
@@ -79,12 +105,24 @@ pub const Fixer = struct {
         defer fixes.deinit();
         try fixes.ensureTotalCapacityPrecise(STACK_SIZE);
 
+        // items not allocated w stack fallback b/c error list must outlive
+        // the lifetime of this function scope.
+        var unfixed_errors = std.ArrayListUnmanaged(Error){}; //.init(self.allocator);
+        errdefer unfixed_errors.deinit(self.allocator);
+
         // filter out no-ops and sort by span start
-        for (reported_fixes) |fix| {
-            if (fix.isNoop()) continue;
+        for (diagnostics) |diagnostic| {
+            const fix: Fix = diagnostic.fix orelse {
+                try unfixed_errors.append(self.allocator, diagnostic.err);
+                continue;
+            };
+            if (fix.isNoop()) {
+                try unfixed_errors.append(self.allocator, diagnostic.err);
+                continue;
+            }
             try fixes.append(fix);
         }
-        if (fixes.items.len == 0) return noFixes();
+        if (fixes.items.len == 0) return noFixes(unfixed_errors);
         mem.sortUnstable(Fix, fixes.items, {}, spanStartLessThan);
 
         var fixed: std.ArrayListUnmanaged(u8) = .{};
@@ -93,7 +131,10 @@ pub const Fixer = struct {
 
         var last_end: u32 = 0;
         for (fixes.items) |fix| {
-            if (fix.span.start < last_end) continue;
+            if (fix.span.start < last_end) {
+                // FIXME: report diagnostic
+                continue;
+            }
             // append source up to the start of the fix
             try fixed.appendSlice(self.allocator, source[last_end..fix.span.start]);
             // append replacement, skipping the deleted/replaced section
@@ -105,33 +146,42 @@ pub const Fixer = struct {
             try fixed.appendSlice(self.allocator, source[last_end..source.len]);
         }
 
-        return fromFixed(fixed);
+        return fromFixed(fixed, unfixed_errors);
     }
 
     pub const Result = struct {
         did_fix: bool,
         source: std.ArrayListUnmanaged(u8),
+        unfixed_errors: std.ArrayListUnmanaged(Error),
 
         pub fn deinit(self: *Result, allocator: Allocator) void {
-            if (!self.did_fix) {
+            if (self.did_fix) {
+                self.source.deinit(allocator);
+            } else {
                 util.debugAssert(
                     self.source.items.len == 0,
                     "invariant violation: no-fix Result has non-empty fixed source.",
                     .{},
                 );
-                return;
             }
-
-            self.source.deinit(allocator);
+            self.unfixed_errors.deinit(allocator);
         }
     };
 
-    inline fn noFixes() Result {
-        return .{ .did_fix = false, .source = .{} };
+    inline fn noFixes(unfixed_errors: std.ArrayListUnmanaged(Error)) Result {
+        return .{
+            .did_fix = false,
+            .source = .{},
+            .unfixed_errors = unfixed_errors,
+        };
     }
 
-    inline fn fromFixed(fixed_source: std.ArrayListUnmanaged(u8)) Result {
-        return .{ .did_fix = true, .source = fixed_source };
+    inline fn fromFixed(fixed_source: std.ArrayListUnmanaged(u8), unfixed_errors: std.ArrayListUnmanaged(Error)) Result {
+        return .{
+            .did_fix = true,
+            .source = fixed_source,
+            .unfixed_errors = unfixed_errors,
+        };
     }
 
     fn spanStartLessThan(_: void, a: Fix, b: Fix) bool {
@@ -151,3 +201,5 @@ const util = @import("util");
 const Allocator = std.mem.Allocator;
 const Span = @import("../span.zig").Span;
 const Cow = util.Cow(false);
+
+const Error = @import("../Error.zig");

--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -89,67 +89,20 @@ pub inline fn labelT(
     };
 }
 
-// pub fn diagnosticFmt(
-//     self: *Context,
-//     comptime message: string,
-//     args: anytype,
-//     spans: anytype,
-// ) *Error {
-//     // TODO: inline
-//     return self._diagnostic(
-//         Error.fmt(self.gpa, message, args) catch @panic("Failed to create error message: Out of memory"),
-//         &spans,
-//     );
-// }
-
-// /// Report a Rule violation.
-// ///
-// /// Takes a short summary of the problem (a static string) and a set of
-// /// [`Span`]s (anything that can be coerced into `[]const Span`)highlighting
-// /// the problematic code. If you need to allocate memory for your `message`, use
-// /// `diagnosticFmt`.
-// ///
-// /// ## Example
-// /// ```zig
-// /// const MyRule = struct {
-// ///   pub fn runOnNode(_: *const MyRule, wrapper: NodeWrapper, ctx: *LinterContext) void {
-// ///     // check for a rule violation..
-// ///     ctx.diagnostic("This is a problem", .{ctx.spanN(wrapper.idx)});
-// ///   }
-// /// };
-// /// ```
-// ///
-// /// ### Notes
-// ///
-// /// - `spans` should not be empty (they _can_ be, but
-// ///   this is not user-friendly.).
-// /// - `spans` is anytype for more flexible coercion into a `[]const Span`
-// pub fn diagnostic(self: *Context, comptime message: string, spans: anytype) *Error {
-//     // TODO: inline
-//     return self._diagnostic(Error.newStatic(message), &spans);
-// }
-
-// fn _diagnostic(self: *Context, err: Error, spans: []const LabeledSpan) *Error {
-//     var e = err;
-//     const a = self.gpa;
-//     e.code = self.curr_rule_name;
-//     e.source_name = if (self.source.pathname) |p| a.dupe(u8, p) catch @panic("OOM") else null;
-//     e.source = self.source.contents.clone();
-//     e.severity = self.curr_severity;
-
-//     if (spans.len > 0) {
-//         e.labels.appendSlice(a, spans) catch @panic("OOM");
-//     }
-//     // TODO: handle errors better
-//     self.errors.append(e) catch @panic("Cannot add new error: Out of memory");
-//     return &self.errors.items[self.errors.items.len - 1];
-// }
-pub fn diagnostic(self: *Context, comptime message: string, spans: anytype) Error {
+/// Create a new `Error` with a static message string.
+pub fn diagnostic(
+    self: *Context,
+    /// error message
+    comptime message: string,
+    /// location(s) of the problem
+    spans: anytype,
+) Error {
     var e = Error.newStatic(message);
     e.labels.ensureTotalCapacityPrecise(self.gpa, spans.len) catch @panic("OOM");
     e.labels.appendSliceAssumeCapacity(&spans);
     return e;
 }
+/// Create a new `Error` with a formatted message
 pub fn diagnosticf(self: *Context, comptime template: []const u8, args: anytype, spans: anytype) Error {
     var e = Error.fmt(self.gpa, template, args) catch @panic("OOM");
     e.labels.ensureTotalCapacityPrecise(self.gpa, spans.len) catch @panic("OOM");

--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -89,60 +89,72 @@ pub inline fn labelT(
     };
 }
 
-pub fn diagnosticFmt(
-    self: *Context,
-    comptime message: string,
-    args: anytype,
-    spans: anytype,
-) *Error {
-    // TODO: inline
-    return self._diagnostic(
-        Error.fmt(self.gpa, message, args) catch @panic("Failed to create error message: Out of memory"),
-        &spans,
-    );
+// pub fn diagnosticFmt(
+//     self: *Context,
+//     comptime message: string,
+//     args: anytype,
+//     spans: anytype,
+// ) *Error {
+//     // TODO: inline
+//     return self._diagnostic(
+//         Error.fmt(self.gpa, message, args) catch @panic("Failed to create error message: Out of memory"),
+//         &spans,
+//     );
+// }
+
+// /// Report a Rule violation.
+// ///
+// /// Takes a short summary of the problem (a static string) and a set of
+// /// [`Span`]s (anything that can be coerced into `[]const Span`)highlighting
+// /// the problematic code. If you need to allocate memory for your `message`, use
+// /// `diagnosticFmt`.
+// ///
+// /// ## Example
+// /// ```zig
+// /// const MyRule = struct {
+// ///   pub fn runOnNode(_: *const MyRule, wrapper: NodeWrapper, ctx: *LinterContext) void {
+// ///     // check for a rule violation..
+// ///     ctx.diagnostic("This is a problem", .{ctx.spanN(wrapper.idx)});
+// ///   }
+// /// };
+// /// ```
+// ///
+// /// ### Notes
+// ///
+// /// - `spans` should not be empty (they _can_ be, but
+// ///   this is not user-friendly.).
+// /// - `spans` is anytype for more flexible coercion into a `[]const Span`
+// pub fn diagnostic(self: *Context, comptime message: string, spans: anytype) *Error {
+//     // TODO: inline
+//     return self._diagnostic(Error.newStatic(message), &spans);
+// }
+
+// fn _diagnostic(self: *Context, err: Error, spans: []const LabeledSpan) *Error {
+//     var e = err;
+//     const a = self.gpa;
+//     e.code = self.curr_rule_name;
+//     e.source_name = if (self.source.pathname) |p| a.dupe(u8, p) catch @panic("OOM") else null;
+//     e.source = self.source.contents.clone();
+//     e.severity = self.curr_severity;
+
+//     if (spans.len > 0) {
+//         e.labels.appendSlice(a, spans) catch @panic("OOM");
+//     }
+//     // TODO: handle errors better
+//     self.errors.append(e) catch @panic("Cannot add new error: Out of memory");
+//     return &self.errors.items[self.errors.items.len - 1];
+// }
+pub fn diagnostic(self: *Context, comptime message: string, spans: anytype) Error {
+    var e = Error.newStatic(message);
+    e.labels.ensureTotalCapacityPrecise(self.gpa, spans.len) catch @panic("OOM");
+    e.labels.appendSliceAssumeCapacity(&spans);
+    return e;
 }
-
-/// Report a Rule violation.
-///
-/// Takes a short summary of the problem (a static string) and a set of
-/// [`Span`]s (anything that can be coerced into `[]const Span`)highlighting
-/// the problematic code. If you need to allocate memory for your `message`, use
-/// `diagnosticFmt`.
-///
-/// ## Example
-/// ```zig
-/// const MyRule = struct {
-///   pub fn runOnNode(_: *const MyRule, wrapper: NodeWrapper, ctx: *LinterContext) void {
-///     // check for a rule violation..
-///     ctx.diagnostic("This is a problem", .{ctx.spanN(wrapper.idx)});
-///   }
-/// };
-/// ```
-///
-/// ### Notes
-///
-/// - `spans` should not be empty (they _can_ be, but
-///   this is not user-friendly.).
-/// - `spans` is anytype for more flexible coercion into a `[]const Span`
-pub fn diagnostic(self: *Context, comptime message: string, spans: anytype) *Error {
-    // TODO: inline
-    return self._diagnostic(Error.newStatic(message), &spans);
-}
-
-fn _diagnostic(self: *Context, err: Error, spans: []const LabeledSpan) *Error {
-    var e = err;
-    const a = self.gpa;
-    e.code = self.curr_rule_name;
-    e.source_name = if (self.source.pathname) |p| a.dupe(u8, p) catch @panic("OOM") else null;
-    e.source = self.source.contents.clone();
-    e.severity = self.curr_severity;
-
-    if (spans.len > 0) {
-        e.labels.appendSlice(a, spans) catch @panic("OOM");
-    }
-    // TODO: handle errors better
-    self.errors.append(e) catch @panic("Cannot add new error: Out of memory");
-    return &self.errors.items[self.errors.items.len - 1];
+pub fn diagnosticf(self: *Context, comptime template: []const u8, args: anytype, spans: anytype) Error {
+    var e = Error.fmt(self.gpa, template, args) catch @panic("OOM");
+    e.labels.ensureTotalCapacityPrecise(self.gpa, spans.len) catch @panic("OOM");
+    e.labels.appendSliceAssumeCapacity(&spans);
+    return e;
 }
 
 /// Report a problem found in a source file.
@@ -184,13 +196,14 @@ pub fn reportWithFix(self: *Context, diagnostic_: Error, fixer: *FixerFn) void {
 }
 
 fn _report(self: *Context, diagnostic_: Diagnostic) void {
-    var e = &diagnostic_.err;
+    var d = diagnostic_;
+    var e = &d.err;
     e.code = self.curr_rule_name;
     e.source_name = if (self.source.pathname) |p| self.gpa.dupe(u8, p) catch @panic("OOM") else null;
     e.source = self.source.contents.clone();
     e.severity = self.curr_severity;
     // TODO: handle errors better
-    self.errors.append(e) catch @panic("Cannot add new error: Out of memory");
+    self.errors.append(d.err) catch @panic("Cannot add new error: Out of memory");
 }
 
 /// Find the comment block ending on the line before the given token.
@@ -228,7 +241,7 @@ pub fn deinit(self: *Context) void {
 pub const Diagnostic = struct {
     err: Error,
     // fix: ?Fix = null,
-    fixer: ?*FixerFn,
+    fixer: ?*FixerFn = null,
 };
 
 pub const ErrorList = std.ArrayList(Error);

--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -153,9 +153,9 @@ pub fn report(self: *Context, diagnostic_: Error) void {
 pub fn reportWithFix(self: *Context, diagnostic_: Error, fixer: *FixerFn) void {
     if (self.fix.isDisabled()) return self._report(Diagnostic{ .err = diagnostic_ });
 
-    const fix_builder = Fix.Builder{ .allocator = self.gpa, .meta = .{ .kind = .fix }};
+    const fix_builder = Fix.Builder{ .allocator = self.gpa, .meta = .{ .kind = .fix } };
     const fix: Fix = @call(.never_inline, fixer, .{fix_builder}) catch |e| {
-        std.debug.panic("Fixer for rule \"{s}\" failed: {s}", .{self.curr_rule_name, @errorName(e) });
+        std.debug.panic("Fixer for rule \"{s}\" failed: {s}", .{ self.curr_rule_name, @errorName(e) });
     };
 
     self._report(Diagnostic{ .err = diagnostic_, .fix = fix });

--- a/src/linter/rule.zig
+++ b/src/linter/rule.zig
@@ -7,6 +7,7 @@ const Ast = std.zig.Ast;
 const string = util.string;
 const Symbol = semantic.Symbol;
 const Severity = @import("../Error.zig").Severity;
+const Fix = @import("./fix.zig").Fix;
 
 const LinterContext = @import("lint_context.zig");
 
@@ -47,7 +48,13 @@ pub const Rule = struct {
     pub const Meta = struct {
         name: string,
         category: Category,
+        /// Default severity when no config file is provided. Rules that are
+        /// `.off` do not get run at all.
         default: Severity = .off,
+        /// Advertise auto-fixing capabilities to users.
+        ///
+        /// Used (in part) when generating documentation.
+        fix: Fix.Meta = Fix.Meta.disabled,
     };
 
     pub const Category = enum {

--- a/src/linter/rules/homeless_try.zig
+++ b/src/linter/rules/homeless_try.zig
@@ -71,7 +71,6 @@ const Node = Ast.Node;
 const Symbol = semantic.Symbol;
 const Scope = semantic.Scope;
 const Loc = std.zig.Loc;
-const Span = _source.Span;
 const LinterContext = @import("../lint_context.zig");
 const Rule = _rule.Rule;
 const NodeWrapper = _rule.NodeWrapper;
@@ -82,15 +81,6 @@ fn notInFnDiagnostic(ctx: *LinterContext, node: Node.Index) Error {
     return ctx.diagnostic("`try` cannot be used outside of a function or test block.", .{
         ctx.labelT(ctx.ast().firstToken(node), "there is nowhere to propagate errors to.", .{}),
     });
-    // var e = Error.newStatic("`try` cannot be used outside of a function or test block.");
-    // e.labels.append()
-
-    // _ = ctx.diagnostic(
-    //     "`try` cannot be used outside of a function.",
-    //     .{
-    //         ctx.labelT(ctx.ast().firstToken(wrapper.idx), "there is nowhere to propagate errors to.", .{}),
-    //     },
-    // );
 }
 
 // Rule metadata

--- a/src/linter/rules/no_catch_return.zig
+++ b/src/linter/rules/no_catch_return.zig
@@ -49,7 +49,6 @@ const Token = std.zig.Token;
 const TokenIndex = Ast.TokenIndex;
 const Symbol = semantic.Symbol;
 const Loc = std.zig.Loc;
-const Span = _source.Span;
 const LinterContext = @import("../lint_context.zig");
 const Rule = _rule.Rule;
 const NodeWrapper = _rule.NodeWrapper;

--- a/src/linter/rules/no_return_try.zig
+++ b/src/linter/rules/no_return_try.zig
@@ -53,6 +53,7 @@ const LinterContext = @import("../lint_context.zig");
 const LabeledSpan = _span.LabeledSpan;
 const Rule = _rule.Rule;
 const NodeWrapper = _rule.NodeWrapper;
+const Error = @import("../../Error.zig");
 const Cow = util.Cow(false);
 
 // Rule metadata
@@ -62,6 +63,13 @@ pub const meta: Rule.Meta = .{
     .category = .pedantic,
     .default = .warning,
 };
+
+fn returnTryDiagnostic(ctx: *LinterContext, return_start: u32, try_start: u32) Error {
+    const span = LabeledSpan.unlabeled(return_start, try_start + 3);
+    var e = ctx.diagnostic("This error union can be directly returned.", .{span});
+    e.help = Cow.static("Replace `return try` with `return`");
+    return e;
+}
 
 // Runs on each node in the AST. Useful for syntax-based rules.
 pub fn runOnNode(_: *const NoReturnTry, wrapper: NodeWrapper, ctx: *LinterContext) void {
@@ -76,12 +84,7 @@ pub fn runOnNode(_: *const NoReturnTry, wrapper: NodeWrapper, ctx: *LinterContex
     const starts = ast.tokens.items(.start);
     const return_start = starts[node.main_token];
     const try_start = starts[ast.nodes.items(.main_token)[returned_id]];
-    const span = LabeledSpan.unlabeled(
-        return_start,
-        try_start + 3,
-    );
-    const e = ctx.diagnostic("This error union can be directly returned.", .{span});
-    e.help = Cow.static("Replace `return try` with `return`");
+    ctx.report(returnTryDiagnostic(ctx, return_start, try_start));
 }
 
 pub fn rule(self: *NoReturnTry) Rule {

--- a/src/linter/rules/no_return_try.zig
+++ b/src/linter/rules/no_return_try.zig
@@ -48,7 +48,6 @@ const Ast = std.zig.Ast;
 const Node = Ast.Node;
 const Symbol = semantic.Symbol;
 const Loc = std.zig.Loc;
-const Span = _source.Span;
 const LinterContext = @import("../lint_context.zig");
 const LabeledSpan = _span.LabeledSpan;
 const Rule = _rule.Rule;

--- a/src/linter/rules/no_undefined.zig
+++ b/src/linter/rules/no_undefined.zig
@@ -69,7 +69,6 @@ const Ast = std.zig.Ast;
 const Node = Ast.Node;
 const TokenIndex = Ast.TokenIndex;
 const Loc = std.zig.Loc;
-const Span = source.Span;
 const LinterContext = @import("../lint_context.zig");
 const Rule = @import("../rule.zig").Rule;
 const NodeWrapper = @import("../rule.zig").NodeWrapper;

--- a/src/linter/rules/no_undefined.zig
+++ b/src/linter/rules/no_undefined.zig
@@ -67,11 +67,13 @@ const source = @import("../../source.zig");
 const Semantic = @import("../../semantic.zig").Semantic;
 const Ast = std.zig.Ast;
 const Node = Ast.Node;
+const TokenIndex = Ast.TokenIndex;
 const Loc = std.zig.Loc;
 const Span = source.Span;
 const LinterContext = @import("../lint_context.zig");
 const Rule = @import("../rule.zig").Rule;
 const NodeWrapper = @import("../rule.zig").NodeWrapper;
+const Error = @import("../../Error.zig");
 const Cow = util.Cow(false);
 
 allow_arrays: bool = true,
@@ -82,6 +84,12 @@ pub const meta: Rule.Meta = .{
     .category = .restriction,
     .default = .warning,
 };
+
+fn undefinedMissingSafetyComment(ctx: *LinterContext, undefined_tok: TokenIndex) Error {
+    var e = ctx.diagnostic("`undefined` is missing a safety comment", .{ctx.spanT(undefined_tok)});
+    e.help = Cow.static("Add a `SAFETY: <reason>` before this line explaining why this code is safe.");
+    return e;
+}
 
 pub fn runOnNode(self: *const NoUndefined, wrapper: NodeWrapper, ctx: *LinterContext) void {
     const node = wrapper.node;
@@ -113,8 +121,7 @@ pub fn runOnNode(self: *const NoUndefined, wrapper: NodeWrapper, ctx: *LinterCon
         }
     }
 
-    const e = ctx.diagnostic("`undefined` is missing a safety comment", .{ctx.spanT(node.main_token)});
-    e.help = Cow.static("Add a `SAFETY: <reason>` before this line explaining why this code is safe.");
+    ctx.report(undefinedMissingSafetyComment(ctx, node.main_token));
 }
 
 pub fn rule(self: *NoUndefined) Rule {

--- a/src/linter/rules/no_unresolved.zig
+++ b/src/linter/rules/no_unresolved.zig
@@ -40,7 +40,6 @@ const _source = @import("../../source.zig");
 const Ast = std.zig.Ast;
 const Node = Ast.Node;
 const Loc = std.zig.Loc;
-const Span = _source.Span;
 const LinterContext = @import("../lint_context.zig");
 const Rule = @import("../rule.zig").Rule;
 const NodeWrapper = @import("../rule.zig").NodeWrapper;

--- a/src/linter/rules/no_unresolved.zig
+++ b/src/linter/rules/no_unresolved.zig
@@ -62,10 +62,11 @@ pub fn runOnNode(_: *const NoUnresolved, wrapper: NodeWrapper, ctx: *LinterConte
         return;
     }
     if (node.data.lhs == 0) {
-        _ = ctx.diagnostic(
+        ctx.report(ctx.diagnostic(
             "Call to `@import()` has no file path or module name.",
             .{ctx.spanN(wrapper.idx)},
-        );
+        ));
+        return;
     }
 
     const tags: []Ast.Node.Tag = ctx.ast().nodes.items(.tag);
@@ -73,7 +74,7 @@ pub fn runOnNode(_: *const NoUnresolved, wrapper: NodeWrapper, ctx: *LinterConte
 
     // Note: this will get caught by ast check
     if (tags[node.data.lhs] != .string_literal) {
-        _ = ctx.diagnostic("@import operand must be a string literal", .{ctx.spanN(node.data.lhs)});
+        ctx.report(ctx.diagnostic("@import operand must be a string literal", .{ctx.spanN(node.data.lhs)}));
         return;
     }
     const pathname_str = ctx.semantic.tokenSlice(main_tokens[node.data.lhs]);
@@ -99,19 +100,19 @@ pub fn runOnNode(_: *const NoUnresolved, wrapper: NodeWrapper, ctx: *LinterConte
         // TODO: use absolute paths and cache stat results.
         // depends on: https://github.com/DonIsaac/zlint/issues/81
         const stat = dir.statFile(pathname) catch {
-            _ = ctx.diagnosticFmt(
+            ctx.report(ctx.diagnosticf(
                 "Unresolved import to '{s}'",
                 .{pathname},
                 .{ctx.spanN(node.data.lhs)},
-            );
+            ));
             return;
         };
         if (stat.kind == .directory) {
-            _ = ctx.diagnosticFmt(
+            ctx.report(ctx.diagnosticf(
                 "Unresolved import to directory '{s}'",
                 .{pathname},
                 .{ctx.spanN(node.data.lhs)},
-            );
+            ));
         }
     }
 }

--- a/src/linter/rules/snapshots/homeless-try.snap
+++ b/src/linter/rules/snapshots/homeless-try.snap
@@ -10,7 +10,7 @@
    ╰────
   help: Change the return type to `!void`.
 
-  𝙭 homeless-try: `try` cannot be used outside of a function.
+  𝙭 homeless-try: `try` cannot be used outside of a function or test block.
    ╭─[homeless-try.zig:2:11]
  1 │ const std = @import("std");
  2 │ const x = try std.heap.page_allocator.alloc(u8, 8);
@@ -18,7 +18,7 @@
    ·            ╰── there is nowhere to propagate errors to.
    ╰────
 
-  𝙭 homeless-try: `try` cannot be used outside of a function.
+  𝙭 homeless-try: `try` cannot be used outside of a function or test block.
    ╭─[homeless-try.zig:4:17]
  3 │   const Bar = struct {
  4 │     baz: []u8 = try std.heap.page_allocator.alloc(u8, 8),

--- a/src/linter/rules/unused_decls.zig
+++ b/src/linter/rules/unused_decls.zig
@@ -107,11 +107,11 @@ pub fn runOnSymbol(_: *const UnusedDecls, symbol: Symbol.Id, ctx: *LinterContext
     if (!scope.eql(semantic.Semantic.ROOT_SCOPE_ID)) return;
 
     if (flags.s_variable and flags.s_const) {
-        _ = ctx.diagnosticFmt(
+        ctx.report(ctx.diagnosticf(
             "variable '{s}' is declared but never used.",
             .{name},
             .{ctx.spanT(slice.items(.token)[s].unwrap().?.int())},
-        );
+        ));
         return;
     }
 }

--- a/src/linter/rules/unused_decls.zig
+++ b/src/linter/rules/unused_decls.zig
@@ -55,7 +55,6 @@ const Node = Ast.Node;
 const Symbol = semantic.Symbol;
 const Scope = semantic.Scope;
 const Loc = std.zig.Loc;
-const Span = _source.Span;
 const LinterContext = @import("../lint_context.zig");
 const Rule = _rule.Rule;
 const NodeWrapper = _rule.NodeWrapper;

--- a/src/linter/test/fix_test.zig
+++ b/src/linter/test/fix_test.zig
@@ -1,0 +1,156 @@
+const std = @import("std");
+const util = @import("util");
+const fix = @import("../fix.zig");
+
+const Cow = util.Cow(false);
+
+const t = std.testing;
+const expect = t.expect;
+const expectEqual = t.expectEqual;
+const expectEqualStrings = t.expectEqualStrings;
+
+test "inserting at start of file" {
+    var fixer = fix.Fixer{ .allocator = t.allocator };
+    const src = "const x = 1;";
+
+    {
+        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+            .{
+                .span = .{ .start = 0, .end = 0 },
+                .replacement = Cow.static("const y = 2;"),
+            },
+        });
+        defer res.deinit(t.allocator);
+        try expect(res.did_fix);
+        try expectEqualStrings(
+            "const y = 2;const x = 1;",
+            res.source.items,
+        );
+    }
+
+    {
+        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+            .{
+                .span = .{ .start = 0, .end = 0 },
+                .replacement = Cow.static("const y = 2;\n"),
+            },
+            .{
+                .span = .{ .start = 0, .end = 0 },
+                .replacement = Cow.static("const z = 3;\n"),
+            },
+        });
+        defer res.deinit(t.allocator);
+        try expect(res.did_fix);
+        try expectEqualStrings(
+            "const y = 2;\nconst z = 3;\nconst x = 1;",
+            res.source.items,
+        );
+    }
+}
+
+test "deleting a section" {
+    var fixer = fix.Fixer{ .allocator = t.allocator };
+    const src = "const x = 1; const y = 2; const z = 3;";
+
+    {
+        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+            .{
+                .span = .{ .start = 0, .end = src.len },
+                .replacement = Cow.static(""),
+            },
+        });
+        defer res.deinit(t.allocator);
+        try expect(res.did_fix);
+        try expectEqualStrings("", res.source.items);
+    }
+
+    {
+        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+            .{
+                .span = .{ .start = 0, .end = 13 },
+                .replacement = Cow.static(""),
+            },
+        });
+        defer res.deinit(t.allocator);
+        try expect(res.did_fix);
+        try expectEqualStrings("const y = 2; const z = 3;", res.source.items);
+    }
+
+    {
+        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+            .{
+                .span = .{ .start = 13, .end = 26 },
+                .replacement = Cow.static(""),
+            },
+        });
+        defer res.deinit(t.allocator);
+        try expect(res.did_fix);
+        try expectEqualStrings("const x = 1; const z = 3;", res.source.items);
+    }
+
+    {
+        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+            .{
+                .span = .{ .start = 25, .end = src.len },
+                .replacement = Cow.static(""),
+            },
+        });
+        defer res.deinit(t.allocator);
+        try expect(res.did_fix);
+        try expectEqualStrings("const x = 1; const y = 2;", res.source.items);
+    }
+}
+
+test "replacing a section" {
+    var fixer = fix.Fixer{ .allocator = t.allocator };
+    const src = "const x = 1; const y = 2; const z = 3;";
+
+    {
+        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+            .{
+                .span = .{ .start = 0, .end = 12 },
+                .replacement = Cow.static("const a = 4;"),
+            },
+        });
+        defer res.deinit(t.allocator);
+        try expect(res.did_fix);
+        try expectEqualStrings("const a = 4; const y = 2; const z = 3;", res.source.items);
+    }
+
+    {
+        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+            .{
+                .span = .{ .start = 13, .end = 25 },
+                .replacement = Cow.static("const b = 5;"),
+            },
+        });
+        defer res.deinit(t.allocator);
+        try expect(res.did_fix);
+        try expectEqualStrings("const x = 1; const b = 5; const z = 3;", res.source.items);
+    }
+
+    {
+        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+            .{
+                .span = .{ .start = 26, .end = src.len },
+                .replacement = Cow.static("const c = 6;"),
+            },
+        });
+        defer res.deinit(t.allocator);
+        try expect(res.did_fix);
+        try expectEqualStrings("const x = 1; const y = 2; const c = 6;", res.source.items);
+    }
+}
+
+test "noop fixes" {
+    var fixer = fix.Fixer{ .allocator = t.allocator };
+    const source = "const x = 1;";
+    const builder = fix.Fix.Builder{ .allocator = t.allocator };
+    const f = builder.noop();
+    try expect(f.isNoop());
+
+    var res = try fixer.applyFixes(source, &[_]fix.Fix{builder.noop()});
+    defer res.deinit(t.allocator);
+    try expect(!res.did_fix);
+    try expectEqual(0, res.source.items.len);
+}

--- a/src/linter/test/fix_test.zig
+++ b/src/linter/test/fix_test.zig
@@ -164,7 +164,7 @@ test "replacing a section" {
 test "noop fixes" {
     var fixer = fix.Fixer{ .allocator = t.allocator };
     const source = "const x = 1;";
-    const builder = fix.Fix.Builder{ .allocator = t.allocator };
+    const builder = fix.Fix.Builder{ .allocator = t.allocator, .ctx = undefined };
     const f = builder.noop();
     try expect(f.isNoop());
 

--- a/src/linter/test/fix_test.zig
+++ b/src/linter/test/fix_test.zig
@@ -10,17 +10,34 @@ const expect = t.expect;
 const expectEqual = t.expectEqual;
 const expectEqualStrings = t.expectEqualStrings;
 
+const Diagnostic = @import("../lint_context.zig").Diagnostic;
+const Error = @import("../../Error.zig");
+
+const fake_err = Error.newStatic("oops");
+inline fn toDiagnostic(comptime fixes: anytype) []const Diagnostic {
+    // yes this returns a slice to a stack-allocated array. Yes its fine, because
+    // this function is inlined.
+    var diagnostics: [fixes.len]Diagnostic = undefined;
+    inline for (fixes, 0..) |f, i| {
+        var d = &diagnostics[i];
+        d.fix = f;
+        d.err = fake_err;
+    }
+
+    return diagnostics[0..fixes.len];
+}
+
 test "inserting at start of file" {
     var fixer = fix.Fixer{ .allocator = t.allocator };
     const src = "const x = 1;";
 
     {
-        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+        var res = try fixer.applyFixes(src, toDiagnostic([_]fix.Fix{
             .{
                 .span = .{ .start = 0, .end = 0 },
                 .replacement = Cow.static("const y = 2;"),
             },
-        });
+        }));
         defer res.deinit(t.allocator);
         try expect(res.did_fix);
         try expectEqualStrings(
@@ -30,7 +47,7 @@ test "inserting at start of file" {
     }
 
     {
-        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+        var res = try fixer.applyFixes(src, toDiagnostic([_]fix.Fix{
             .{
                 .span = .{ .start = 0, .end = 0 },
                 .replacement = Cow.static("const y = 2;\n"),
@@ -39,7 +56,7 @@ test "inserting at start of file" {
                 .span = .{ .start = 0, .end = 0 },
                 .replacement = Cow.static("const z = 3;\n"),
             },
-        });
+        }));
         defer res.deinit(t.allocator);
         try expect(res.did_fix);
         try expectEqualStrings(
@@ -54,48 +71,48 @@ test "deleting a section" {
     const src = "const x = 1; const y = 2; const z = 3;";
 
     {
-        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+        var res = try fixer.applyFixes(src, toDiagnostic([_]fix.Fix{
             .{
                 .span = .{ .start = 0, .end = src.len },
                 .replacement = Cow.static(""),
             },
-        });
+        }));
         defer res.deinit(t.allocator);
         try expect(res.did_fix);
         try expectEqualStrings("", res.source.items);
     }
 
     {
-        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+        var res = try fixer.applyFixes(src, toDiagnostic([_]fix.Fix{
             .{
                 .span = .{ .start = 0, .end = 13 },
                 .replacement = Cow.static(""),
             },
-        });
+        }));
         defer res.deinit(t.allocator);
         try expect(res.did_fix);
         try expectEqualStrings("const y = 2; const z = 3;", res.source.items);
     }
 
     {
-        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+        var res = try fixer.applyFixes(src, toDiagnostic([_]fix.Fix{
             .{
                 .span = .{ .start = 13, .end = 26 },
                 .replacement = Cow.static(""),
             },
-        });
+        }));
         defer res.deinit(t.allocator);
         try expect(res.did_fix);
         try expectEqualStrings("const x = 1; const z = 3;", res.source.items);
     }
 
     {
-        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+        var res = try fixer.applyFixes(src, toDiagnostic([_]fix.Fix{
             .{
                 .span = .{ .start = 25, .end = src.len },
                 .replacement = Cow.static(""),
             },
-        });
+        }));
         defer res.deinit(t.allocator);
         try expect(res.did_fix);
         try expectEqualStrings("const x = 1; const y = 2;", res.source.items);
@@ -104,37 +121,40 @@ test "deleting a section" {
 
 test "replacing a section" {
     var fixer = fix.Fixer{ .allocator = t.allocator };
-    var builder = fix.Fix.Builder{ .allocator = t.allocator };
+    // var builder = fix.Fix.Builder{ .allocator = t.allocator };
     const src = "const x = 1; const y = 2; const z = 3;";
 
     {
-        var res = try fixer.applyFixes(src, &[_]fix.Fix{
-            builder.replace(Span.new(0, 12), Cow.static("const a = 4;")),
-        });
+        var res = try fixer.applyFixes(src, toDiagnostic([_]fix.Fix{
+        // comptime builder.replace(Span.new(0, 12), Cow.static("const a = 4;")),
+        .{
+            .span = Span.new(0, 12),
+            .replacement = Cow.static("const a = 4;"),
+        }}));
         defer res.deinit(t.allocator);
         try expect(res.did_fix);
         try expectEqualStrings("const a = 4; const y = 2; const z = 3;", res.source.items);
     }
 
     {
-        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+        var res = try fixer.applyFixes(src, toDiagnostic([_]fix.Fix{
             .{
                 .span = .{ .start = 13, .end = 25 },
                 .replacement = Cow.static("const b = 5;"),
             },
-        });
+        }));
         defer res.deinit(t.allocator);
         try expect(res.did_fix);
         try expectEqualStrings("const x = 1; const b = 5; const z = 3;", res.source.items);
     }
 
     {
-        var res = try fixer.applyFixes(src, &[_]fix.Fix{
+        var res = try fixer.applyFixes(src, toDiagnostic([_]fix.Fix{
             .{
                 .span = .{ .start = 26, .end = src.len },
                 .replacement = Cow.static("const c = 6;"),
             },
-        });
+        }));
         defer res.deinit(t.allocator);
         try expect(res.did_fix);
         try expectEqualStrings("const x = 1; const y = 2; const c = 6;", res.source.items);
@@ -148,7 +168,7 @@ test "noop fixes" {
     const f = builder.noop();
     try expect(f.isNoop());
 
-    var res = try fixer.applyFixes(source, &[_]fix.Fix{builder.noop()});
+    var res = try fixer.applyFixes(source, toDiagnostic([_]fix.Fix{builder.noop()}));
     defer res.deinit(t.allocator);
     try expect(!res.did_fix);
     try expectEqual(0, res.source.items.len);

--- a/src/linter/test/fix_test.zig
+++ b/src/linter/test/fix_test.zig
@@ -3,6 +3,7 @@ const util = @import("util");
 const fix = @import("../fix.zig");
 
 const Cow = util.Cow(false);
+const Span = @import("../../span.zig").Span;
 
 const t = std.testing;
 const expect = t.expect;
@@ -103,14 +104,12 @@ test "deleting a section" {
 
 test "replacing a section" {
     var fixer = fix.Fixer{ .allocator = t.allocator };
+    var builder = fix.Fix.Builder{ .allocator = t.allocator };
     const src = "const x = 1; const y = 2; const z = 3;";
 
     {
         var res = try fixer.applyFixes(src, &[_]fix.Fix{
-            .{
-                .span = .{ .start = 0, .end = 12 },
-                .replacement = Cow.static("const a = 4;"),
-            },
+            builder.replace(Span.new(0, 12), Cow.static("const a = 4;")),
         });
         defer res.deinit(t.allocator);
         try expect(res.did_fix);

--- a/src/semantic/Semantic.zig
+++ b/src/semantic/Semantic.zig
@@ -51,6 +51,10 @@ pub fn tokenSlice(self: *const Semantic, token: TokenIndex) []const u8 {
     return self.ast.source[loc.start..loc.end];
 }
 
+pub fn tokenSpan(self: *const Semantic, token: TokenIndex) Span {
+    return Span.from(self.tokens.items(.loc)[token]);
+}
+
 /// Find the symbol bound to an identifier name that was declared in some scope.
 ///
 /// To find a binding that is referrable within a scope, but that may not have
@@ -95,6 +99,7 @@ const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const Ast = std.zig.Ast;
 const Type = std.builtin.Type;
+const Span = @import("../span.zig").Span;
 const assert = std.debug.assert;
 
 const _ast = @import("./ast.zig");

--- a/src/source.zig
+++ b/src/source.zig
@@ -16,13 +16,12 @@ pub const Source = struct {
     contents: ArcStr,
     pathname: ?string = null,
     gpa: Allocator,
-    fd: ?fs.File,
 
     /// Create a source from an opened file. This file must be opened with at least read permissions.
     ///
     /// Both `file` and `pathname` are moved into the source.
     pub fn init(gpa: Allocator, file: fs.File, pathname: ?string) !Source {
-        errdefer file.close();
+        defer file.close();
         const meta = try file.metadata();
         const contents = try gpa.allocSentinel(u8, meta.size(), 0);
         errdefer gpa.free(contents);
@@ -33,7 +32,6 @@ pub const Source = struct {
             .contents = try ArcStr.init(gpa, contents),
             .pathname = pathname,
             .gpa = gpa,
-            .fd = file,
         };
     }
     /// Create a source file directly from a string. Takes ownership of both
@@ -46,7 +44,6 @@ pub const Source = struct {
             .contents = contents_arc,
             .pathname = pathname,
             .gpa = gpa,
-            .fd = null,
         };
     }
 
@@ -57,7 +54,6 @@ pub const Source = struct {
     pub fn deinit(self: *Source) void {
         self.contents.deinit();
         if (self.pathname) |p| self.gpa.free(p);
-        if (self.fd) |f| f.close();
         self.* = undefined;
     }
 };

--- a/src/span.zig
+++ b/src/span.zig
@@ -52,6 +52,8 @@ pub const Span = struct {
     start: u32,
     end: u32,
 
+    pub const EMPTY = Span{ .start = 0, .end = 0 };
+
     pub inline fn new(start: u32, end: u32) Span {
         assert(end >= start);
         return .{ .start = start, .end = end };


### PR DESCRIPTION
## What This PR Does
Part of #183.

Adds automatic fixing capabilities. Lint rules may now provide a fixer function when they report an error that, when applied to the linted source, will fix the violation that was found.

This PR also adds an auto-fixer to `no-catch-return`.

- Testing infrastructure will be added in a follow-up pr. It is blocked by the upcoming LintService refactor
- Rule docgen still needs to be updated to include fix info in rule documentation. Again, will be added in an upcoming PR.