### PR TITLE
feat(linter/no-unresolved): inform on missing file vs directory imports

### DIFF
--- a/src/linter/rules/no_unresolved.zig
+++ b/src/linter/rules/no_unresolved.zig
@@ -99,7 +99,7 @@ pub fn runOnNode(_: *const NoUnresolved, wrapper: NodeWrapper, ctx: *LinterConte
             ctx.report(ctx.diagnosticf(
                 "Unresolved import to '{s}'",
                 .{pathname},
-                .{ctx.spanN(node.data.lhs)},
+                .{ctx.labelN(node.data.lhs, "file '{s}' does not exist", .{pathname})},
             ));
             return;
         };
@@ -107,7 +107,7 @@ pub fn runOnNode(_: *const NoUnresolved, wrapper: NodeWrapper, ctx: *LinterConte
             ctx.report(ctx.diagnosticf(
                 "Unresolved import to directory '{s}'",
                 .{pathname},
-                .{ctx.spanN(node.data.lhs)},
+                .{ctx.labelN(node.data.lhs, "'{s}' is a folder", .{pathname})},
             ));
         }
     }

--- a/src/linter/rules/no_unresolved.zig
+++ b/src/linter/rules/no_unresolved.zig
@@ -33,6 +33,7 @@
 //! const y = @import("mod/bar.zig");
 //! ```
 const std = @import("std");
+const util = @import("util");
 const fs = std.fs;
 const path = std.fs.path;
 
@@ -81,7 +82,7 @@ pub fn runOnNode(_: *const NoUnresolved, wrapper: NodeWrapper, ctx: *LinterConte
         // 2 for open/close quotes
         if (pathname.len < 4) return;
         const ext = pathname[pathname.len - 4 ..];
-        if (!std.mem.eql(u8, ext, ".zig")) return;
+        if (!isDotSlash(ext) and !std.mem.eql(u8, ext, ".zig")) return;
     }
 
     // join it with the current file's folder to get where it would be
@@ -113,6 +114,11 @@ pub fn runOnNode(_: *const NoUnresolved, wrapper: NodeWrapper, ctx: *LinterConte
     }
 }
 
+fn isDotSlash(pathname: []const u8) bool {
+    if (pathname.len < 2) return false;
+    return pathname[0] == '.' and (pathname[1] == '/' or (util.IS_DEBUG and pathname[1] == '\\'));
+}
+
 pub fn rule(self: *NoUnresolved) Rule {
     return Rule.init(self);
 }
@@ -130,7 +136,10 @@ test NoUnresolved {
         "const x = @import(\"main.zig\");",
     };
     const fail = &[_][:0]const u8{
-        "const x = @import(\"does-not-exist.zig\");",
+        \\const x = @import("does-not-exist.zig");
+        ,
+        // TODO: dir.statFile() returns .{ .kind = .file } even for directories
+        // \\const x = @import("./walk");
         // TODO: currently caught by semantic analysis. Right now sema failures
         // make the linter panic. uncomment when sema failures are handled
         // "const p = \"foo.zig\"\nconst x = @import(foo);",

--- a/src/linter/rules/snapshots/no-unresolved.snap
+++ b/src/linter/rules/snapshots/no-unresolved.snap
@@ -1,6 +1,7 @@
   𝙭 no-unresolved: Unresolved import to 'does-not-exist.zig'
    ╭─[src/no-unresolved.zig:1:19]
  1 │ const x = @import("does-not-exist.zig");
-   ·                   ────────────────────
+   ·                   ───────────┬───────────
+   ·                              ╰── file 'does-not-exist.zig' does not exist
    ╰────
 


### PR DESCRIPTION
Add a label telling users if they're importing a missing file or a directory.

```
  𝙭 no-unresolved: Unresolved import to 'does-not-exist.zig'
   ╭─[src/no-unresolved.zig:1:19]
 1 │ const x = @import("does-not-exist.zig");
   ·                   ───────────┬───────────
   ·                              ╰── file 'does-not-exist.zig' does not exist
   ╰────

```