### PR TITLE
feat(linter/no-undefined): check for undefined in comparisons

### DIFF
--- a/src/linter/rules/no_undefined.zig
+++ b/src/linter/rules/no_undefined.zig
@@ -62,14 +62,11 @@
 const std = @import("std");
 const util = @import("util");
 const mem = std.mem;
-const source = @import("../../source.zig");
 
 const Semantic = @import("../../semantic.zig").Semantic;
-const Scope = Semantic.Scope;
 const Ast = std.zig.Ast;
 const Node = Ast.Node;
 const TokenIndex = Ast.TokenIndex;
-const Loc = std.zig.Loc;
 const LinterContext = @import("../lint_context.zig");
 const Rule = @import("../rule.zig").Rule;
 const NodeWrapper = @import("../rule.zig").NodeWrapper;

--- a/src/linter/rules/no_undefined.zig
+++ b/src/linter/rules/no_undefined.zig
@@ -115,7 +115,8 @@ pub fn runOnNode(self: *const NoUndefined, wrapper: NodeWrapper, ctx: *LinterCon
                 .global_var_decl,
                 .local_var_decl,
                 .aligned_var_decl,
-                .simple_var_decl, => if (self.allow_arrays) {
+                .simple_var_decl,
+                => if (self.allow_arrays) {
                     // SAFETY: tags in case guarantee that a full variable declaration
                     // is present.
                     const decl = ast.fullVarDecl(parent) orelse unreachable;
@@ -129,12 +130,7 @@ pub fn runOnNode(self: *const NoUndefined, wrapper: NodeWrapper, ctx: *LinterCon
 
                 // Comparison to undefined is always U.B. NOTE: we skip safety
                 // comment check b/c this is _never_ safe.
-                .equal_equal,
-                .bang_equal,
-                .less_or_equal,
-                .less_than,
-                .greater_or_equal,
-                .greater_than => return ctx.report(undefinedComparison(ctx, node.main_token)),
+                .equal_equal, .bang_equal, .less_or_equal, .less_than, .greater_or_equal, .greater_than => return ctx.report(undefinedComparison(ctx, node.main_token)),
                 else => {},
             }
         }

--- a/src/linter/rules/no_undefined.zig
+++ b/src/linter/rules/no_undefined.zig
@@ -65,6 +65,7 @@ const mem = std.mem;
 const source = @import("../../source.zig");
 
 const Semantic = @import("../../semantic.zig").Semantic;
+const Scope = Semantic.Scope;
 const Ast = std.zig.Ast;
 const Node = Ast.Node;
 const TokenIndex = Ast.TokenIndex;
@@ -89,6 +90,11 @@ fn undefinedMissingSafetyComment(ctx: *LinterContext, undefined_tok: TokenIndex)
     e.help = Cow.static("Add a `SAFETY: <reason>` before this line explaining why this code is safe.");
     return e;
 }
+fn undefinedComparison(ctx: *LinterContext, undefined_tok: TokenIndex) Error {
+    var e = ctx.diagnostic("`undefined` cannot be used in comparisons.", .{ctx.spanT(undefined_tok)});
+    e.help = Cow.static("uninitialized data can have any value. If you need to check that a value does not exist, use `null`.");
+    return e;
+}
 
 pub fn runOnNode(self: *const NoUndefined, wrapper: NodeWrapper, ctx: *LinterContext) void {
     const node = wrapper.node;
@@ -98,14 +104,37 @@ pub fn runOnNode(self: *const NoUndefined, wrapper: NodeWrapper, ctx: *LinterCon
     const name = ast.getNodeSource(wrapper.idx);
     if (!std.mem.eql(u8, name, "undefined")) return;
 
-    if (self.allow_arrays) arrays: {
-        const tags: []const Node.Tag = ast.nodes.items(.tag);
+    const node_tags: []const Node.Tag = ast.nodes.items(.tag);
+
+    early_exit: {
         if (ctx.semantic.node_links.getParent(wrapper.idx)) |parent| {
-            const decl = ast.fullVarDecl(parent) orelse break :arrays;
-            const ty = decl.ast.type_node;
-            if (ty == Semantic.NULL_NODE) break :arrays;
-            switch (tags[ty]) {
-                .array_type, .array_type_sentinel => return,
+            const parent_tag = node_tags[parent];
+            switch (parent_tag) {
+                // initializing arrays to undefined can be ok, e.g. when using
+                // @memset.
+                .global_var_decl,
+                .local_var_decl,
+                .aligned_var_decl,
+                .simple_var_decl, => if (self.allow_arrays) {
+                    // SAFETY: tags in case guarantee that a full variable declaration
+                    // is present.
+                    const decl = ast.fullVarDecl(parent) orelse unreachable;
+                    const ty = decl.ast.type_node;
+                    if (ty == Semantic.NULL_NODE) break :early_exit;
+                    switch (node_tags[ty]) {
+                        .array_type, .array_type_sentinel => return,
+                        else => {},
+                    }
+                },
+
+                // Comparison to undefined is always U.B. NOTE: we skip safety
+                // comment check b/c this is _never_ safe.
+                .equal_equal,
+                .bang_equal,
+                .less_or_equal,
+                .less_than,
+                .greater_or_equal,
+                .greater_than => return ctx.report(undefinedComparison(ctx, node.main_token)),
                 else => {},
             }
         }
@@ -153,6 +182,12 @@ test NoUndefined {
         "const many_ptr: [*:0]u8 = undefined;",
         \\// This is not a safety comment
         \\const x = undefined;
+        ,
+        \\fn foo(x: *Foo) void {
+        \\  if (x == undefined) {
+        \\    @import("std").debug.print("x is undefined\n", .{});
+        \\  }
+        \\}
     };
 
     try runner

--- a/src/linter/rules/no_undefined.zig
+++ b/src/linter/rules/no_undefined.zig
@@ -184,6 +184,18 @@ test NoUndefined {
         \\    @import("std").debug.print("x is undefined\n", .{});
         \\  }
         \\}
+        ,
+        "fn foo(x: *Foo) void { if (x > undefined) {} }",
+        "fn foo(x: *Foo) void { if (x >= undefined) {} }",
+        "fn foo(x: *Foo) void { if (x != undefined) {} }",
+        "fn foo(x: *Foo) void { if (x <= undefined) {} }",
+        "fn foo(x: *Foo) void { if (x < undefined) {} }",
+        \\fn foo(x: *Foo) void {
+        \\  // SAFETY: this is never safe, so this comment is ignored
+        \\  if (x == undefined) {
+        \\    @import("std").debug.print("x is undefined\n", .{});
+        \\  }
+        \\}
     };
 
     try runner

--- a/src/linter/rules/snapshots/no-undefined.snap
+++ b/src/linter/rules/snapshots/no-undefined.snap
@@ -50,3 +50,47 @@
    ╰────
   help: uninitialized data can have any value. If you need to check that a value does not exist, use `null`.
 
+  𝙭 no-undefined: `undefined` cannot be used in comparisons.
+   ╭─[no-undefined.zig:1:32]
+ 1 │ fn foo(x: *Foo) void { if (x > undefined) {} }
+   ·                                ─────────
+   ╰────
+  help: uninitialized data can have any value. If you need to check that a value does not exist, use `null`.
+
+  𝙭 no-undefined: `undefined` cannot be used in comparisons.
+   ╭─[no-undefined.zig:1:33]
+ 1 │ fn foo(x: *Foo) void { if (x >= undefined) {} }
+   ·                                 ─────────
+   ╰────
+  help: uninitialized data can have any value. If you need to check that a value does not exist, use `null`.
+
+  𝙭 no-undefined: `undefined` cannot be used in comparisons.
+   ╭─[no-undefined.zig:1:33]
+ 1 │ fn foo(x: *Foo) void { if (x != undefined) {} }
+   ·                                 ─────────
+   ╰────
+  help: uninitialized data can have any value. If you need to check that a value does not exist, use `null`.
+
+  𝙭 no-undefined: `undefined` cannot be used in comparisons.
+   ╭─[no-undefined.zig:1:33]
+ 1 │ fn foo(x: *Foo) void { if (x <= undefined) {} }
+   ·                                 ─────────
+   ╰────
+  help: uninitialized data can have any value. If you need to check that a value does not exist, use `null`.
+
+  𝙭 no-undefined: `undefined` cannot be used in comparisons.
+   ╭─[no-undefined.zig:1:32]
+ 1 │ fn foo(x: *Foo) void { if (x < undefined) {} }
+   ·                                ─────────
+   ╰────
+  help: uninitialized data can have any value. If you need to check that a value does not exist, use `null`.
+
+  𝙭 no-undefined: `undefined` cannot be used in comparisons.
+   ╭─[no-undefined.zig:3:12]
+ 2 │   // SAFETY: this is never safe, so this comment is ignored
+ 3 │   if (x == undefined) {
+   ·            ─────────
+ 4 │     @import("std").debug.print("x is undefined\n", .{});
+   ╰────
+  help: uninitialized data can have any value. If you need to check that a value does not exist, use `null`.
+

--- a/src/linter/rules/snapshots/no-undefined.snap
+++ b/src/linter/rules/snapshots/no-undefined.snap
@@ -41,3 +41,12 @@
    ╰────
   help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
 
+  𝙭 no-undefined: `undefined` cannot be used in comparisons.
+   ╭─[no-undefined.zig:2:12]
+ 1 │ fn foo(x: *Foo) void {
+ 2 │   if (x == undefined) {
+   ·            ─────────
+ 3 │     @import("std").debug.print("x is undefined\n", .{});
+   ╰────
+  help: uninitialized data can have any value. If you need to check that a value does not exist, use `null`.
+


### PR DESCRIPTION
Explicitly ban `undefined` in all comparisons, even if a safety comment is present.

```zig
fn foo(bar: *Bar) void {
  // this is never safe
  if (bar == undefined) {}
}
```