### PR TITLE
fix(sema): container field/variable name collisions

### DIFF
--- a/src/linter/rules/unused_decls.zig
+++ b/src/linter/rules/unused_decls.zig
@@ -169,6 +169,11 @@ test UnusedDecls {
         \\const module = @import("module.zig");
         \\usingnamespace module;
         ,
+        \\const Bar = @import("Foo.zig");
+        \\pub const Thing = union(enum) {
+        \\  Foo,
+        \\  Bar: Bar, 
+        \\};
     };
 
     const fail = &[_][:0]const u8{

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -819,7 +819,11 @@ fn visitAssignDestructure(
 fn visitIdentifier(self: *SemanticBuilder, node_id: NodeIndex) !void {
     const main_tokens = self.AST().nodes.items(.main_token);
     const identifier = try self.assertToken(main_tokens[node_id], .identifier);
-    const symbol = self._semantic.resolveBinding(self.currentScope(), self.tokenSlice(identifier));
+    const symbol = self._semantic.resolveBinding(
+        self.currentScope(),
+        self.tokenSlice(identifier),
+        .{ .exclude = .{ .s_member = true } },
+    );
 
     _ = try self.recordReference(.{
         .node = node_id,

--- a/src/semantic/test/symbol_ref_test.zig
+++ b/src/semantic/test/symbol_ref_test.zig
@@ -506,9 +506,6 @@ test "Reference flags - `x` - tuples" {
 }
 
 test "Reference flags - `x` - tagged unions" {
-    const x = 1;
-    _ = x;
-    std.debug.print("here\n", .{});
     try testRefsOnX(&[_]RefTestCase{
         .{
             \\const x = u32;
@@ -521,6 +518,15 @@ test "Reference flags - `x` - tagged unions" {
         .{
             \\const x = enum { a, b };
             \\const Foo = union(x) { a: u32, b: i32 };
+            ,
+            .{ .type = true },
+        },
+        .{
+            \\const x = u32;
+            \\const Foo = union(enum) {
+            \\  y,
+            \\  x: x,
+            \\};
             ,
             .{ .type = true },
         },


### PR DESCRIPTION
Fixes a bug where references to identifiers were being resolved to container members in cases of name collision
```zig
const T = u32;
const Foo = union(enum) {
  T: T, // <- annotation was resolving to declared union member
};
```