### PR TITLE
fix(linter): multiple file level directives

### DIFF
--- a/src/linter.zig
+++ b/src/linter.zig
@@ -290,7 +290,7 @@ pub const Linter = struct {
         // no rules will be matched if disable directives are misused or rule
         // names are misspelled (e.g. `zlint-disable not-a-rule`). In this case,
         // no rules are disabled so we just run them all.
-        return if (i == 0) configured_rules else rulebuf[0..i];
+        return rulebuf[0..i];
     }
 
     pub const LintError = error{

--- a/src/linter/disable_directives/Parser.zig
+++ b/src/linter/disable_directives/Parser.zig
@@ -181,43 +181,25 @@ test parse {
     const TestCase = Tuple(&[_]type{ []const u8, ?DisableDirectiveComment, ExpectedDisableDisableDirectives });
     const cases = &[_]TestCase{
         // global directives
-        TestCase{
-            "//zlint-disable",
-            .{ .kind = .global, .span = .{ .start = 0, .end = 15 } }, &[_][]const u8{} },
-        TestCase{
-            "// zlint-disable",
-            .{ .kind = .global, .span = .{ .start = 0, .end = 16 } }, &[_][]const u8{} },
-        TestCase{
-            "// zlint-disable -- no-undefined",
-            .{ .kind = .global, .span = .{ .start = 0, .end = 16 } }, &[_][]const u8{} },
-        TestCase{
-            "// zlint-disable no-undefined",
-            .{
-                .kind = .global,
-                .span = .{ .start = 0, .end = 29 },
-                .disabled_rules = @constCast(&[_]Span{Span.new(17, 29)}),
-            },
-            &[_][]const u8{
-                "no-undefined",
-            }
-        },
-        TestCase{
-            "// zlint-disable foo bar baz",
-            .{
-                .kind = .global,
-                .span = .{ .start = 0, .end = 28 },
-                .disabled_rules = @constCast(&[_]Span{
-                    Span.new(17, 20),
-                    Span.new(21, 24),
-                    Span.new(25, 28),
-                }),
-            },
-            &[_][]const u8{
-                "foo",
-                "bar",
-                "baz"
-            }
-        },
+        TestCase{ "//zlint-disable", .{ .kind = .global, .span = .{ .start = 0, .end = 15 } }, &[_][]const u8{} },
+        TestCase{ "// zlint-disable", .{ .kind = .global, .span = .{ .start = 0, .end = 16 } }, &[_][]const u8{} },
+        TestCase{ "// zlint-disable -- no-undefined", .{ .kind = .global, .span = .{ .start = 0, .end = 16 } }, &[_][]const u8{} },
+        TestCase{ "// zlint-disable no-undefined", .{
+            .kind = .global,
+            .span = .{ .start = 0, .end = 29 },
+            .disabled_rules = @constCast(&[_]Span{Span.new(17, 29)}),
+        }, &[_][]const u8{
+            "no-undefined",
+        } },
+        TestCase{ "// zlint-disable foo bar baz", .{
+            .kind = .global,
+            .span = .{ .start = 0, .end = 28 },
+            .disabled_rules = @constCast(&[_]Span{
+                Span.new(17, 20),
+                Span.new(21, 24),
+                Span.new(25, 28),
+            }),
+        }, &[_][]const u8{ "foo", "bar", "baz" } },
     };
 
     for (cases) |case| {
@@ -234,7 +216,7 @@ test parse {
             for (0.., expected_disabled_directives) |idx, expected_disabled_directive| {
                 try t.expectEqualStrings(
                     expected_disabled_directive,
-                    source[a.disabled_rules[idx].start  .. a.disabled_rules[idx].end],
+                    source[a.disabled_rules[idx].start..a.disabled_rules[idx].end],
                 );
             }
 

--- a/src/linter/disable_directives/Parser.zig
+++ b/src/linter/disable_directives/Parser.zig
@@ -97,8 +97,7 @@ pub fn parse(self: *DisableDirectivesParser, allocator: Allocator, line_comment:
                 else => break,
             }
         }
-        self.cursor = @min(self.cursor + 1, self.span.end);
-        // try self.rules.append(alloc, self.source[start..self.cursor]);
+        self.cursor = @min(self.cursor, self.span.end);
         try self.rules.append(alloc, Span.new(@intCast(start), @intCast(self.cursor)));
         self.eat(',') orelse {};
         self.eatWhitespace();
@@ -198,8 +197,8 @@ test parse {
                 .kind = .global,
                 .span = .{ .start = 0, .end = 28 },
                 .disabled_rules = @constCast(&[_]Span{
-                    Span.new(17, 21),
-                    Span.new(21, 25),
+                    Span.new(17, 20),
+                    Span.new(21, 24),
                     Span.new(25, 28),
                 }),
             },

--- a/src/linter/disable_directives/Parser_test.zig
+++ b/src/linter/disable_directives/Parser_test.zig
@@ -117,8 +117,8 @@ test "disabling specific rules" {
                 .kind = .global,
                 .span = NULL_SPAN,
                 .disabled_rules = @constCast(&[_]Span{
-                    Span.new(17, 21),
-                    Span.new(21, 25),
+                    Span.new(17, 20),
+                    Span.new(21, 24),
                     Span.new(25, 28),
                 }),
             },
@@ -129,8 +129,8 @@ test "disabling specific rules" {
                 .kind = .global,
                 .span = NULL_SPAN,
                 .disabled_rules = @constCast(&[_]Span{
-                    Span.new(17, 21),
-                    Span.new(22, 26),
+                    Span.new(17, 20),
+                    Span.new(22, 25),
                     Span.new(27, 30),
                 }),
             },


### PR DESCRIPTION
👋 hey there, thanks for creating this! i did a quick search and didnt see this come up in any issues, but apologies if I missed something. 

I've got a test file I wanted to do some ignores on like:

```zig
// zlint-disable suppressed-errors, no-undefined
// imports
```

it seemed like only one of the directives was being picked up -- I tried with and without commas. so I took a look.

I added a simple test following the pattern of existing tests and the test failed, so did some poking around and made a few tweaks. `just test` and `just e2e` all seems happy so I think/hope I didnt break anything here 😄 

Changes:
- added test to assert multiple global directives are picked up
- in Parser modified the current cursor position check parse method to select the min of itself or end of the span (rather than min of itself +1, end of span)
  - this had knock on affect of making some of the span indexes wrong in a few tests, so I updated the test data there, looking at the test results I think this branch is still "correct" as it the spans still cover the full directive (i.e. all of "foo" in the test)
- in src/linter modified the filterDisableRules func to return the view into the rule_buf from 0 -> `i` of matched rules always - before either returned this or all configured rules if `i` was 0, which in the case of the test (or anyone having exactly n:n configured rules to global ignore directives). this felt a bit scarier, but everything seems to pass/work still

let me know if this needs any tweaks or anything!

carl