### PR TITLE
feat(linter): add `must-return-ref` rule

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -111,6 +111,7 @@ new-rule name:
     else \
         echo "Please install bun to use this command."; \
     fi
+    just codegen
     zig fmt src/linter
 
 # (MacOS only) sign binaries so they can be debugged and traced with Instruments

--- a/docs/rules/must-return-ref.md
+++ b/docs/rules/must-return-ref.md
@@ -1,0 +1,56 @@
+# `must-return-ref`
+
+> Category: suspicious
+>
+> Enabled by default?: Yes (warning)
+
+## What This Rule Does
+
+Disallows returning copies of types that store a `capacity`.
+
+Zig does not have move semantics. Returning a value by value copies it.
+Returning a copy of a struct's field that records how much memory it has
+allocated can easily lead to memory leaks.
+
+```zig
+const std = @import("std");
+pub const Foo = struct {
+  list: std.ArrayList(u32),
+  pub fn getList(self: *Foo) std.ArrayList(u32) {
+      return self.list;
+  }
+};
+
+pub fn main() !void {
+  var foo: Foo = .{
+    .list = try std.ArrayList(u32).init(std.heap.page_allocator)
+  };
+  defer foo.list.deinit();
+  var list = foo.getList();
+  try list.append(1); // leaked!
+}
+```
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```zig
+fn foo(self: *Foo) std.ArrayList(u32) {
+  return self.list;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```zig
+// pass by reference
+fn foo(self: *Foo) *std.ArrayList(u32) {
+  return &self.list;
+}
+
+// new instances are fine
+fn foo() ArenaAllocator {
+  return std.mem.ArenaAllocator.init(std.heap.page_allocator);
+}
+```

--- a/src/linter/ast_utils.zig
+++ b/src/linter/ast_utils.zig
@@ -1,0 +1,22 @@
+const Context = @import("./lint_context.zig");
+const semantic = @import("../semantic.zig");
+const Semantic = semantic.Semantic;
+const Node = semantic.Ast.Node;
+const Token = Semantic.Token;
+const TokenIndex = semantic.Ast.TokenIndex;
+
+/// - `foo` -> `foo`
+/// - `foo.bar` -> `bar`
+/// - `foo()` -> `foo`
+/// - `foo.bar()` -> `bar`
+pub fn getRightmostIdentifier(ctx: *Context, id: Node.Index) ?TokenIndex {
+    const nodes = ctx.ast().nodes;
+    const tags: []const Node.Tag = nodes.items(.tag);
+
+    return switch (tags[id]) {
+        .identifier => nodes.items(.main_token)[id],
+        .field_access => nodes.items(.data)[id].rhs,
+        .call, .call_comma, .call_one, .call_one_comma => nodes.items(.data)[id].lhs,
+        else => null,
+    };
+}

--- a/src/linter/ast_utils.zig
+++ b/src/linter/ast_utils.zig
@@ -2,21 +2,19 @@ const Context = @import("./lint_context.zig");
 const semantic = @import("../semantic.zig");
 const Semantic = semantic.Semantic;
 const Node = semantic.Ast.Node;
-const Token = Semantic.Token;
-const TokenIndex = semantic.Ast.TokenIndex;
 
 /// - `foo` -> `foo`
 /// - `foo.bar` -> `bar`
 /// - `foo()` -> `foo`
 /// - `foo.bar()` -> `bar`
-pub fn getRightmostIdentifier(ctx: *Context, id: Node.Index) ?TokenIndex {
+pub fn getRightmostIdentifier(ctx: *Context, id: Node.Index) ?[]const u8 {
     const nodes = ctx.ast().nodes;
-    const tags: []const Node.Tag = nodes.items(.tag);
+    const tag: Node.Tag = nodes.items(.tag)[id];
 
-    return switch (tags[id]) {
-        .identifier => nodes.items(.main_token)[id],
-        .field_access => nodes.items(.data)[id].rhs,
-        .call, .call_comma, .call_one, .call_one_comma => nodes.items(.data)[id].lhs,
+    return switch (tag) {
+        .identifier => ctx.semantic.tokenSlice(nodes.items(.main_token)[id]),
+        .field_access => ctx.semantic.tokenSlice(nodes.items(.data)[id].rhs),
+        .call, .call_comma, .call_one, .call_one_comma => getRightmostIdentifier(ctx, nodes.items(.data)[id].lhs),
         else => null,
     };
 }

--- a/src/linter/config/rules_config.zig
+++ b/src/linter/config/rules_config.zig
@@ -4,6 +4,7 @@ const rules = @import("../rules.zig");
 
 pub const RulesConfig = struct {
     pub usingnamespace @import("./rules_config.methods.zig").RulesConfigMethods(@This());
+    must_return_ref: RuleConfig(rules.MustReturnRef) = .{},
     homeless_try: RuleConfig(rules.HomelessTry) = .{},
     no_catch_return: RuleConfig(rules.NoCatchReturn) = .{},
     no_return_try: RuleConfig(rules.NoReturnTry) = .{},

--- a/src/linter/config/rules_config.zig
+++ b/src/linter/config/rules_config.zig
@@ -4,7 +4,6 @@ const rules = @import("../rules.zig");
 
 pub const RulesConfig = struct {
     pub usingnamespace @import("./rules_config.methods.zig").RulesConfigMethods(@This());
-    must_return_ref: RuleConfig(rules.MustReturnRef) = .{},
     homeless_try: RuleConfig(rules.HomelessTry) = .{},
     no_catch_return: RuleConfig(rules.NoCatchReturn) = .{},
     no_return_try: RuleConfig(rules.NoReturnTry) = .{},
@@ -12,4 +11,5 @@ pub const RulesConfig = struct {
     suppressed_errors: RuleConfig(rules.SuppressedErrors) = .{},
     unsafe_undefined: RuleConfig(rules.UnsafeUndefined) = .{},
     unused_decls: RuleConfig(rules.UnusedDecls) = .{},
+    must_return_ref: RuleConfig(rules.MustReturnRef) = .{},
 };

--- a/src/linter/rules.zig
+++ b/src/linter/rules.zig
@@ -5,3 +5,4 @@ pub const NoUnresolved = @import("./rules/no_unresolved.zig");
 pub const SuppressedErrors = @import("./rules/suppressed_errors.zig");
 pub const UnsafeUndefined = @import("./rules/unsafe_undefined.zig");
 pub const UnusedDecls = @import("./rules/unused_decls.zig");
+pub const MustReturnRef = @import("./rules/must_return_ref.zig");

--- a/src/linter/rules/must_return_ref.zig
+++ b/src/linter/rules/must_return_ref.zig
@@ -73,6 +73,7 @@ pub fn runOnNode(_: *const MustReturnRef, wrapper: NodeWrapper, ctx: *LinterCont
         ctx.ast(),
         &visitor,
     ) catch @panic("oom");
+    defer walker.deinit();
     walker.walk() catch @panic("oom");
 }
 

--- a/src/linter/rules/must_return_ref.zig
+++ b/src/linter/rules/must_return_ref.zig
@@ -1,0 +1,167 @@
+//! ## What This Rule Does
+//! Explain what this rule checks for. Also explain why this is a problem.
+//!
+//! ## Examples
+//!
+//! Examples of **incorrect** code for this rule:
+//! ```zig
+//! ```
+//!
+//! Examples of **correct** code for this rule:
+//! ```zig
+//! ```
+
+const std = @import("std");
+const util = @import("util");
+const _source = @import("../../source.zig");
+const semantic = @import("../../semantic.zig");
+const _rule = @import("../rule.zig");
+const _span = @import("../../span.zig");
+const a = @import("../ast_utils.zig");
+const walk = @import("../../visit/walk.zig");
+
+// const Allocator = std.mem.Allocator;
+const Semantic = semantic.Semantic;
+const Ast = std.zig.Ast;
+const Node = Ast.Node;
+const TokenIndex = Ast.TokenIndex;
+const Symbol = semantic.Symbol;
+const Loc = std.zig.Loc;
+const Span = _span.Span;
+const LabeledSpan = _span.LabeledSpan;
+const LinterContext = @import("../lint_context.zig");
+const Rule = _rule.Rule;
+const NodeWrapper = _rule.NodeWrapper;
+const Error = @import("../../Error.zig");
+const Cow = util.Cow(false);
+
+fn mustReturnRefDiagnostic(ctx: *LinterContext, type_name: []const u8, returned: Node.Index) Error {
+    var e = ctx.diagnosticf(
+        "Members of type `{s}` must be passed by reference",
+        .{type_name},
+        .{ctx.labelN(returned, "This is a copy, not a move.", .{})},
+    );
+    e.help = Cow.static("This type records its allocation size, so mutating a copy can result in a memory leak.");
+    return e;
+}
+
+const MustReturnRef = @This();
+pub const meta: Rule.Meta = .{
+    .name = "must-return-ref",
+    .default = .err,
+    .category = .suspicious,
+};
+
+pub fn runOnNode(_: *const MustReturnRef, wrapper: NodeWrapper, ctx: *LinterContext) void {
+    if (wrapper.node.tag != .fn_decl) return;
+
+    // const nodes = ctx.ast().nodes;
+    // const tags: []const Node.Tag = nodes.items(.tag);
+
+    var buf: [1]Node.Index = undefined;
+    // SAFETY: fn decls always have a fn proto
+    const decl = ctx.ast().fullFnProto(&buf, wrapper.idx) orelse unreachable;
+    const return_type = decl.ast.return_type;
+    const returned_tok: TokenIndex = a.getRightmostIdentifier(ctx, return_type) orelse return;
+    const returned_ident = ctx.ast().tokenSlice(returned_tok);
+    if (!types_to_check.has(returned_ident)) return;
+
+    var visitor = ReturnVisitor.new(ctx, returned_ident);
+    var stackAlloc = std.heap.stackFallback(512, ctx.gpa);
+    var walker = walk.Walker(ReturnVisitor, error{}).init(
+        stackAlloc.get(),
+        ctx.ast(),
+        &visitor,
+    ) catch @panic("oom");
+    walker.walk() catch @panic("oom");
+}
+
+const ReturnVisitor = struct {
+    typename: []const u8,
+    ctx: *LinterContext,
+    datas: []const Node.Data,
+    tags: []const Node.Tag,
+
+    fn new(ctx: *LinterContext, typename: []const u8) ReturnVisitor {
+        return .{
+            .typename = typename,
+            .ctx = ctx,
+            .datas = ctx.ast().nodes.items(.data),
+            .tags = ctx.ast().nodes.items(.tag),
+        };
+    }
+
+    pub fn visit_return(self: *ReturnVisitor, node: Node.Index) error{}!walk.WalkState {
+        const returned = self.datas[node].lhs;
+        if (returned == Semantic.NULL_NODE) return .Continue; // type error
+        // todo: check that leftmost ident is `this`.
+        if (self.tags[returned] != .field_access) return .Continue;
+
+        var ctx = self.ctx;
+        ctx.report(mustReturnRefDiagnostic(ctx, self.typename, returned));
+
+        return .Continue;
+    }
+};
+
+const types_to_check = std.StaticStringMap(void).initComptime(&[_]struct { []const u8 }{
+    .{"ArenaAllocator"},
+    // array list
+    .{"ArrayList"},
+    .{"ArrayListUnmanaged"},
+    .{"AutoArrayHashMap"},
+    .{"AutoArrayHashMapUnmanaged"},
+    // multi array list
+    .{"MultiArrayList"},
+    .{"MultiArrayListUnmanaged"},
+    // hash map
+    .{"AutoHashMap"},
+    .{"AutoHashMapUnmanaged"},
+    .{"HashMap"},
+    .{"HashMapUnmanaged"},
+    .{"StringHashMap"},
+    .{"StringHashMapUnmanaged"},
+});
+
+pub fn rule(self: *MustReturnRef) Rule {
+    return Rule.init(self);
+}
+
+const RuleTester = @import("../tester.zig");
+test MustReturnRef {
+    const t = std.testing;
+
+    var must_return_ref = MustReturnRef{};
+    var runner = RuleTester.init(t.allocator, must_return_ref.rule());
+    defer runner.deinit();
+
+    // Code your rule should pass on
+    const pass = &[_][:0]const u8{
+        \\const std = @import("std");
+        \\const ArenaAllocator = std.mem.ArenaAllocator;
+        \\
+        \\const Foo = struct {
+        \\  pub fn newArena(self: *Foo) ArenaAllocator {
+        \\    return createArenaSomehow();
+        \\  }
+        \\};
+    };
+
+    // Code your rule should fail on
+    const fail = &[_][:0]const u8{
+        \\const std = @import("std");
+        \\const ArenaAllocator = std.mem.ArenaAllocator;
+        \\
+        \\const Foo = struct {
+        \\  arena: ArenaAllocator,
+        \\  pub fn getArena(self: *Foo) ArenaAllocator {
+        \\    return self.arena;
+        \\  }
+        \\};
+    };
+
+    try runner
+        .withPass(pass)
+        .withFail(fail)
+        .run();
+}

--- a/src/linter/rules/snapshots/must-return-ref.snap
+++ b/src/linter/rules/snapshots/must-return-ref.snap
@@ -8,3 +8,13 @@
    ╰────
   help: This type records its allocation size, so mutating a copy can result in a memory leak.
 
+  𝙭 must-return-ref: Members of type `ArrayList` must be passed by reference
+   ╭─[must-return-ref.zig:5:12]
+ 4 │   } else {
+ 5 │     return self.list;
+   ·            ────┬────
+   ·                ╰── This is a copy, not a move.
+ 6 │   }
+   ╰────
+  help: This type records its allocation size, so mutating a copy can result in a memory leak.
+

--- a/src/linter/rules/snapshots/must-return-ref.snap
+++ b/src/linter/rules/snapshots/must-return-ref.snap
@@ -1,0 +1,10 @@
+  𝙭 must-return-ref: Members of type `ArenaAllocator` must be passed by reference
+   ╭─[must-return-ref.zig:7:12]
+ 6 │   pub fn getArena(self: *Foo) ArenaAllocator {
+ 7 │     return self.arena;
+   ·            ──────┬──────
+   ·                  ╰── This is a copy, not a move.
+ 8 │   }
+   ╰────
+  help: This type records its allocation size, so mutating a copy can result in a memory leak.
+

--- a/src/visit/walk.zig
+++ b/src/visit/walk.zig
@@ -460,8 +460,11 @@ pub fn Walker(Visitor: type, Error: type) type {
                     try self.pushManyUnconditional(members);
                 },
                 // lhs/rhs both ignored
-                .unset, .token => {},
-                else => |kind| std.debug.panic("todo: {s} ({s})", .{ @tagName(kind), @tagName(tag) }),
+                .unset, .token, .token_unset => {},
+                else => |kind| if (comptime util.IS_DEBUG) std.debug.panic(
+                    "todo: {s} ({s})",
+                    .{ @tagName(kind), @tagName(tag) },
+                ),
             }
         }
 
@@ -885,7 +888,7 @@ const NodeDataKind = enum {
             .@"continue" => K.token_unset,
             // `break :lhs rhs`
             // both lhs and rhs may be omitted.
-            .@"break" => K.node,
+            .@"break" => K.token_node,
             // `return lhs`. lhs can be omitted. rhs is unused.
             .@"return" => K.node_unset,
             // `fn (a: lhs) rhs`. lhs can be omitted.

--- a/src/visit/walk_test.zig
+++ b/src/visit/walk_test.zig
@@ -157,6 +157,7 @@ test "where's waldo, but its `x`" {
     try testXSeenTimes(1, "fn main() void { for(x) {} }");
     try testXSeenTimes(1, "const x = struct{};");
     try testXSeenTimes(1, "const Foo = struct{ pub const y = 1; pub const z = 2; pub const x = 3;};");
+    try testXSeenTimes(1, "const y = blk: { break :blk x; };");
     // try testXSeenTimes(3,
     //     \\fn foo(x: u32) void {
     //     \\  const a = 1 + (2 - (3 / (4 * x)));

--- a/src/visit/walk_test.zig
+++ b/src/visit/walk_test.zig
@@ -158,6 +158,15 @@ test "where's waldo, but its `x`" {
     try testXSeenTimes(1, "const x = struct{};");
     try testXSeenTimes(1, "const Foo = struct{ pub const y = 1; pub const z = 2; pub const x = 3;};");
     try testXSeenTimes(1, "const y = blk: { break :blk x; };");
+    try testXSeenTimes(1,
+        \\fn main() void {
+        \\  if (a) {
+        \\    return y;
+        \\  } else {
+        \\    return x;
+        \\  }
+        \\}
+    );
     // try testXSeenTimes(3,
     //     \\fn foo(x: u32) void {
     //     \\  const a = 1 + (2 - (3 / (4 * x)));

--- a/tasks/gen_utils.zig
+++ b/tasks/gen_utils.zig
@@ -1,12 +1,8 @@
 const std = @import("std");
 const zlint = @import("zlint");
 const fs = std.fs;
-const log = std.log;
 const mem = std.mem;
-const path = fs.path;
-const panic = std.debug.panic;
 
-const Allocator = mem.Allocator;
 const Rule = zlint.lint.Rule;
 
 pub const RULES_DIR = "src/linter/rules";

--- a/tasks/new-rule.ts
+++ b/tasks/new-rule.ts
@@ -91,18 +91,24 @@ const createRule = ({ name, StructName, underscored }: RuleData) => {
 //! \`\`\`
 
 const std = @import("std");
+const util = @import("util");
 const _source = @import("../../source.zig");
 const semantic = @import("../../semantic.zig");
 const _rule = @import("../rule.zig");
+const _span = @import("../../span.zig");
 
 const Ast = std.zig.Ast;
 const Node = Ast.Node;
 const Symbol = semantic.Symbol;
 const Loc = std.zig.Loc;
-const Span = _source.Span;
+const Span = _span.Span;
+const LabeledSpan = _span.LabeledSpan;
 const LinterContext = @import("../lint_context.zig");
 const Rule = _rule.Rule;
 const NodeWrapper = _rule.NodeWrapper;
+
+const Error = @import("../../Error.zig");
+const Cow = util.Cow(false);
 
 // Rule metadata
 const ${StructName} = @This();


### PR DESCRIPTION
## What This PR Does

Adds a new rule that checks for list/allocator typed properties returned by value instead of by reference.

```zig
const std = @import("std");

pub const Foo = struct {
  list: std.ArrayList(u32),
  pub fn getList(self: *Foo) std.ArrayList(u32) {
      return self.list;
  }
};

pub fn main() !void {
  var foo: Foo = .{
    .list = try std.ArrayList(u32).init(std.heap.page_allocator)
  };
  defer foo.list.deinit();
  var list = foo.getList();
  try list.append(1); // leaked!
}
```