### PR TITLE
feat(linter): add `avoid-as` rule

### DIFF
--- a/docs/rules/avoid-as.md
+++ b/docs/rules/avoid-as.md
@@ -1,0 +1,42 @@
+# `avoid-as`
+
+> Category: pedantic
+>
+> Enabled by default?: Yes (warning)
+
+## What This Rule Does
+
+Disallows using `@as()` when types can be otherwise inferred.
+
+Zig has powerful [Result Location Semantics](https://ziglang.org/documentation/master/#Result-Location-Semantics) for inferring what type
+something should be. This happens in function parameters, return types,
+and type annotations. `@as()` is a last resort when no other contextual
+information is available. In any other case, other type inference mechanisms
+should be used.
+
+> [!NOTE]
+> Checks for function parameters and return types are not yet implemented.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```zig
+const x = @as(u32, 1);
+
+fn foo(x: u32) u64 {
+  return @as(u64, x); // type is inferred from return type
+}
+foo(@as(u32, 1)); // type is inferred from function signature
+```
+
+Examples of **correct** code for this rule:
+
+```zig
+const x: u32 = 1;
+
+fn foo(x: u32) void {
+  // ...
+}
+foo(1);
+```

--- a/src/linter/config/rules_config.zig
+++ b/src/linter/config/rules_config.zig
@@ -15,4 +15,5 @@ pub const RulesConfig = struct {
     unused_decls: RuleConfig(rules.UnusedDecls) = .{},
     useless_error_return: RuleConfig(rules.UselessErrorReturn) = .{},
     empty_file: RuleConfig(rules.EmptyFile) = .{},
+    avoid_as: RuleConfig(rules.AvoidAs) = .{},
 };

--- a/src/linter/rules.zig
+++ b/src/linter/rules.zig
@@ -9,3 +9,4 @@ pub const UnsafeUndefined = @import("./rules/unsafe_undefined.zig");
 pub const UnusedDecls = @import("./rules/unused_decls.zig");
 pub const UselessErrorReturn = @import("./rules/useless_error_return.zig");
 pub const EmptyFile = @import("./rules/empty_file.zig");
+pub const AvoidAs = @import("./rules/avoid_as.zig");

--- a/src/linter/rules/avoid_as.zig
+++ b/src/linter/rules/avoid_as.zig
@@ -35,7 +35,6 @@
 
 const std = @import("std");
 const util = @import("util");
-const _source = @import("../../source.zig");
 const semantic = @import("../../semantic.zig");
 const Semantic = semantic.Semantic;
 const _rule = @import("../rule.zig");
@@ -43,10 +42,6 @@ const _span = @import("../../span.zig");
 
 const Ast = std.zig.Ast;
 const Node = Ast.Node;
-const Symbol = semantic.Symbol;
-const Loc = std.zig.Loc;
-const Span = _span.Span;
-const LabeledSpan = _span.LabeledSpan;
 const LinterContext = @import("../lint_context.zig");
 const Rule = _rule.Rule;
 const NodeWrapper = _rule.NodeWrapper;

--- a/src/linter/rules/avoid_as.zig
+++ b/src/linter/rules/avoid_as.zig
@@ -1,0 +1,135 @@
+//! ## What This Rule Does
+//!
+//! Disallows using `@as()` when types can be otherwise inferred.
+//!
+//! Zig has powerful [Result Location Semantics](https://ziglang.org/documentation/master/#Result-Location-Semantics) for inferring what type
+//! something should be. This happens in function parameters, return types,
+//! and type annotations. `@as()` is a last resort when no other contextual
+//! information is available. In any other case, other type inference mechanisms
+//! should be used.
+//!
+//! > [!NOTE]
+//! > Checks for function parameters and return types are not yet implemented.
+//!
+//! ## Examples
+//!
+//! Examples of **incorrect** code for this rule:
+//! ```zig
+//! const x = @as(u32, 1);
+//!
+//! fn foo(x: u32) u64 {
+//!   return @as(u64, x); // type is inferred from return type
+//! }
+//! foo(@as(u32, 1)); // type is inferred from function signature
+//! ```
+//!
+//! Examples of **correct** code for this rule:
+//! ```zig
+//! const x: u32 = 1;
+//!
+//! fn foo(x: u32) void {
+//!   // ...
+//! }
+//! foo(1);
+//! ```
+
+const std = @import("std");
+const util = @import("util");
+const _source = @import("../../source.zig");
+const semantic = @import("../../semantic.zig");
+const Semantic = semantic.Semantic;
+const _rule = @import("../rule.zig");
+const _span = @import("../../span.zig");
+
+const Ast = std.zig.Ast;
+const Node = Ast.Node;
+const Symbol = semantic.Symbol;
+const Loc = std.zig.Loc;
+const Span = _span.Span;
+const LabeledSpan = _span.LabeledSpan;
+const LinterContext = @import("../lint_context.zig");
+const Rule = _rule.Rule;
+const NodeWrapper = _rule.NodeWrapper;
+
+const Error = @import("../../Error.zig");
+const Cow = util.Cow(false);
+
+// Rule metadata
+const AvoidAs = @This();
+pub const meta: Rule.Meta = .{
+    .name = "avoid-as",
+    .category = .pedantic,
+    .default = .warning,
+};
+
+fn preferTypeAnnotationDiagnostic(ctx: *LinterContext, as_tok: Ast.TokenIndex) Error {
+    const span = ctx.semantic.tokenSpan(as_tok);
+    var e = ctx.diagnostic(
+        "Prefer using type annotations over @as().",
+        .{LabeledSpan.from(span)},
+    );
+    e.help = Cow.static("Add a type annotation to the variable declaration.");
+    return e;
+}
+
+// Runs on each node in the AST. Useful for syntax-based rules.
+pub fn runOnNode(_: *const AvoidAs, wrapper: NodeWrapper, ctx: *LinterContext) void {
+    const node = wrapper.node;
+    if (node.tag != .builtin_call_two and node.tag != .builtin_call_comma) {
+        return;
+    }
+
+    const builtin_name = ctx.semantic.tokenSlice(node.main_token);
+    if (!std.mem.eql(u8, builtin_name, "@as")) {
+        return;
+    }
+
+    const tags: []const Node.Tag = ctx.ast().nodes.items(.tag);
+    const datas: []const Node.Data = ctx.ast().nodes.items(.data);
+    const parent = ctx.links().getParent(wrapper.idx) orelse return;
+
+    switch (tags[parent]) {
+        .simple_var_decl => {
+            const data = datas[parent];
+            const ty_annotation = data.lhs;
+            if (ty_annotation == Semantic.NULL_NODE) {
+                @branchHint(.likely);
+                ctx.report(preferTypeAnnotationDiagnostic(ctx, node.main_token));
+            }
+        },
+
+        else => {},
+    }
+}
+
+// Used by the Linter to register the rule so it can be run.
+pub fn rule(self: *AvoidAs) Rule {
+    return Rule.init(self);
+}
+
+const RuleTester = @import("../tester.zig");
+test AvoidAs {
+    const t = std.testing;
+
+    var avoid_as = AvoidAs{};
+    var runner = RuleTester.init(t.allocator, avoid_as.rule());
+    defer runner.deinit();
+
+    // Code your rule should pass on
+    const pass = &[_][:0]const u8{
+        // TODO: add test cases
+        "const x = 1;",
+        "const x: u32 = 1;",
+    };
+
+    // Code your rule should fail on
+    const fail = &[_][:0]const u8{
+        // TODO: add test cases
+        "const x = @as(u32, 1);",
+    };
+
+    try runner
+        .withPass(pass)
+        .withFail(fail)
+        .run();
+}

--- a/src/linter/rules/snapshots/avoid-as.snap
+++ b/src/linter/rules/snapshots/avoid-as.snap
@@ -3,5 +3,5 @@
  1 │ const x = @as(u32, 1);
    ·           ───
    ╰────
-  help: Add a type annotation to the variable declaration.
+  help: Use a type annotation instead.
 

--- a/src/linter/rules/snapshots/avoid-as.snap
+++ b/src/linter/rules/snapshots/avoid-as.snap
@@ -5,3 +5,10 @@
    ╰────
   help: Use a type annotation instead.
 
+  𝙭 avoid-as: Unnecessary use of @as().
+   ╭─[avoid-as.zig:1:16]
+ 1 │ const x: u32 = @as(u32, 1);
+   ·                ───
+   ╰────
+  help: Remove the @as() call.
+

--- a/src/linter/rules/snapshots/avoid-as.snap
+++ b/src/linter/rules/snapshots/avoid-as.snap
@@ -1,0 +1,7 @@
+  𝙭 avoid-as: Prefer using type annotations over @as().
+   ╭─[avoid-as.zig:1:11]
+ 1 │ const x = @as(u32, 1);
+   ·           ───
+   ╰────
+  help: Add a type annotation to the variable declaration.
+


### PR DESCRIPTION
> AI generated bc im feeling lazy

This pull request introduces a new linting rule to disallow the use of `@as()` when types can be inferred, along with the necessary changes to integrate this rule into the existing system.

### New Linting Rule:

* Added a new rule `avoid-as` that disallows the use of `@as()` when types can be inferred. This rule is categorized as `pedantic` and is enabled by default as a warning. [[1]](diffhunk://#diff-eca5dc407c141ea5b0c0e57df9f7d5d859bb57158b92836db34c1cfa214aabe4R1-R42) [[2]](diffhunk://#diff-f0b74904761a925e1f9e35ab917c5a2eaf91b7afeb7673e69a854fbd3b62b47eR1-R201)

### Integration of the New Rule:

* Updated `rules_config.zig` to include the new `avoid-as` rule in the `RulesConfig` struct.
* Updated `rules.zig` to import the new `avoid_as.zig` file.

### Supporting Changes:

* Added a snapshot file `avoid-as.snap` for the new rule to provide diagnostic messages and suggestions.
* Enhanced the `Span` and `LabeledSpan` structs in `span.zig` to include conversion functions from various types, which are used in the new rule implementation. [[1]](diffhunk://#diff-35d3d2d0cf701ff9be24302e2c679f08f5f040b793d8a864702a1294fc0eaf20R64) [[2]](diffhunk://#diff-35d3d2d0cf701ff9be24302e2c679f08f5f040b793d8a864702a1294fc0eaf20R152-R172)