### PR TITLE
fix(linter/homeless-try): false positive in labeled continues

### DIFF
--- a/src/linter/rules/homeless_try.zig
+++ b/src/linter/rules/homeless_try.zig
@@ -298,6 +298,22 @@ test HomelessTry {
         \\  try foo();
         \\  return error.Bar;
         \\}
+        ,
+        //https://github.com/DonIsaac/zlint/issues/258
+        \\fn getValue(value: u8) !u8 {
+        \\    if (value == 1) return error.Test;
+        \\
+        \\    return value - 1;
+        \\}
+        \\
+        \\pub fn main() !void {
+        \\    loop: switch (3) {
+        \\        3 => continue :loop try getValue(3),
+        \\        2 => continue :loop try getValue(2),
+        \\        1 => {},
+        \\        else => unreachable
+        \\    }
+        \\}
     };
 
     const fail = &[_][:0]const u8{

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -464,7 +464,6 @@ fn visitNode(self: *SemanticBuilder, node_id: NodeIndex) SemanticError!void {
         .@"break" => return self.visit(data[node_id].rhs),
         // rhs for these nodes are always `undefined`.
         .@"await",
-        .@"continue",
         .@"nosuspend",
         .@"return",
         .@"suspend",


### PR DESCRIPTION
closes #258

We needed to change how `continue` nodes got visited, since both lhs and rhs are now used in zig 0.14