### PR TITLE
fix(linter/homeless-try): handle `if` in fn return type

### DIFF
--- a/src/linter/rules/snapshots/homeless-try.snap
+++ b/src/linter/rules/snapshots/homeless-try.snap
@@ -27,3 +27,18 @@
  5 │   };
    ╰────
 
+  𝙭 homeless-try: `try` cannot be used in functions that do not return errors.
+   ╭─[homeless-try.zig:2:8]
+ 1 │ const std = @import("std");
+ 2 │ pub fn push(list: std.ArrayList(u32), x: u32, comptime assume_capacity: bool) if(assume_capacity) void else void {
+   ·        ───┬───
+   ·           ╰── function `push` is declared here.
+ 3 │   if (comptime assume_capacity) {
+ 5 │   } else {
+ 6 │     try list.append(x);
+   ·     ─┬─
+   ·      ╰── it cannot propagate error unions.
+ 7 │   }
+   ╰────
+  help: Change the return type to `!if(assume_capacity) void else void`.
+


### PR DESCRIPTION
Handle functions that may or may not return an error union.
```zig
const std = @import("std");
pub fn push(list: std.ArrayList(u32), x: u32, comptime assume_capacity: bool) if(assume_capacity) void else Allocator.Error!void {
  if (comptime assume_capacity) {
    list.appendAssumeCapacity(x);
  } else {
    try list.append(x);
  }
}
```