### PR TITLE
fix: spans over multi-line nodes

### DIFF
--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -65,8 +65,14 @@ pub inline fn links(self: *const Context) *const Semantic.NodeLinks {
 
 pub fn spanN(self: *const Context, node_id: Ast.Node.Index) LabeledSpan {
     // TODO: inline
-    const s = self.semantic.ast.nodeToSpan(node_id);
-    return LabeledSpan.unlabeled(s.start, s.end);
+    const ast_ = self.semantic.ast;
+    const tok_locations: []const Semantic.Token.Loc = self.semantic.tokens.items(.loc);
+
+    const first = ast_.firstToken(node_id);
+    const last = ast_.lastToken(node_id);
+    const first_start = tok_locations[first].start;
+    const last_end = tok_locations[last].end;
+    return LabeledSpan.unlabeled(@intCast(first_start), @intCast(last_end));
 }
 
 pub fn spanT(self: *const Context, token_id: Ast.TokenIndex) LabeledSpan {

--- a/src/linter/rules/unused_decls.zig
+++ b/src/linter/rules/unused_decls.zig
@@ -181,11 +181,21 @@ test UnusedDecls {
     const fix = &[_]RuleTester.FixCase{
         .{ .src = "const x = 1;", .expected = "" },
         .{ .src = "const std = @import(\"std\");", .expected = "" },
+        .{ .src = "const x = struct {\na: u32,\n};", .expected = "" },
         .{ .src = 
         \\//! This module does a thing
         \\const std = @import("std");
         , .expected = 
         \\//! This module does a thing
+        \\
+        },
+        .{ .src = 
+        \\pub const used = 1;
+        \\const unused = struct {
+        \\  a: u32 = 1
+        \\};
+        , .expected = 
+        \\pub const used = 1;
         \\
         },
     };


### PR DESCRIPTION
`ast.nodeToSpan` truncates spans for nodes that cover more than one line. Not sure why they do that, but it breaks our code. We should replace all usages of it tbh.