### PR TITLE
feat(linter): add dangerous auto fixer for `unused-decls`

### DIFF
--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -71,6 +71,9 @@ fn parse(alloc: Allocator, args_iter: anytype, err: ?*Error) ParseError!Options 
         }
         if (eq(arg, "--fix")) {
             opts.fix = true;
+        } else if (eq(arg, "--fix-dangerously")) {
+            opts.fix_dangerously = true;
+            opts.fix = true;
         } else if (eq(arg, "-q") or eq(arg, "--quiet")) {
             opts.quiet = true;
         } else if (eq(arg, "-V") or eq(arg, "--verbose")) {

--- a/src/linter/LintService.zig
+++ b/src/linter/LintService.zig
@@ -20,7 +20,7 @@ pub fn init(
     options: Options,
 ) !LintService {
     errdefer config.arena.deinit();
-    var linter = try Linter.init(allocator, config);
+    var linter = try Linter.initWithOptions(allocator, config, .{ .fix = options.fix });
     errdefer linter.deinit();
     const pool = try allocator.create(Thread.Pool);
     errdefer allocator.destroy(pool);

--- a/src/linter/fix.zig
+++ b/src/linter/fix.zig
@@ -20,19 +20,10 @@ pub const Fix = struct {
             .kind = Kind.none,
             .dangerous = false,
         };
-
-        pub inline fn fix() Meta {
-            return Meta{ .kind = Kind.fix, .dangerous = false };
-        }
-        pub inline fn suggestion() Meta {
-            return Meta{ .kind = Kind.suggestion, .dangerous = false };
-        }
-        pub inline fn dangerousFix() Meta {
-            return Meta{ .kind = Kind.fix, .dangerous = true };
-        }
-        pub inline fn dangerousSuggestion() Meta {
-            return Meta{ .kind = Kind.suggestion, .dangerous = true };
-        }
+        pub const dangerous_fix: Meta = .{ .kind = Kind.fix, .dangerous = true };
+        pub const safe_fix: Meta = .{ .kind = Kind.fix, .dangerous = false };
+        pub const dangerous_suggestion: Meta = .{ .kind = Kind.suggestion, .dangerous = true };
+        pub const safe_suggestion: Meta = .{ .kind = Kind.suggestion, .dangerous = false };
 
         pub fn isDisabled(self: Meta) bool {
             // TODO: check output assembly, check if `@bitcast(self) == 0` is faster.

--- a/src/linter/linter.zig
+++ b/src/linter/linter.zig
@@ -50,7 +50,7 @@ pub const Linter = struct {
             .rules = ruleset,
             .gpa = gpa,
             .arena = arena,
-            .options = options, 
+            .options = options,
         };
         return linter;
     }

--- a/src/linter/linter.zig
+++ b/src/linter/linter.zig
@@ -39,6 +39,9 @@ pub const Linter = struct {
     }
 
     pub fn init(gpa: Allocator, config: Config.Managed) !Linter {
+        return initWithOptions(gpa, config, .{});
+    }
+    pub fn initWithOptions(gpa: Allocator, config: Config.Managed, options: Options) !Linter {
         var arena = ArenaAllocator.init(gpa);
         errdefer arena.deinit();
         var ruleset = RuleSet{};
@@ -47,6 +50,7 @@ pub const Linter = struct {
             .rules = ruleset,
             .gpa = gpa,
             .arena = arena,
+            .options = options, 
         };
         return linter;
     }
@@ -82,7 +86,8 @@ pub const Linter = struct {
 
         var ctx = Context.init(self.gpa, semantic, source);
         defer ctx.deinit();
-        if (self.options.fix) ctx.fix = Fix.Meta.fix();
+        // if (self.options.fix) ctx.fix = Fix.Meta.safe_fix;
+        ctx.fix = self.options.fix;
         const nodes = ctx.semantic.ast.nodes;
         assert(nodes.len < std.math.maxInt(u32));
 
@@ -244,7 +249,7 @@ pub const Linter = struct {
     };
 
     pub const Options = struct {
-        fix: bool = false,
+        fix: Fix.Meta = Fix.Meta.disabled,
     };
 };
 

--- a/src/linter/rules/no_catch_return.zig
+++ b/src/linter/rules/no_catch_return.zig
@@ -59,7 +59,7 @@ pub const meta: Rule.Meta = .{
     .name = "no-catch-return",
     .category = .pedantic,
     .default = .warning,
-    .fix = Fix.Meta.fix(),
+    .fix = Fix.Meta.safe_fix,
 };
 
 fn noCatchReturnDiagnostic(ctx: *LinterContext, return_node: Node.Index) Error {

--- a/src/linter/rules/unused_decls.zig
+++ b/src/linter/rules/unused_decls.zig
@@ -48,10 +48,15 @@
 const std = @import("std");
 const semantic = @import("../../semantic.zig");
 const _rule = @import("../rule.zig");
+const _fix = @import("../fix.zig");
+const _span = @import("../../span.zig");
 
+const Span = _span.Span;
 const Symbol = semantic.Symbol;
 const Scope = semantic.Scope;
+const Node = semantic.Ast.Node;
 const LinterContext = @import("../lint_context.zig");
+const Fix = _fix.Fix;
 const Rule = _rule.Rule;
 
 // Rule metadata
@@ -61,12 +66,13 @@ pub const meta: Rule.Meta = .{
     .default = .warning,
     // TODO: set the category to an appropriate value
     .category = .correctness,
+    .fix = Fix.Meta.dangerous_fix,
 };
 
 pub fn runOnSymbol(_: *const UnusedDecls, symbol: Symbol.Id, ctx: *LinterContext) void {
     const s = symbol.into(usize);
-    const slice = ctx.symbols().symbols.slice();
-    const references: []const semantic.Reference.Id = slice.items(.references)[s].items;
+    const symbols = ctx.symbols().symbols.slice();
+    const references: []const semantic.Reference.Id = symbols.items(.references)[s].items;
     // TODO: ignore write references
     // TODO: check for references by variables that are themselves unused. for
     // example, both `foo` and `bar` should be reported:
@@ -76,11 +82,11 @@ pub fn runOnSymbol(_: *const UnusedDecls, symbol: Symbol.Id, ctx: *LinterContext
     //
     if (references.len > 0) return;
 
-    const visibility: Symbol.Visibility = slice.items(.visibility)[s];
+    const visibility: Symbol.Visibility = symbols.items(.visibility)[s];
     if (visibility == .public) return;
 
-    const flags: Symbol.Flags = slice.items(.flags)[s];
-    const name = slice.items(.name)[s];
+    const flags: Symbol.Flags = symbols.items(.flags)[s];
+    const name = symbols.items(.name)[s];
 
     // TODO:
     //  1) member references (`foo.bar`) are not currently resolved
@@ -97,20 +103,46 @@ pub fn runOnSymbol(_: *const UnusedDecls, symbol: Symbol.Id, ctx: *LinterContext
     // TODO: since references on container members are not yet recorded, there
     // are too many false positives for non-root constants. Once such references
     // are reliably resolved, remove this check.
-    const scope: Scope.Id = slice.items(.scope)[s];
+    const scope: Scope.Id = symbols.items(.scope)[s];
     if (!scope.eql(semantic.Semantic.ROOT_SCOPE_ID)) return;
 
     if (flags.s_variable and flags.s_const) {
-        ctx.report(ctx.diagnosticf(
-            "variable '{s}' is declared but never used.",
-            .{name},
-            .{ctx.spanT(slice.items(.token)[s].unwrap().?.int())},
-        ));
+        const span = ctx.spanT(symbols.items(.token)[s].unwrap().?.int());
+        const fixer = UnusedDeclsFixer.init(ctx, symbol);
+        ctx.reportWithFix(
+            fixer,
+            ctx.diagnosticf(
+                "variable '{s}' is declared but never used.",
+                .{name},
+                .{span},
+            ),
+            &UnusedDeclsFixer.removeDecl,
+        );
         return;
     }
 }
 
-// Used by the Linter to register the rule so it can be run.
+const UnusedDeclsFixer = struct {
+    span: Span,
+
+    fn init(ctx: *const LinterContext, symbol: Symbol.Id) UnusedDeclsFixer {
+        if (ctx.fix.isDisabled()) return .{ .span = Span.EMPTY };
+        // NOTE: if we cover more kinds of symbols in the future, this may cover
+        // something we don't want (e.g. decl node for fn params is the fn proto).
+        // Fine for now since we only report top-level vars.
+        const decl: Node.Index = ctx.symbols().symbols.items(.decl)[symbol.int()];
+        var span = ctx.spanN(decl).span;
+        const text = ctx.source.text();
+        if (span.end < text.len and text[span.end] == ';') span.end += 1;
+
+        return .{ .span = span };
+    }
+
+    fn removeDecl(self: UnusedDeclsFixer, b: Fix.Builder) anyerror!Fix {
+        return b.delete(self.span);
+    }
+};
+
 pub fn rule(self: *UnusedDecls) Rule {
     return Rule.init(self);
 }
@@ -139,17 +171,28 @@ test UnusedDecls {
         ,
     };
 
-    // Code your rule should fail on
     const fail = &[_][:0]const u8{
-        // TODO: add test cases
         "const x = 1;",
         \\const std = @import("std"); const Allocator = std.mem.Allocator;
         ,
         "extern const x: usize;",
     };
 
+    const fix = &[_]RuleTester.FixCase{
+        .{ .src = "const x = 1;", .expected = "" },
+        .{ .src = "const std = @import(\"std\");", .expected = "" },
+        .{ .src = 
+        \\//! This module does a thing
+        \\const std = @import("std");
+        , .expected = 
+        \\//! This module does a thing
+        \\
+        },
+    };
+
     try runner
         .withPass(pass)
         .withFail(fail)
+        .withFix(fix)
         .run();
 }

--- a/src/linter/test/fix_test.zig
+++ b/src/linter/test/fix_test.zig
@@ -66,6 +66,23 @@ test "inserting at start of file" {
     }
 }
 
+test "deleting full lines" {
+    var fixer = fix.Fixer{ .allocator = t.allocator };
+
+    const source = "const x = 1;";
+
+    var res = try fixer.applyFixes(source, toDiagnostic([_]fix.Fix{
+        fix.Fix{
+            .span = Span.new(0, source.len),
+            .replacement = Cow.static(""),
+        },
+    }));
+    defer res.deinit(t.allocator);
+
+    try expect(res.did_fix);
+    try expectEqualStrings("", res.source.items);
+}
+
 test "deleting a section" {
     var fixer = fix.Fixer{ .allocator = t.allocator };
     const src = "const x = 1; const y = 2; const z = 3;";

--- a/src/linter/tester.zig
+++ b/src/linter/tester.zig
@@ -113,12 +113,12 @@ pub fn run(self: *RuleTester) !void {
         try stderr.writeByte('\n');
 
         switch (e) {
-            TestError.PassFailed => {
+            TestError.PassFailed, error.AnalysisFailed => {
                 for (self.diagnostics.items) |diagnostic| {
                     try self.fmt.format(&stderr, diagnostic.err);
                     try stderr.writeByte('\n');
                 }
-                return TestError.FailPassed;
+                return e;
             },
             else => return e,
         }
@@ -177,7 +177,7 @@ fn runImpl(self: *RuleTester) LintTesterError!void {
 
     // Run fix cases
     i = 0;
-    self.linter.options.fix = true;
+    self.linter.options.fix = Fix.Meta.safe_fix;
     for (self.fixes.items) |case| {
         defer i += 1;
 


### PR DESCRIPTION
After this PR is merged, `zlint --fix-dangerously` will automatically delete all unused top-level variable declarations 🎊 