### PR TITLE
fix(linter/unsafe-undefined): false positive for enum variants named `undefined`

### DIFF
--- a/src/linter/rules/unsafe_undefined.zig
+++ b/src/linter/rules/unsafe_undefined.zig
@@ -447,7 +447,6 @@ test UnsafeUndefined {
         \\const deinit: u32 = undefined;
     };
 
-    _ = debug;
     try runner
         .withPass(pass)
         .withFail(fail)

--- a/src/semantic/NodeLinks.zig
+++ b/src/semantic/NodeLinks.zig
@@ -18,6 +18,11 @@ parents: std.ArrayListUnmanaged(NodeIndex) = .{},
 ///
 /// This is _not_ a mapping for scopes that nodes create.
 scopes: std.ArrayListUnmanaged(Scope.Id) = .{},
+/// Maps identifier tokens to the symbols bound to them.
+///
+/// These are the same as `symbol.identifier`, but allow for lookups the other
+/// way.
+symbols: std.AutoHashMapUnmanaged(Ast.TokenIndex, Symbol.Id) = .{},
 /// Maps tokens (usually `.identifier`s) to the references they create. Since
 /// references are sparse in an AST, a hashmap is used to avoid wasting memory.
 references: std.AutoHashMapUnmanaged(Ast.TokenIndex, Reference.Id) = .{},
@@ -36,7 +41,7 @@ pub fn init(alloc: Allocator, ast: *const Ast) Allocator.Error!NodeLinks {
 }
 
 pub fn deinit(self: *NodeLinks, alloc: Allocator) void {
-    inline for (.{ "parents", "scopes", "references" }) |name| {
+    inline for (.{ "parents", "scopes", "symbols", "references" }) |name| {
         @field(self, name).deinit(alloc);
     }
 }
@@ -102,6 +107,7 @@ const ROOT_NODE_ID = Semantic.ROOT_NODE_ID;
 const NULL_NODE = Semantic.NULL_NODE;
 const ROOT_SCOPE_ID = Semantic.ROOT_SCOPE_ID;
 const Scope = Semantic.Scope;
+const Symbol = Semantic.Symbol;
 const Reference = Semantic.Reference;
 
 const Allocator = std.mem.Allocator;

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -1495,6 +1495,9 @@ inline fn declareSymbol(
         opts.flags.merge(self._curr_symbol_flags),
     );
     try self._semantic.scopes.addBinding(self._gpa, scope, symbol_id);
+    if (opts.identifier) |identifier| {
+        try self._semantic.node_links.symbols.put(self._gpa, identifier, symbol_id);
+    }
     return symbol_id;
 }
 


### PR DESCRIPTION
Closes #242, supersedes #254

This also adds identifier tokens -> symbol declarations in `NodeLinks`