### PR TITLE
fix(linter/avoid-as): auto fixer on multi-line @as() args

### DIFF
--- a/src/linter/fix.zig
+++ b/src/linter/fix.zig
@@ -94,8 +94,14 @@ pub const Fix = struct {
 
         pub fn spanCovering(self: Builder, comptime kind: Spanned, id: u32) Span {
             return switch (kind) {
-                .node => Span.from(self.ctx.ast().nodeToSpan(id)),
                 .token => Span.from(self.ctx.semantic.tokens.items(.loc)[id]),
+                .node => {
+                    const locs: []const Semantic.Token.Loc = self.ctx.semantic.tokens.items(.loc);
+                    const ast = self.ctx.ast();
+                    const start = ast.firstToken(id);
+                    const last = ast.lastToken(id);
+                    return Span.new(@intCast(locs[start].start), @intCast(locs[last].end));
+                },
             };
         }
     };
@@ -223,6 +229,7 @@ const std = @import("std");
 const heap = std.heap;
 const mem = std.mem;
 const util = @import("util");
+const Semantic = @import("../semantic.zig").Semantic;
 
 const Allocator = std.mem.Allocator;
 const Span = @import("../span.zig").Span;

--- a/src/linter/rules/avoid_as.zig
+++ b/src/linter/rules/avoid_as.zig
@@ -231,23 +231,22 @@ test AvoidAs {
             \\}
             ,
         },
-        // FIXME: multi-line
-        // .{
-        //     .src =
-        //     \\const x = @as(u32, switch (some_comptime_enum) {
-        //     \\  .foo => 1,
-        //     \\  .bar => 2,
-        //     \\  else => 3,
-        //     \\});
-        //     ,
-        //     .expected =
-        //     \\const x: u32 = switch (some_comptime_enum) {
-        //     \\  .foo => 1,
-        //     \\  .bar => 2,
-        //     \\  else => 3,
-        //     \\};
-        //     ,
-        // },
+        .{
+            .src =
+            \\const x = @as(u32, switch (some_comptime_enum) {
+            \\  .foo => 1,
+            \\  .bar => 2,
+            \\  else => 3,
+            \\});
+            ,
+            .expected =
+            \\const x: u32 = switch (some_comptime_enum) {
+            \\  .foo => 1,
+            \\  .bar => 2,
+            \\  else => 3,
+            \\};
+            ,
+        },
     };
 
     try runner


### PR DESCRIPTION
Fixes a bug in `avoid-as`'s auto fixer where multi-line arguments to `@as()` were not handled properly
```zig
// this now fixes properly
const x = @as(u32, switch (some_comptime_enum) {
  .foo => 1,
  .bar => 2,
  else => 3,
});

// into this:
const x: u32 = switch (some_comptime_enum) {
  .foo => 1,
  .bar => 2,
  else => 3,
};
```