### PR TITLE
refactor(sema): make better use of namespaces

### DIFF
--- a/src/cli/print_command.zig
+++ b/src/cli/print_command.zig
@@ -12,14 +12,14 @@ const Allocator = std.mem.Allocator;
 
 const Options = @import("../cli/Options.zig");
 const Source = @import("../source.zig").Source;
-const semantic = @import("../semantic.zig");
+const Semantic = @import("../semantic.zig").Semantic;
 
 const Printer = @import("../printer/Printer.zig");
 const AstPrinter = @import("../printer/AstPrinter.zig");
 const SemanticPrinter = @import("../printer/SemanticPrinter.zig");
 
 pub fn parseAndPrint(alloc: Allocator, opts: Options, source: Source) !void {
-    var builder = semantic.SemanticBuilder.init(alloc);
+    var builder = Semantic.Builder.init(alloc);
     defer builder.deinit();
     var sema_result = try builder.build(source.text());
     defer sema_result.deinit();

--- a/src/linter/LintService.zig
+++ b/src/linter/LintService.zig
@@ -102,7 +102,7 @@ pub fn lintSource(
 ) (LintError || Allocator.Error)!void {
     // FIXME: empty sources break something but i forget what
     if (source.text().len == 0) return;
-    var builder = SemanticBuilder.init(self.allocator);
+    var builder = Semantic.Builder.init(self.allocator);
     builder.withSource(source);
     defer builder.deinit();
 
@@ -188,4 +188,4 @@ const Fix = @import("fix.zig").Fix;
 const Fixer = @import("fix.zig").Fixer;
 const Error = @import("../Error.zig");
 
-const SemanticBuilder = @import("../semantic.zig").SemanticBuilder;
+const Semantic = @import("../semantic.zig").Semantic;

--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -56,7 +56,7 @@ pub inline fn scopes(self: *const Context) *const Semantic.ScopeTree {
     return &self.semantic.scopes;
 }
 
-pub inline fn symbols(self: *const Context) *const Semantic.SymbolTable {
+pub inline fn symbols(self: *const Context) *const Semantic.Symbol.Table {
     return &self.semantic.symbols;
 }
 

--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -52,7 +52,7 @@ pub fn tokens(self: *const Context) *const Semantic.TokenList.Slice {
     return &self.semantic.tokens;
 }
 
-pub inline fn scopes(self: *const Context) *const Semantic.ScopeTree {
+pub inline fn scopes(self: *const Context) *const Semantic.Scope.Tree {
     return &self.semantic.scopes;
 }
 

--- a/src/linter/test/disabling_rules_test.zig
+++ b/src/linter/test/disabling_rules_test.zig
@@ -5,7 +5,7 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 const lint = @import("../../lint.zig");
 const Linter = lint.Linter;
 const Config = lint.Config;
-const SemanticBuilder = @import("../../semantic.zig").SemanticBuilder;
+const Semantic = @import("../../semantic.zig").Semantic;
 
 const Source = @import("../../source.zig").Source;
 
@@ -49,7 +49,7 @@ test "Enabled rules have their violations reported" {
         },
     };
 
-    var builder = SemanticBuilder.init(t.allocator);
+    var builder = Semantic.Builder.init(t.allocator);
     builder.withSource(&src);
     defer builder.deinit();
 
@@ -84,7 +84,7 @@ test "When no rules are enabled, no violations are reported" {
         errs.deinit();
     };
 
-    var builder = SemanticBuilder.init(t.allocator);
+    var builder = Semantic.Builder.init(t.allocator);
     builder.withSource(&src);
     defer builder.deinit();
 
@@ -119,7 +119,7 @@ test "When a rule is configured to 'off', none of its violations are reported" {
         },
     };
 
-    var builder = SemanticBuilder.init(t.allocator);
+    var builder = Semantic.Builder.init(t.allocator);
     builder.withSource(&src);
     defer builder.deinit();
 
@@ -166,7 +166,7 @@ test "When rules are configured but a specific rule is disabled with 'zlint-disa
         },
     };
 
-    var builder = SemanticBuilder.init(t.allocator);
+    var builder = Semantic.Builder.init(t.allocator);
     builder.withSource(&src);
     defer builder.deinit();
 
@@ -213,7 +213,7 @@ test "When rules are configured but disabled with 'zlint-disable', nothing gets 
         },
     };
 
-    var builder = SemanticBuilder.init(t.allocator);
+    var builder = Semantic.Builder.init(t.allocator);
     builder.withSource(&src);
     defer builder.deinit();
 
@@ -259,7 +259,7 @@ test "When the global disable directive is misplaced, violations still gets repo
         },
     };
 
-    var builder = SemanticBuilder.init(t.allocator);
+    var builder = Semantic.Builder.init(t.allocator);
     builder.withSource(&src);
     defer builder.deinit();
 
@@ -305,7 +305,7 @@ test "When the multiple global directives are set, all rules are honored" {
         },
     };
 
-    var builder = SemanticBuilder.init(t.allocator);
+    var builder = Semantic.Builder.init(t.allocator);
     builder.withSource(&src);
     defer builder.deinit();
 

--- a/src/linter/test/lint_context_test.zig
+++ b/src/linter/test/lint_context_test.zig
@@ -1,11 +1,9 @@
 const std = @import("std");
 const LinterContext = @import("../lint_context.zig");
 const Fix = @import("../fix.zig").Fix;
-const _semantic = @import("../../semantic.zig");
+const Semantic = @import("../../semantic.zig").Semantic;
 const _span = @import("../../span.zig");
 const Source = @import("../../source.zig").Source;
-const Semantic = _semantic.Semantic;
-const SemanticBuilder = _semantic.SemanticBuilder;
 
 const t = std.testing;
 const print = std.debug.print;
@@ -16,7 +14,7 @@ fn createCtx(src: [:0]const u8, sema_out: *Semantic, source_out: *Source) !Linte
     errdefer source.deinit();
     source_out.* = source;
 
-    var builder = _semantic.SemanticBuilder.init(t.allocator);
+    var builder = Semantic.Builder.init(t.allocator);
     builder.withSource(&source);
     defer builder.deinit();
 

--- a/src/linter/tester.zig
+++ b/src/linter/tester.zig
@@ -254,7 +254,7 @@ fn lint(
     src: [:0]const u8,
     test_id: usize,
     errors: *Linter.Diagnostic.List,
-) (Linter.LintError || SemanticBuilder.SemanticError || Allocator.Error)!void {
+) (Linter.LintError || Semantic.Builder.SemanticError || Allocator.Error)!void {
     // TODO: support static strings in Source w/o leaking memory.
     var source = try Source.fromString(
         self.alloc,
@@ -263,7 +263,7 @@ fn lint(
     );
     defer source.deinit();
 
-    var builder = SemanticBuilder.init(self.alloc);
+    var builder = Semantic.Builder.init(self.alloc);
     defer builder.deinit();
     builder.withSource(&source);
 
@@ -361,7 +361,7 @@ const Linter = @import("linter.zig").Linter;
 const Rule = @import("rule.zig").Rule;
 const Fix = @import("fix.zig").Fix;
 const Fixer = @import("fix.zig").Fixer;
-const SemanticBuilder = @import("../semantic.zig").SemanticBuilder;
+const Semantic = @import("../semantic.zig").Semantic;
 const Source = @import("../source.zig").Source;
 const GraphicalFormatter = @import("../reporter.zig").formatter.Graphical;
 

--- a/src/printer/SemanticPrinter.zig
+++ b/src/printer/SemanticPrinter.zig
@@ -54,7 +54,7 @@ pub fn printSymbolTable(self: *SemanticPrinter) !void {
     }
 }
 
-fn printSymbol(self: *SemanticPrinter, symbol: *const Semantic.Symbol, symbols: *const Semantic.SymbolTable) !void {
+fn printSymbol(self: *SemanticPrinter, symbol: *const Semantic.Symbol, symbols: *const Semantic.Symbol.Table) !void {
     const p = self.printer;
     try p.pushObject();
     defer p.pop();

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -14,7 +14,6 @@ pub const Semantic = @import("./semantic/Semantic.zig");
 // parts of semantic
 pub const Ast = std.zig.Ast;
 pub const Symbol = @import("./semantic/Symbol.zig");
-pub const SymbolTable = Symbol.SymbolTable;
 pub const Scope = @import("./semantic/Scope.zig");
 pub const ScopeTree = Scope.ScopeTree;
 pub const Reference = @import("./semantic/Reference.zig");

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -8,8 +8,6 @@
 //! an entire linked binary or library; rather it refers to a single parsed
 //! file.
 
-pub const SemanticBuilder = @import("./semantic/SemanticBuilder.zig");
-
 pub const Semantic = @import("./semantic/Semantic.zig");
 // parts of semantic
 pub const Ast = std.zig.Ast;

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -15,7 +15,6 @@ pub const Semantic = @import("./semantic/Semantic.zig");
 pub const Ast = std.zig.Ast;
 pub const Symbol = @import("./semantic/Symbol.zig");
 pub const Scope = @import("./semantic/Scope.zig");
-pub const ScopeTree = Scope.ScopeTree;
 pub const Reference = @import("./semantic/Reference.zig");
 
 const std = @import("std");

--- a/src/semantic/Scope.zig
+++ b/src/semantic/Scope.zig
@@ -47,7 +47,7 @@ pub const Flags = packed struct(FLAGS_REPR) {
 };
 
 /// Stores variable scopes created by a zig program.
-pub const ScopeTree = struct {
+pub const Tree = struct {
     /// Indexed by scope id.
     scopes: std.MultiArrayList(Scope) = .{},
     /// Mappings from scopes to their descendants.
@@ -61,7 +61,7 @@ pub const ScopeTree = struct {
     /// Returns the number of declared scopes in a program.
     ///
     /// Shorthand for `scope_tree.scopes.len`.
-    pub inline fn len(self: *const ScopeTree) u32 {
+    pub inline fn len(self: *const Scope.Tree) u32 {
         @setRuntimeSafety(!util.IS_DEBUG);
         assert(self.scopes.len < Id.MAX);
 
@@ -72,7 +72,7 @@ pub const ScopeTree = struct {
     ///
     /// Avoid this when possible. Prefer using property slices for better cache
     /// locality.
-    pub fn getScope(self: *const ScopeTree, id: Scope.Id) Scope {
+    pub fn getScope(self: *const Scope.Tree, id: Scope.Id) Scope {
         return self.scopes.get(id.into(usize));
     }
 
@@ -81,7 +81,7 @@ pub const ScopeTree = struct {
     /// ## Errors
     /// If allocation fails. Usually due to OOM.
     pub fn addScope(
-        self: *ScopeTree,
+        self: *Scope.Tree,
         alloc: Allocator,
         parent: ?Scope.Id,
         node: NodeIndex,
@@ -116,22 +116,22 @@ pub const ScopeTree = struct {
         return id;
     }
 
-    pub fn addBinding(self: *ScopeTree, alloc: Allocator, scope_id: Scope.Id, symbol_id: Symbol.Id) Allocator.Error!void {
+    pub fn addBinding(self: *Scope.Tree, alloc: Allocator, scope_id: Scope.Id, symbol_id: Symbol.Id) Allocator.Error!void {
         return self.bindings.items[scope_id.int()].append(alloc, symbol_id);
     }
 
-    pub fn getBindings(self: *const ScopeTree, scope_id: Scope.Id) []const Symbol.Id {
+    pub fn getBindings(self: *const Scope.Tree, scope_id: Scope.Id) []const Symbol.Id {
         return self.bindings.items[scope_id.int()].items;
     }
 
-    pub fn iterParents(self: *const ScopeTree, scope_id: Scope.Id) ScopeParentIterator {
+    pub fn iterParents(self: *const Scope.Tree, scope_id: Scope.Id) ScopeParentIterator {
         return .{
             .curr = scope_id.into(Id.Optional),
             .parents = self.scopes.items(.parent),
         };
     }
 
-    pub fn deinit(self: *ScopeTree, alloc: Allocator) void {
+    pub fn deinit(self: *Scope.Tree, alloc: Allocator) void {
         self.scopes.deinit(alloc);
 
         for (0..self.children.items.len) |i| {
@@ -149,7 +149,7 @@ pub const ScopeTree = struct {
 
 const ScopeParentIterator = struct {
     curr: Scope.Id.Optional,
-    // tree: *const ScopeTree,
+    // tree: *const Scope.Tree,
     parents: []const Id.Optional,
 
     pub fn next(self: *ScopeParentIterator) ?Scope.Id {
@@ -188,11 +188,11 @@ test Flags {
     try t.expectEqual(block, block.merge(.{ .s_block = false }));
 }
 
-test "ScopeTree.addScope" {
+test "Scope.Tree.addScope" {
     const alloc = t.allocator;
     const expectEqual = t.expectEqual;
 
-    var tree = ScopeTree{};
+    var tree = Scope.Tree{};
     defer tree.deinit(alloc);
 
     const root_id = try tree.addScope(alloc, null, 0, .{ .s_top = true });

--- a/src/semantic/Semantic.zig
+++ b/src/semantic/Semantic.zig
@@ -13,7 +13,7 @@
 //! an entire linked binary or library; rather it refers to a single parsed
 //! file.
 
-symbols: SymbolTable = .{},
+symbols: Symbol.Table = .{},
 scopes: ScopeTree = .{},
 modules: ModuleRecord = .{},
 ast: Ast, // NOTE: allocated in _arena
@@ -129,6 +129,5 @@ pub const NodeLinks = @import("NodeLinks.zig");
 pub const Scope = @import("Scope.zig");
 pub const ScopeTree = Scope.ScopeTree;
 pub const Symbol = @import("Symbol.zig");
-pub const SymbolTable = Symbol.SymbolTable;
 pub const Reference = @import("Reference.zig");
 pub const ModuleRecord = @import("ModuleRecord.zig");

--- a/src/semantic/Semantic.zig
+++ b/src/semantic/Semantic.zig
@@ -125,6 +125,7 @@ const TokenIndex = _ast.TokenIndex;
 pub const Token = _tokenizer.Token;
 pub const TokenList = _tokenizer.TokenList;
 
+pub const Builder = @import("SemanticBuilder.zig");
 pub const NodeLinks = @import("NodeLinks.zig");
 pub const Scope = @import("Scope.zig");
 pub const Symbol = @import("Symbol.zig");

--- a/src/semantic/Semantic.zig
+++ b/src/semantic/Semantic.zig
@@ -14,7 +14,7 @@
 //! file.
 
 symbols: Symbol.Table = .{},
-scopes: ScopeTree = .{},
+scopes: Scope.Tree = .{},
 modules: ModuleRecord = .{},
 ast: Ast, // NOTE: allocated in _arena
 // NOTE: We re-tokenize and store our own tokens b/c AST throws away the end
@@ -127,7 +127,6 @@ pub const TokenList = _tokenizer.TokenList;
 
 pub const NodeLinks = @import("NodeLinks.zig");
 pub const Scope = @import("Scope.zig");
-pub const ScopeTree = Scope.ScopeTree;
 pub const Symbol = @import("Symbol.zig");
 pub const Reference = @import("Reference.zig");
 pub const ModuleRecord = @import("ModuleRecord.zig");

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -1701,7 +1701,7 @@ inline fn symbolTable(self: *SemanticBuilder) *Semantic.Symbol.Table {
 }
 
 /// Shorthand for getting the scope tree.
-inline fn scopeTree(self: *SemanticBuilder) *Semantic.ScopeTree {
+inline fn scopeTree(self: *SemanticBuilder) *Semantic.Scope.Tree {
     return &self._semantic.scopes;
 }
 

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -1696,7 +1696,7 @@ inline fn AST(self: *const SemanticBuilder) *const Ast {
 }
 
 /// Shorthand for getting the symbol table.
-inline fn symbolTable(self: *SemanticBuilder) *Semantic.SymbolTable {
+inline fn symbolTable(self: *SemanticBuilder) *Semantic.Symbol.Table {
     return &self._semantic.symbols;
 }
 

--- a/src/semantic/SemanticBuilder.zig
+++ b/src/semantic/SemanticBuilder.zig
@@ -8,6 +8,8 @@
 //     `ast.extra_data`. That gets the variable-len list of child nodes.
 //
 
+const SemanticBuilder = @This();
+
 _gpa: Allocator,
 _arena: ArenaAllocator,
 
@@ -1892,8 +1894,6 @@ fn printScopeStack(self: *const SemanticBuilder) void {
         print("  - {d}: (flags: {any})\n", .{ id, scope_flags[id.into(usize)] });
     }
 }
-
-const SemanticBuilder = @This();
 
 const builtins = @import("builtins.zig");
 const Semantic = @import("./Semantic.zig");

--- a/src/semantic/test/util.zig
+++ b/src/semantic/test/util.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 
 const _source = @import("../../source.zig");
-const SemanticBuilder = @import("../SemanticBuilder.zig");
 const Semantic = @import("../Semantic.zig");
 const report = @import("../../reporter.zig");
 
@@ -17,7 +16,7 @@ pub fn build(src: [:0]const u8) !Semantic {
         report.formatter.Graphical.Theme.unicodeNoColor(),
     );
     defer r.deinit();
-    var builder = SemanticBuilder.init(t.allocator);
+    var builder = Semantic.Builder.init(t.allocator);
     var source = try _source.Source.fromString(
         t.allocator,
         try t.allocator.dupeZ(u8, src),

--- a/test/semantic/ecosystem_coverage.zig
+++ b/test/semantic/ecosystem_coverage.zig
@@ -16,7 +16,7 @@ const REPOS_DIR = "zig-out/repos";
 // SAFETY: globalSetup is always run before this is read
 var repos: std.json.Parsed([]Repo) = undefined;
 
-const SemanticError = zlint.semantic.SemanticBuilder.SemanticError;
+const SemanticError = zlint.semantic.Semantic.Builder.SemanticError;
 var is_tty: bool = false;
 
 pub fn globalSetup(alloc: Allocator) !void {
@@ -51,7 +51,7 @@ fn testSemantic(alloc: Allocator, source: *const Source) !void {
         else
             print("\n", .{});
     }
-    var builder = zlint.semantic.SemanticBuilder.init(alloc);
+    var builder = zlint.semantic.Semantic.Builder.init(alloc);
     defer builder.deinit();
     var res = try builder.build(source.text());
     defer res.deinit();

--- a/test/semantic/snapshot_coverage.zig
+++ b/test/semantic/snapshot_coverage.zig
@@ -9,7 +9,7 @@ const TestFolders = utils.TestFolders;
 const Printer = zlint.printer.Printer;
 const SemanticPrinter = zlint.printer.SemanticPrinter;
 
-const SemanticBuilder = zlint.semantic.SemanticBuilder;
+const Semantic = zlint.semantic.Semantic;
 
 const FailError = error{
     ExpectedSemanticFailure,
@@ -17,7 +17,7 @@ const FailError = error{
 const Error = error{
     // The walker produced a source without a filename.
     SourceMissingFilename,
-} || FailError || SemanticBuilder.SemanticError || Allocator.Error;
+} || FailError || Semantic.Builder.SemanticError || Allocator.Error;
 
 fn run(alloc: Allocator) !void {
     const Suite = std.meta.Tuple(&[_]type{ []const u8, *const test_runner.TestSuite.TestFn });
@@ -51,7 +51,7 @@ fn run(alloc: Allocator) !void {
 
 fn runPass(alloc: Allocator, source: *const zlint.Source) anyerror!void {
     // run analysis
-    var builder = SemanticBuilder.init(alloc);
+    var builder = Semantic.Builder.init(alloc);
     defer builder.deinit();
     var semantic_result = try builder.build(source.text());
     defer semantic_result.deinit();
@@ -111,11 +111,11 @@ fn runFail(alloc: Allocator, source: *const zlint.Source) anyerror!void {
     defer reporter.deinit();
 
     // run analysis
-    var builder = SemanticBuilder.init(alloc);
+    var builder = Semantic.Builder.init(alloc);
     builder.withSource(source);
     defer builder.deinit();
 
-    var semantic_result: SemanticBuilder.Result = builder.build(source.text()) catch {
+    var semantic_result: Semantic.Builder.Result = builder.build(source.text()) catch {
         reporter.reportErrorSlice(alloc, builder._errors.items);
         builder._errors.deinit(alloc);
         return;


### PR DESCRIPTION
* `SymbolTable` -> `Symbol.Table`
* `ScopeTree` -> `Scope.Tree`
* `SemanticBuilder` -> `Semantic.Builder`