### PR TITLE
feat(linter): report configs with unknown rules

### DIFF
--- a/src/Error.zig
+++ b/src/Error.zig
@@ -21,7 +21,7 @@ help: ?Cow(false) = null,
 // Although this is not [:0]const u8, it should not be mutated. Needs to be mut
 // to indicate to Arc it's owned by the Error. Otherwise, arc.deinit() won't
 // free the slice.
-const ArcStr = Arc([:0]u8);
+pub const ArcStr = Arc([:0]u8);
 
 pub fn new(message: []u8, allocator: Allocator) Error {
     return Error{ .message = Cow(false).owned(message, allocator) };

--- a/src/cli/lint_config.zig
+++ b/src/cli/lint_config.zig
@@ -155,7 +155,6 @@ const customRuleMessages = std.StaticStringMap([]const u8).initComptime([_]struc
     .{ "\"no-undefined\"", "`no-undefined` has been renamed to `unsafe-undefined`." },
 });
 
-
 const t = std.testing;
 test ParentIterator {
     if (util.IS_WINDOWS) {

--- a/src/span.zig
+++ b/src/span.zig
@@ -90,6 +90,7 @@ pub const Span = struct {
     }
 
     /// Translate a span towards the end of the file by `offset` characters.
+    /// Opposite of `shiftLeft`.
     ///
     /// ## Example
     /// ```zig
@@ -99,6 +100,19 @@ pub const Span = struct {
     /// ```
     pub fn shiftRight(self: Span, offset: u32) Span {
         return .{ .start = self.start + offset, .end = self.end + offset };
+    }
+
+    /// Translate a span towards the start of the file by `offset` characters.
+    /// Opposite of `shiftRight`.
+    ///
+    /// ## Example
+    /// ```zig
+    /// const span = Span.new(5, 7);
+    /// const moved = span.shiftLeft(5);
+    /// try std.testing.expectEqual(Span.new(0, 2), moved);
+    /// ```
+    pub fn shiftLeft(self: Span, offset: u32) Span {
+        return .{ .start = self.start - offset, .end = self.end - offset };
     }
 
     pub inline fn contains(self: Span, point: u32) bool {
@@ -114,6 +128,13 @@ test "Span.shiftRight" {
     const span = Span.new(5, 7);
     const moved = span.shiftRight(5);
     try t.expectEqual(Span.new(10, 12), moved);
+    try t.expectEqual(Span.new(5, 7), span); // original span is not mutated
+}
+
+test "Span.shiftLeft" {
+    const span = Span.new(5, 7);
+    const moved = span.shiftLeft(5);
+    try t.expectEqual(Span.new(0, 2), moved);
     try t.expectEqual(Span.new(5, 7), span); // original span is not mutated
 }
 

--- a/src/util.zig
+++ b/src/util.zig
@@ -17,13 +17,14 @@ pub const NEWLINE = if (IS_WINDOWS) "\r\n" else "\n";
 pub const DebugOnly = @import("./util/debug_only.zig").DebugOnly;
 pub const debugOnly = @import("./util/debug_only.zig").debugOnly;
 
-const WHITESPACE = [4]u8{ ' ', '\t', '\n', '\r' };
 pub fn trimWhitespace(s: string) string {
-    return std.mem.trim(u8, s, &WHITESPACE);
+    return std.mem.trim(u8, s, &std.ascii.whitespace);
 }
-
 pub fn trimWhitespaceRight(s: string) string {
-    return std.mem.trimRight(u8, s, &WHITESPACE);
+    return std.mem.trimRight(u8, s, &std.ascii.whitespace);
+}
+pub fn isWhitespace(c: u8) bool {
+    return std.mem.indexOfScalar(u8, &std.ascii.whitespace, c) != null;
 }
 
 /// Assert that `condition` is true, panicking if it is not.

--- a/src/util/cow.zig
+++ b/src/util/cow.zig
@@ -75,6 +75,11 @@ pub fn Cow(comptime sentinel: bool) type {
             };
         }
 
+        /// Create a `Cow` that borrows its data.
+        pub fn borrowed(str: Slice) Self {
+            return .{ .borrowed = true, .str = str };
+        }
+
         /// Create an owned `Cow` by printing a format string.
         pub fn fmt(allocator: Allocator, comptime format_str: []const u8, args: anytype) Allocator.Error!Self {
             const print = if (sentinel) std.fmt.allocPrintZ else std.fmt.allocPrint;


### PR DESCRIPTION
Closes #206.

Zlint now prints an error and exits with a failure code when a `zlint.json` config contains rules that do not exist.