### PR TITLE
fix(must-return-ref): only walk subtree of target function

### DIFF
--- a/src/linter/fix.zig
+++ b/src/linter/fix.zig
@@ -94,14 +94,8 @@ pub const Fix = struct {
 
         pub fn spanCovering(self: Builder, comptime kind: Spanned, id: u32) Span {
             return switch (kind) {
-                .token => Span.from(self.ctx.semantic.tokens.items(.loc)[id]),
-                .node => {
-                    const locs: []const Semantic.Token.Loc = self.ctx.semantic.tokens.items(.loc);
-                    const ast = self.ctx.ast();
-                    const start = ast.firstToken(id);
-                    const last = ast.lastToken(id);
-                    return Span.new(@intCast(locs[start].start), @intCast(locs[last].end));
-                },
+                .token => self.ctx.semantic.tokenSpan(id),
+                .node => self.ctx.semantic.nodeSpan(id),
             };
         }
     };

--- a/src/semantic/Semantic.zig
+++ b/src/semantic/Semantic.zig
@@ -56,6 +56,14 @@ pub fn tokenSpan(self: *const Semantic, token: TokenIndex) Span {
     return Span.from(self.tokens.items(.loc)[token]);
 }
 
+pub fn nodeSpan(self: *const Semantic, node: Ast.Node.Index) Span {
+    const locs: []const Semantic.Token.Loc = self.tokens.items(.loc);
+    const start = locs[self.ast.firstToken(node)].start;
+    const end = locs[self.ast.lastToken(node)].end;
+    assert(start <= end);
+    return Span.new(@intCast(start), @intCast(end));
+}
+
 /// Find the symbol bound to an identifier name that was declared in some scope.
 ///
 /// To find a binding that is referrable within a scope, but that may not have
@@ -116,6 +124,7 @@ const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const Ast = std.zig.Ast;
 const Span = @import("../span.zig").Span;
+const assert = std.debug.assert;
 
 const _ast = @import("./ast.zig");
 const _tokenizer = @import("./tokenizer.zig");


### PR DESCRIPTION
Fixes a bunch of false positives in `must-return-ref`