### PR TITLE
fix(sema): handle container layouts

### DIFF
--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -561,54 +561,38 @@ fn visitContainer(self: *SemanticBuilder, node: NodeIndex, container: full.Conta
 
     const main_token = main_tokens[node];
     const container_tag = tags[main_tokens[node]];
-    const scope_flags: Scope.Flags, const symbol_flags: Symbol.Flags = switch (container_tag) {
+    const scope_flags: Scope.Flags, var symbol_flags: Symbol.Flags = switch (container_tag) {
         .keyword_enum => .{ .{ .s_enum = true }, .{ .s_enum = true } },
-        .keyword_struct => struct_flags: {
-            const scope_flags_: Scope.Flags = .{ .s_struct = true };
-            var symbol_flags_: Symbol.Flags = .{ .s_struct = true };
-            if (container.layout_token) |layout_token| switch (tags[layout_token]) {
-                // const Foo = extern struct { ... }
-                .keyword_extern => symbol_flags_.s_extern = true,
-                // packed structs may have a concrete layout type. We need to
-                // record a type reference for it. e.g.
-                // const Foo = packed struct(u32) { ... }
-                .keyword_packed => {
-                    const maybe_identifier = main_token + 2;
-                    if (tags[maybe_identifier] == .identifier and tags[maybe_identifier + 1] != .period) {
-                        const prev = self.takeReferenceFlags();
-                        defer self._curr_reference_flags = prev;
-                        _ = try self.recordReference(.{
-                            .flags = .{ .type = true },
-                            .node = node,
-                            .token = maybe_identifier,
-                        });
-                    }
-                },
-                else => {},
-            };
-            break :struct_flags .{ scope_flags_, symbol_flags_ };
-        },
-        .keyword_union => union_flags: {
-            // record references in tagged unions, e.g. T in `const Bar = union(T) { ... };`
-            // `union(enum)` cases have `enum_token` populated.
-            if (container.ast.enum_token == null) {
-                const maybe_identifier = main_token + 2;
-                if (tags[maybe_identifier] == .identifier and tags[maybe_identifier + 1] != .period) {
-                    const prev = self.takeReferenceFlags();
-                    defer self._curr_reference_flags = prev;
-                    _ = try self.recordReference(.{
-                        .flags = .{ .type = true },
-                        .node = node,
-                        .token = maybe_identifier,
-                    });
-                }
-            }
-
-            break :union_flags .{ .{ .s_union = true }, .{ .s_union = true } };
-        },
+        .keyword_struct => .{ .{ .s_struct = true }, .{ .s_struct = true } },
+        .keyword_union => .{ .{ .s_union = true }, .{ .s_union = true } },
         // e.g. opaque
         else => .{ .{}, .{} },
     };
+
+    // const Foo = packed struct { ... }
+    //             ^^^^^^
+    if (container.layout_token) |layout_token| switch (tags[layout_token]) {
+        // TODO: extern/packed enums are not allowed. Report it.
+        .keyword_extern => symbol_flags.s_extern = true,
+        else => {},
+    };
+
+    // packed structs, tagged unions, and enums may specify a representation type.
+    // We need to record a type reference for it.
+    // TODO: check if extern containers are banned from having a representation type.
+    // if so, report it.
+    if (container.ast.enum_token == null) {
+        const maybe_ident = main_token + 2;
+        if (tags[maybe_ident] == .identifier and tags[maybe_ident + 1] != .period) {
+            const prev = self.takeReferenceFlags();
+            defer self._curr_reference_flags = prev;
+            _ = try self.recordReference(.{
+                .flags = .{ .type = true },
+                .node = node,
+                .token = maybe_ident,
+            });
+        }
+    }
 
     self.currentContainerSymbolFlags().set(symbol_flags, true);
     self._curr_symbol_flags.set(symbol_flags, true);

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -583,7 +583,10 @@ fn visitContainer(self: *SemanticBuilder, node: NodeIndex, container: full.Conta
     // if so, report it.
     if (container.ast.enum_token == null) {
         const maybe_ident = main_token + 2;
-        if (tags[maybe_ident] == .identifier and tags[maybe_ident + 1] != .period) {
+        if (tags[main_token + 1] == .l_paren and // w/o this, enum { x } triggers on x
+            tags[maybe_ident] == .identifier and
+            tags[maybe_ident + 1] != .period)
+        {
             const prev = self.takeReferenceFlags();
             defer self._curr_reference_flags = prev;
             _ = try self.recordReference(.{

--- a/src/semantic/test/symbol_decl_test.zig
+++ b/src/semantic/test/symbol_decl_test.zig
@@ -62,6 +62,10 @@ test "Symbol flags - container declarations" {
             .{ .s_struct = true, .s_variable = true, .s_const = true },
         },
         .{
+            "const x = extern struct { y: u32 };",
+            .{ .s_struct = true, .s_extern = true, .s_variable = true, .s_const = true },
+        },
+        .{
             "const x = enum { y };",
             .{ .s_enum = true, .s_variable = true, .s_const = true },
         },

--- a/src/semantic/test/symbol_decl_test.zig
+++ b/src/semantic/test/symbol_decl_test.zig
@@ -55,6 +55,7 @@ test "Symbol flags - variable declarations" {
         },
     });
 }
+
 test "Symbol flags - container declarations" {
     try testFlags(&[_]TestCase{
         .{
@@ -72,6 +73,10 @@ test "Symbol flags - container declarations" {
         .{
             "const x = union(enum) { y };",
             .{ .s_union = true, .s_variable = true, .s_const = true },
+        },
+        .{
+            "const x = extern union { x: Foo, y: Bar };",
+            .{ .s_union = true, .s_extern = true, .s_variable = true, .s_const = true },
         },
     });
 }

--- a/src/semantic/test/symbol_ref_test.zig
+++ b/src/semantic/test/symbol_ref_test.zig
@@ -424,7 +424,7 @@ test "Reference flags - `x` - indexes and slices" {
     });
 }
 
-test "Reference flags - `x` - containers" {
+test "Reference flags - `x` - structs" {
     try testRefsOnX(&[_]RefTestCase{
         .{
             \\const x = 1;
@@ -433,12 +433,39 @@ test "Reference flags - `x` - containers" {
             .{ .read = true },
         },
         .{
+            \\const x = u8;
+            \\const Foo = packed struct(x) { a: bool, _: u7 };
+            ,
+            .{ .type = true },
+        },
+        .{
             \\const x = struct {};
             \\const y = x{};
             ,
             .{ .read = true },
         },
     });
+}
+
+test "Reference flags - `x` - tagged unions" {
+    const x = 1;
+    _ = x;
+    std.debug.print("here\n", .{});
+    try testRefsOnX(&[_]RefTestCase{
+    // .{
+    //     \\const x = u32;
+    //     \\const Foo = union(enum) {
+    //     \\  a: x
+    //     \\};
+    //     ,
+    //     .{ .type = true },
+    // },
+    .{
+        \\const x = enum { a, b };
+        \\const Foo = union(x) { a: u32, b: i32 };
+        ,
+        .{ .type = true },
+    }});
 }
 
 test "symbols referenced before their declaration" {

--- a/src/semantic/test/symbol_ref_test.zig
+++ b/src/semantic/test/symbol_ref_test.zig
@@ -468,6 +468,23 @@ test "Reference flags - `x` - tagged unions" {
     }});
 }
 
+test "Reference flags - `x` - enums" {
+    try testRefsOnX(&[_]RefTestCase{
+        .{
+            \\const x = u32;
+            \\const Foo = enum(x) { a, b };
+            ,
+            .{ .type = true },
+        },
+        .{
+            \\const x = 1;
+            \\const Foo = enum { a = 1, b = x };
+            ,
+            .{ .read = true },
+        },
+    });
+}
+
 test "symbols referenced before their declaration" {
     const sources = [_][:0]const u8{
         \\const y = x;

--- a/src/semantic/test/symbol_ref_test.zig
+++ b/src/semantic/test/symbol_ref_test.zig
@@ -452,20 +452,21 @@ test "Reference flags - `x` - tagged unions" {
     _ = x;
     std.debug.print("here\n", .{});
     try testRefsOnX(&[_]RefTestCase{
-    // .{
-    //     \\const x = u32;
-    //     \\const Foo = union(enum) {
-    //     \\  a: x
-    //     \\};
-    //     ,
-    //     .{ .type = true },
-    // },
-    .{
-        \\const x = enum { a, b };
-        \\const Foo = union(x) { a: u32, b: i32 };
-        ,
-        .{ .type = true },
-    }});
+        .{
+            \\const x = u32;
+            \\const Foo = union(enum) {
+            \\  a: x
+            \\};
+            ,
+            .{ .type = true },
+        },
+        .{
+            \\const x = enum { a, b };
+            \\const Foo = union(x) { a: u32, b: i32 };
+            ,
+            .{ .type = true },
+        },
+    });
 }
 
 test "Reference flags - `x` - enums" {


### PR DESCRIPTION
This PR has two fixes in it.


First, record identifier references for containers that specify a backing representation.

```zig
const Foo = packed struct (u32) { };
//                         ^^^
const Tag = enum { a, b };
const Bar = union(Tag) { a: void, b: u32 };
//                ^^^
const Baz = enum(u8) { a, b };
//               ^^
```

Second, add `.s_extern` to symbol flags for extern unions and structs. extern enums aren't allowed by Zig, but for now they still get `.s_extern`.