### PR TITLE
fix(linter): `--fix` should not apply dangerous fixes

### DIFF
--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -67,10 +67,8 @@ pub fn lint(alloc: Allocator, options: Options) !u8 {
             try walker.walk();
         } else {
             // SAFETY: initialized by reader
-            var msg_buf: [4069]u8 = undefined;
+            var msg_buf: [4096]u8 = undefined;
             var stdin = std.io.getStdIn();
-            // const did_lock = try stdin.tryLock(.shared);
-            // defer if (did_lock) stdin.unlock();
             var buf_reader = std.io.bufferedReader(stdin.reader());
             var reader = buf_reader.reader();
             while (try reader.readUntilDelimiterOrEof(&msg_buf, '\n')) |filepath| {

--- a/src/linter/fix.zig
+++ b/src/linter/fix.zig
@@ -16,10 +16,7 @@ pub const Fix = struct {
         kind: Kind = .fix,
         dangerous: bool = false,
 
-        pub const disabled = Meta{
-            .kind = Kind.none,
-            .dangerous = false,
-        };
+        pub const disabled = Meta{ .kind = Kind.none, .dangerous = false };
         pub const dangerous_fix: Meta = .{ .kind = Kind.fix, .dangerous = true };
         pub const safe_fix: Meta = .{ .kind = Kind.fix, .dangerous = false };
         pub const dangerous_suggestion: Meta = .{ .kind = Kind.suggestion, .dangerous = true };
@@ -28,6 +25,15 @@ pub const Fix = struct {
         pub fn isDisabled(self: Meta) bool {
             // TODO: check output assembly, check if `@bitcast(self) == 0` is faster.
             return self.kind == Kind.none;
+        }
+
+        /// Check if a fix (`other`) may be applied based on a user-configured filter.
+        /// Here, `self` does not come from a Fix, but from a linter config.
+        pub fn canApply(self: Meta, other: Meta) bool {
+            if (self.kind == .none) return false; // disabled
+            if (!self.dangerous and other.dangerous) return false; // fix is dangerous, but only safe fixes are allowed
+            if (self.kind != other.kind) return false;
+            return true;
         }
     };
 

--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -193,7 +193,11 @@ pub fn reportWithFix(
         std.debug.panic("Fixer for rule \"{s}\" failed: {s}", .{ self.curr_rule_name, @errorName(e) });
     };
 
-    self._report(Diagnostic{ .err = diagnostic_, .fix = fix });
+    if (self.fix.canApply(fix.meta)) {
+        self._report(Diagnostic{ .err = diagnostic_, .fix = fix });
+    } else {
+        self._report(Diagnostic{ .err = diagnostic_ });
+    }
 }
 
 fn _report(self: *Context, diagnostic_: Diagnostic) void {
@@ -273,3 +277,7 @@ const string = util.string;
 
 const Fix = @import("./fix.zig").Fix;
 const FixerFn = @import("./fix.zig").FixerFn;
+
+test {
+    _ = @import("test/lint_context_test.zig");
+}

--- a/src/linter/test/lint_context_test.zig
+++ b/src/linter/test/lint_context_test.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const LinterContext = @import("../lint_context.zig");
+const Fix = @import("../fix.zig").Fix;
+const _semantic = @import("../../semantic.zig");
+const _span = @import("../../span.zig");
+const Source = @import("../../source.zig").Source;
+const Semantic = _semantic.Semantic;
+const SemanticBuilder = _semantic.SemanticBuilder;
+
+const t = std.testing;
+const print = std.debug.print;
+
+fn createCtx(src: [:0]const u8, sema_out: *Semantic, source_out: *Source) !LinterContext {
+    const src2 = try t.allocator.dupeZ(u8, src);
+    var source = try Source.fromString(t.allocator, src2, null);
+    errdefer source.deinit();
+    source_out.* = source;
+
+    var builder = _semantic.SemanticBuilder.init(t.allocator);
+    builder.withSource(&source);
+    defer builder.deinit();
+
+    var res = try builder.build(src);
+    defer res.deinitErrors();
+    if (res.hasErrors()) {
+        defer res.value.deinit();
+        print("Semantic analysis failed with {d} errors. Source:\n\n{s}\n", .{ res.errors.items.len, src });
+        return error.TestFailed;
+    }
+    sema_out.* = res.value;
+    return LinterContext.init(t.allocator, sema_out, source_out);
+}
+
+test "Dangerous fixes do not get saved when only safe fixes are allowed" {
+    var sema: Semantic = undefined;
+    var source: Source = undefined;
+    var ctx = try createCtx("fn foo() void { return 1; }", &sema, &source);
+    defer {
+        var diagnostics = ctx.takeDiagnostics();
+        for (diagnostics.items) |*diagnostic| {
+            diagnostic.deinit(t.allocator);
+        }
+        diagnostics.deinit();
+        ctx.deinit();
+    }
+    defer sema.deinit();
+    defer source.deinit();
+
+    const DangerousFixer = struct {
+        span: _span.Span,
+
+        fn remove(self: @This(), b: Fix.Builder) anyerror!Fix {
+            var fix = b.delete(self.span);
+            fix.meta.dangerous = true;
+            return fix;
+        }
+    };
+
+    const fix_ctx = DangerousFixer{ .span = _span.Span.EMPTY };
+    ctx.reportWithFix(
+        fix_ctx,
+        ctx.diagnostic("ahhh", .{_span.LabeledSpan.from(fix_ctx.span)}),
+        &DangerousFixer.remove,
+    );
+
+    try t.expectEqual(1, ctx.diagnostics.items.len);
+    try t.expectEqual(null, ctx.diagnostics.items[0].fix);
+    try t.expectEqualStrings("ahhh", ctx.diagnostics.items[0].err.message.borrow());
+}


### PR DESCRIPTION
### What This PR Does
Dangerous fixes were being run and applied when users ran `zlint --fix`.