### PR TITLE
fix(linter/suppressed-errors): allow suppression in test blocks

### DIFF
--- a/docs/rules/suppressed-errors.md
+++ b/docs/rules/suppressed-errors.md
@@ -57,4 +57,9 @@ const y = foo() catch {
 const z = foo() catch null;
 // Writer errors may be safely ignored
 writer.print("{}", .{5}) catch {};
+
+// suppression is allowed in tests
+test foo {
+  foo() catch {};
+}
 ```

--- a/src/linter/ast_utils.zig
+++ b/src/linter/ast_utils.zig
@@ -18,3 +18,17 @@ pub fn getRightmostIdentifier(ctx: *Context, id: Node.Index) ?[]const u8 {
         else => null,
     };
 }
+
+pub fn isInTest(ctx: *const Context, node: Node.Index) bool {
+    const tags: []const Node.Tag = ctx.ast().nodes.items(.tag);
+    var parents = ctx.links().iterParentIds(node);
+
+    while (parents.next()) |parent| {
+        // NOTE: container and fn decls may be nested within a test.
+        switch (tags[parent]) {
+            .test_decl => return true,
+            else => continue,
+        }
+    }
+    return false;
+}

--- a/src/linter/rules/suppressed_errors.zig
+++ b/src/linter/rules/suppressed_errors.zig
@@ -47,6 +47,11 @@
 //! const z = foo() catch null;
 //! // Writer errors may be safely ignored
 //! writer.print("{}", .{5}) catch {};
+//!
+//! // suppression is allowed in tests
+//! test foo {
+//!   foo() catch {};
+//! }
 //! ```
 
 const std = @import("std");

--- a/src/linter/rules/suppressed_errors.zig
+++ b/src/linter/rules/suppressed_errors.zig
@@ -54,6 +54,7 @@ const util = @import("util");
 const semantic = @import("../../semantic.zig");
 const _rule = @import("../rule.zig");
 const _span = @import("../../span.zig");
+const a = @import("../ast_utils.zig");
 
 const Ast = std.zig.Ast;
 const Node = Ast.Node;
@@ -114,6 +115,7 @@ pub fn runOnNode(_: *const SuppressedErrors, wrapper: NodeWrapper, ctx: *LinterC
             // `catch {}`
             if (stmts.lhs == NULL_NODE) {
                 if (isSuppressingWriterError(ctx, caught)) return;
+                if (a.isInTest(ctx, wrapper.idx)) return;
                 const body_span = ast.nodeToSpan(catch_body);
                 const catch_keyword_start: u32 = ast.tokens.items(.start)[node.main_token];
                 const span = Span.new(catch_keyword_start, body_span.end);
@@ -123,6 +125,7 @@ pub fn runOnNode(_: *const SuppressedErrors, wrapper: NodeWrapper, ctx: *LinterC
             switch (tags[stmts.lhs]) {
                 .unreachable_literal => {
                     if (isSuppressingWriterError(ctx, caught)) return;
+                    if (a.isInTest(ctx, wrapper.idx)) return;
                     const span = ast.nodeToSpan(stmts.lhs);
                     ctx.report(unreachableDiagnostic(ctx, .{ .start = span.start, .end = span.end }));
                 },
@@ -131,6 +134,7 @@ pub fn runOnNode(_: *const SuppressedErrors, wrapper: NodeWrapper, ctx: *LinterC
         },
         .unreachable_literal => {
             if (isSuppressingWriterError(ctx, caught)) return;
+            if (a.isInTest(ctx, wrapper.idx)) return;
             // lexeme() exists
             const unreachable_token = ast.nodes.items(.main_token)[catch_body];
             const start: u32 = ast.tokens.items(.start)[unreachable_token];
@@ -234,6 +238,16 @@ test SuppressedErrors {
         \\fn foo(bar: *Foo) void {
         \\  bar.baz.writeAll("") catch {};
         \\}
+        ,
+        // suppression in tests is allowed
+        \\test bar {
+        \\  bar() catch {};
+        \\}
+        ,
+        \\test bar {
+        \\  bar() catch unreachable;
+        \\}
+        ,
     };
 
     const fail = &[_][:0]const u8{


### PR DESCRIPTION
This is no longer a `suppressed-errors` violation:
```zig
test bar {
  bar(1) catch {};
}
```