### PR TITLE
feat: add `ignore-rules` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ All lints and what they do can be found [here](docs/rules/).
 
 ## ⚙️ Configuration
 
-Create a `zlint.json` file in the same directory as `build.zig`. This disables
-all default rules, only enabling the ones you choose.
+Create a `zlint.json` file in the same directory as `build.zig`. Once you've created this configuration file, you can specify which rules you want to enable and at what severity level they should be reported.
 
 ```json
 {
@@ -54,6 +53,17 @@ all default rules, only enabling the ones you choose.
     "unsafe-undefined": "error",
     "homeless-try": "warn"
   }
+}
+```
+
+You can also use the `ignore-rules` array to disable specific rules globally:
+
+```json
+{
+  "ignore-rules": [
+    "unsafe-undefined",
+    "homeless-try"
+  ]
 }
 ```
 

--- a/src/linter/Config.zig
+++ b/src/linter/Config.zig
@@ -1,5 +1,6 @@
-rules: RulesConfig = .{},
-ignore: []const []const u8 = &[_][]const u8{},
+rules: RulesConfig = DEFAULT_RULES_CONFIG,
+ignore: []const []const u8 = &[_][]const u8{"zig-out", "vendor"},
+@"ignore-rules": []const []const u8 = &[_][]const u8{},
 
 const Config = @This();
 

--- a/src/linter/linter.zig
+++ b/src/linter/linter.zig
@@ -43,7 +43,7 @@ pub const Linter = struct {
         var arena = ArenaAllocator.init(gpa);
         errdefer arena.deinit();
         var ruleset = RuleSet{};
-        try ruleset.loadRulesFromConfig(arena.allocator(), &config.config.rules);
+        try ruleset.loadRulesFromConfig(arena.allocator(), &config.config.rules, config.config.@"ignore-rules");
         const linter = Linter{
             .rules = ruleset,
             .gpa = gpa,

--- a/zlint.schema.json
+++ b/zlint.schema.json
@@ -55,6 +55,14 @@
             "additionalProperties": {
                 "$ref": "#/definitions/RuleToggle"
             }
+        },
+        "ignore-rules": {
+            "type": "array",
+            "description": "Configure what rules ignore.",
+            "default": [],
+            "items": {
+                "type": "string"
+            }
         }
     },
     "definitions": {


### PR DESCRIPTION
Hi, great project. I've been using it for a couple of days and I'm fascinated.

I wanted to propose a new configuration for `zlint.json`, in which we can define which rules to ignore globally. Currently, we can define it through the `rules` field, and those not defined there will be ignored. However, in the future, as you add more rules, it will become a bit tedious to have to check for new rules and keep the configuration file updated.

A simple example can be:

```json
{
  "ignore-rules": [
    "unsafe-undefined",
    "unused-decls"
  ]
}
```