### PR TITLE
feat(cli): add CLI flag to apply dangerous fixes

### DIFF
--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -22,6 +22,8 @@ summary: bool = true,
 stdin: bool = false,
 /// enable auto fixes
 fix: bool = false,
+/// Like `--fix`, but also enable potentially dangerous fixes.
+fix_dangerously: bool = false,
 /// Positional arguments
 args: std.ArrayListUnmanaged(util.string) = .{},
 
@@ -34,6 +36,7 @@ const help =
     \\--no-summary        Do not print a summary after linting
     \\-S, --stdin         Lint filepaths received from stdin (newline separated)
     \\--fix               Apply automatic fixes where possible
+    \\--fix-dangerously   Like --fix, but also enable potentially dangerous fixes
     \\--deny-warnings     Warnings produce a non-zero exit code
     \\-q, --quiet         Only display error diagnostics
     \\-V, --verbose       Enable verbose logging   

--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -16,6 +16,7 @@ const WalkState = walk.WalkState;
 const Error = @import("../Error.zig");
 
 const LintService = _lint.LintService;
+const Fix = _lint.Fix;
 const Options = @import("../cli/Options.zig");
 
 pub fn lint(alloc: Allocator, options: Options) !u8 {
@@ -45,12 +46,17 @@ pub fn lint(alloc: Allocator, options: Options) !u8 {
     const start = std.time.milliTimestamp();
 
     {
+        const fix = if (options.fix or options.fix_dangerously) Fix.Meta{
+            .kind = .fix,
+            .dangerous = options.fix_dangerously,
+        } else Fix.Meta.disabled;
+
         // TODO: use options to specify number of threads (if provided)
         var service = try LintService.init(
             alloc,
             &reporter,
             config,
-            .{ .fix = options.fix },
+            .{ .fix = fix },
         );
         defer service.deinit();
 

--- a/src/lint.zig
+++ b/src/lint.zig
@@ -3,6 +3,7 @@ pub const LintService = @import("linter/LintService.zig");
 pub const Config = @import("linter/Config.zig");
 pub const Rule = @import("linter/rule.zig").Rule;
 pub const rules = @import("linter/rules.zig");
+pub const Fix = @import("linter/fix.zig").Fix;
 
 test {
     const std = @import("std");

--- a/src/linter/LintService.zig
+++ b/src/linter/LintService.zig
@@ -1,7 +1,7 @@
 const LintService = @This();
 
 pub const Options = struct {
-    fix: bool = false,
+    fix: Fix.Meta = Fix.Meta.disabled,
     /// Defaults to # of CPUs
     n_threads: ?u32 = null,
 };
@@ -128,7 +128,7 @@ pub fn lintSource(
 
         // FIXME: take errors from ctx. requires using Error instead of Diagnostic
         // when fix is false
-        if (!self.options.fix) {
+        if (self.options.fix.isDisabled()) {
             const n = diagnostics.items.len;
             util.assert(n > 0, "Linter should never assign an empty error list when problems are reported", .{});
             util.assert(self.allocator.ptr == diagnostics.allocator.ptr, "diagnostics used a different allocator than one used to make errors", .{});


### PR DESCRIPTION
## What This PR Does
Adds a `--fix-dangerously` CLI flag to enable possibly breaking auto fixes. This currently has no effect (outside of normal `--fix` behavior) and will not do anything until I implement dangerous fixers for some rules.