### PR TITLE
perf: use SmpAllocator

### DIFF
--- a/test/harness/runner.zig
+++ b/test/harness/runner.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const utils = @import("../utils.zig");
 const TestSuite = @import("TestSuite.zig");
 
@@ -12,8 +13,12 @@ const TestAllocator = std.heap.GeneralPurposeAllocator(.{
     // .retain_metadata = true,
 });
 
-var gpa = TestAllocator{};
-var global_runner_instance = TestRunner.new(gpa.allocator());
+const is_debug = builtin.mode == .Debug;
+var debug_allocator = TestAllocator{};
+var global_runner_instance = TestRunner.new(if (is_debug)
+    debug_allocator.allocator()
+else
+    std.heap.smp_allocator);
 
 pub fn getRunner() *TestRunner {
     return &global_runner_instance;
@@ -27,10 +32,12 @@ pub fn addTest(test_file: TestRunner.TestFile) *TestRunner {
 pub fn globalShutdown() void {
     getRunner().deinit();
 
-    _ = gpa.detectLeaks();
-    const status = gpa.deinit();
-    if (status == .leak) {
-        panic("Memory leak detected\n", .{});
+    if (is_debug) {
+        _ = debug_allocator.detectLeaks();
+        const status = debug_allocator.deinit();
+        if (status == .leak) {
+            panic("Memory leak detected\n", .{});
+        }
     }
 }
 


### PR DESCRIPTION
Use the new `SmpAllocator` in release builds. Gives us another 17% perf bump
<img width="752" alt="image" src="https://github.com/user-attachments/assets/e313eaf9-fb4a-4e7a-b9ac-142eb841a698" />
