### PR TITLE
perf: format to string before writing

### DIFF
--- a/src/reporter/Reporter.zig
+++ b/src/reporter/Reporter.zig
@@ -116,7 +116,7 @@ pub const Reporter = struct {
 
         for (errors) |err| {
             var e = err;
-            defer e.deinit(allocator);
+            defer e.deinit(alloc);
             if (self.opts.quiet and err.severity != .err) continue;
             var w = string_writer.writer().any();
             self.vtable.format(self.ptr, &w, err) catch |fmt_err| {

--- a/src/reporter/Reporter.zig
+++ b/src/reporter/Reporter.zig
@@ -238,5 +238,4 @@ const Writer = std.io.AnyWriter;
 
 test {
     std.testing.refAllDecls(@This());
-    std.testing.refAllDecls(@import("Queue.zig"));
 }

--- a/src/reporter/StringWriter.zig
+++ b/src/reporter/StringWriter.zig
@@ -12,7 +12,7 @@ pub inline fn slice(self: *const StringWriter) []const u8 {
     return self.buf.items;
 }
 
-pub fn writer(self: *StringWriter) Writer  {
+pub fn writer(self: *StringWriter) Writer {
     return Writer{ .context = self };
 }
 

--- a/src/reporter/StringWriter.zig
+++ b/src/reporter/StringWriter.zig
@@ -1,0 +1,26 @@
+const StringWriter = @This();
+const Writer = std.io.GenericWriter(*StringWriter, Allocator.Error, write);
+
+buf: std.ArrayList(u8),
+
+pub fn initCapacity(capacity: usize, allocator: Allocator) Allocator.Error!StringWriter {
+    const buf = try std.ArrayList(u8).initCapacity(allocator, capacity);
+    return StringWriter{ .buf = buf };
+}
+
+pub inline fn slice(self: *const StringWriter) []const u8 {
+    return self.buf.items;
+}
+
+pub fn writer(self: *StringWriter) Writer  {
+    return Writer{ .context = self };
+}
+
+pub fn write(self: *StringWriter, bytes: []const u8) Allocator.Error!usize {
+    try self.buf.appendSlice(bytes);
+    return bytes.len;
+}
+
+const std = @import("std");
+const io = std.io;
+const Allocator = std.mem.Allocator;


### PR DESCRIPTION
This reduces write contention on stdout lock by letting linting threads format in parallel before blocking to write. Brings average reporting times when running on Bun from ~800ms to ~500ms.