### PR TITLE
feat(linter): configure ignored folders

### DIFF
--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -109,6 +109,11 @@ const LintVisitor = struct {
                 } else if (mem.eql(u8, entry.basename, "vendor") or mem.eql(u8, entry.basename, "zig-out")) {
                     return WalkState.Skip;
                 }
+                for (self.service.config.config.ignore) |ignore| {
+                    if (mem.startsWith(u8, entry.path, ignore)) {
+                        return WalkState.Skip;
+                    }
+                }
             },
             .file => {
                 if (!mem.eql(u8, path.extension(entry.path), ".zig")) {

--- a/src/cli/lint_config.zig
+++ b/src/cli/lint_config.zig
@@ -37,7 +37,12 @@ pub fn resolveLintConfig(
         scanner.enableDiagnostics(&diagnostics);
         // FIXME: i hate all these allocations, but they're needed b/c of how
         // errors work. That needs refactoring.
-        const config = json.parseFromTokenSourceLeaky(lint.Config, arena_alloc, &scanner, .{}) catch |e| {
+        const config = json.parseFromTokenSourceLeaky(
+            lint.Config,
+            arena_alloc,
+            &scanner,
+            .{ .ignore_unknown_fields = true },
+        ) catch |e| {
             err.* = getReportForParseError(err_alloc, e, source, &diagnostics);
             err.source_name = err_alloc.dupe(u8, maybe_path_to_config) catch @panic(err.message.borrow());
             return e;

--- a/src/linter/Config.zig
+++ b/src/linter/Config.zig
@@ -1,4 +1,5 @@
 rules: RulesConfig = .{},
+ignore: []const []const u8 = &[_][]const u8{},
 
 const Config = @This();
 
@@ -112,7 +113,6 @@ test "RulesConfig.jsonParse" {
             RulesConfig,
             t.allocator,
             &scanner,
-            .{},
         ));
     }
 }

--- a/src/linter/Config.zig
+++ b/src/linter/Config.zig
@@ -113,6 +113,7 @@ test "RulesConfig.jsonParse" {
             RulesConfig,
             t.allocator,
             &scanner,
+            .{},
         ));
     }
 }

--- a/zlint.schema.json
+++ b/zlint.schema.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ZLint Config",
+    "type": "object",
+    "properties": {
+        "ignore": {
+            "type": "array",
+            "description": "Files and folders to skip. Uses `startsWith` to check if files are ignored.\n\n`zig-out` and `vendor` are always ignored, as well as hidden folders.",
+            "default": [
+                "zig-out",
+                "vendor"
+            ],
+            "items": {
+                "type": "string"
+            }
+        },
+        "rules": {
+            "type": "object",
+            "description": "Configure what rules to run and what error level to set them to.",
+            "properties": {
+                "homeless-try": {
+                    "$ref": "#/definitions/RuleToggle"
+                },
+                "line-length": {
+                    "$ref": "#/definitions/RuleToggle"
+                },
+                "must-return-ref": {
+                    "$ref": "#/definitions/RuleToggle"
+                },
+                "no-catch-return": {
+                    "$ref": "#/definitions/RuleToggle"
+                },
+                "no-return-try": {
+                    "$ref": "#/definitions/RuleToggle"
+                },
+                "no-unresolved": {
+                    "$ref": "#/definitions/RuleToggle"
+                },
+                "suppressed-errors": {
+                    "$ref": "#/definitions/RuleToggle"
+                },
+                "unsafe-undefined": {
+                    "$ref": "#/definitions/RuleToggle"
+                },
+                "unused-decls": {
+                    "$ref": "#/definitions/RuleToggle"
+                },
+                "useless-error-return": {
+                    "$ref": "#/definitions/RuleToggle"
+                },
+                "empty-file": {
+                    "$ref": "#/definitions/RuleToggle"
+                }
+            },
+            "additionalProperties": {
+                "$ref": "#/definitions/RuleToggle"
+            }
+        }
+    },
+    "definitions": {
+        "RuleToggle": {
+            "type": "string",
+            "description": "Set the error level of a rule. 'off' and 'allow' do the same thing.",
+            "enum": [
+                "error",
+                "warn",
+                "off",
+                "allow"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Support ignoring files and folders via `zlint.json`. I've also added a JSON schema file to make life a little better.

```json
{
    "$schema": "./zlint.schema.json",
    "ignore": ["test/fixtures"],
    "rules": {
        "unused-decls": "warn"
    }
}
```