### PR TITLE
feat(linter/unsafe-undefined): allow ignoring certain types

### DIFF
--- a/docs/rules/unsafe-undefined.md
+++ b/docs/rules/unsafe-undefined.md
@@ -55,6 +55,23 @@ const Foo = struct {
 };
 ```
 
+#### Whitelisting Types
+
+You may whitelist specific types that are allowed to be initialized to `undefined`.
+Any variable with this type will not have a violation triggered, as long as
+the type is obvious to ZLint's semantic analyzer. By default the whitelist
+contains `ThreadPool`/`Thread.Pool` from `std.Thread.Pool`
+
+```zig
+// "unsafe-undefined": ["error", { "allow_types": ["CustomBuffer"] }]
+const CustomBuffer = [4096]u8;
+var buf: CustomBuffer = undefined; // ok
+```
+
+> [!NOTE]
+> ZLint does not have a type checker yet, so implicit struct initializations
+> will not be ignored.
+
 #### Destructors
 
 Invalidating freed pointers/data by setting it to `undefined` is helpful for
@@ -132,4 +149,5 @@ test Foo {
 
 This rule accepts the following options:
 
+- allowed_types: array
 - allow_arrays: boolean

--- a/src/linter/rule.zig
+++ b/src/linter/rule.zig
@@ -48,7 +48,7 @@ pub const Rule = struct {
 
     /// Rules must have a constant with this name of type `Rule.Meta`.
     const META_FIELD_NAME = "meta";
-    pub const MAX_SIZE: usize = 16;
+    pub const MAX_SIZE: usize = 32;
     pub const Meta = struct {
         name: []const u8,
         category: Category,
@@ -86,7 +86,10 @@ pub const Rule = struct {
             };
         };
         if (@sizeOf(ptr_info.child) > MAX_SIZE) {
-            @compileError("Rule " ++ @typeName(ptr_info.child) ++ " is too large. Maximum size is " ++ MAX_SIZE);
+            @compileError(std.fmt.comptimePrint(
+                "Rule " ++ @typeName(ptr_info.child) ++ " is too large. Maximum size is {d}",
+                .{MAX_SIZE},
+            ));
         }
         const meta: Meta = if (@hasDecl(ptr_info.child, META_FIELD_NAME))
             @field(ptr_info.child, META_FIELD_NAME)
@@ -105,13 +108,13 @@ pub const Rule = struct {
             }
             pub fn runOnNode(pointer: *const anyopaque, node: NodeWrapper, ctx: *LinterContext) anyerror!void {
                 if (@hasDecl(ptr_info.child, "runOnNode")) {
-                    const self: T = @ptrCast(@constCast(pointer));
+                    const self: T = @ptrCast(@alignCast(@constCast(pointer)));
                     return ptr_info.child.runOnNode(self, node, ctx);
                 }
             }
             pub fn runOnSymbol(pointer: *const anyopaque, symbol: Symbol.Id, ctx: *LinterContext) anyerror!void {
                 if (@hasDecl(ptr_info.child, "runOnSymbol")) {
-                    const self: T = @ptrCast(@constCast(pointer));
+                    const self: T = @ptrCast(@alignCast(@constCast(pointer)));
                     return ptr_info.child.runOnSymbol(self, symbol, ctx);
                 }
             }

--- a/src/linter/rules/snapshots/unsafe-undefined.snap
+++ b/src/linter/rules/snapshots/unsafe-undefined.snap
@@ -13,6 +13,20 @@
   help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
 
   𝙭 unsafe-undefined: `undefined` is missing a safety comment
+   ╭─[unsafe-undefined.zig:1:19]
+ 1 │ var slice: []u8 = undefined;
+   ·                   ─────────
+   ╰────
+  help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
+
+  𝙭 unsafe-undefined: `undefined` is missing a safety comment
+   ╭─[unsafe-undefined.zig:1:27]
+ 1 │ const slice: []const u8 = undefined;
+   ·                           ─────────
+   ╰────
+  help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
+
+  𝙭 unsafe-undefined: `undefined` is missing a safety comment
    ╭─[unsafe-undefined.zig:1:23]
  1 │ const slice: [:0]u8 = undefined;
    ·                       ─────────
@@ -33,20 +47,26 @@
    ╰────
   help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
 
+  𝙭 unsafe-undefined: `undefined` is missing a safety comment
+   ╭─[unsafe-undefined.zig:1:35]
+ 1 │ const slice: []const []const u8 = undefined;
+   ·                                   ─────────
+   ╰────
+  help: Add a `SAFETY: <reason>` before this line explaining why this code is safe.
+
   𝙭 unsafe-undefined: Do not use `undefined` as a default value
    ╭─[unsafe-undefined.zig:1:33]
  1 │ const Foo = struct { bar: u32 = undefined };
    ·                                 ─────────
- 2 │ fn foo(x: *Foo) void {
    ╰────
   help: If this really can be `undefined`, do so explicitly during struct initialization.
 
   𝙭 unsafe-undefined: comparing with `undefined` is unspecified behavior.
-   ╭─[unsafe-undefined.zig:3:12]
- 2 │ fn foo(x: *Foo) void {
- 3 │   if (x == undefined) {
+   ╭─[unsafe-undefined.zig:2:12]
+ 1 │ fn foo(x: *Foo) void {
+ 2 │   if (x == undefined) {
    ·            ─────────
- 4 │     @import("std").debug.print("x is undefined\n", .{});
+ 3 │     @import("std").debug.print("x is undefined\n", .{});
    ╰────
   help: Uninitialized data can have any value. If you need to check that a value does not exist, use `null`.
 

--- a/src/linter/rules/unsafe_undefined.zig
+++ b/src/linter/rules/unsafe_undefined.zig
@@ -47,6 +47,21 @@
 //! };
 //! ```
 //!
+//! #### Whitelisting Types
+//! You may whitelist specific types that are allowed to be initialized to `undefined`.
+//! Any variable with this type will not have a violation triggered, as long as
+//! the type is obvious to ZLint's semantic analyzer. By default the whitelist
+//! contains `ThreadPool`/`Thread.Pool` from `std.Thread.Pool`
+//!
+//! ```zig
+//! // "unsafe-undefined": ["error", { "allow_types": ["CustomBuffer"] }]
+//! const CustomBuffer = [4096]u8;
+//! var buf: CustomBuffer = undefined; // ok
+//! ```
+//! > [!NOTE]
+//! > ZLint does not have a type checker yet, so implicit struct initializations
+//! > will not be ignored.
+//!
 //! #### Destructors
 //! Invalidating freed pointers/data by setting it to `undefined` is helpful for
 //! finding use-after-free bugs. Using `undefined` in destructors will not trigger
@@ -131,7 +146,10 @@ const Error = @import("../../Error.zig");
 const Cow = util.Cow(false);
 
 allow_arrays: bool = true,
-allowed_types: []const []const u8 = &[_][]const u8{"ThreadPool"},
+allowed_types: []const []const u8 = &[_][]const u8{
+    "ThreadPool",
+    "Thread.Pool",
+},
 
 const UnsafeUndefined = @This();
 pub const meta: Rule.Meta = .{

--- a/src/semantic/Semantic.zig
+++ b/src/semantic/Semantic.zig
@@ -64,6 +64,10 @@ pub fn nodeSpan(self: *const Semantic, node: Ast.Node.Index) Span {
     return Span.new(@intCast(start), @intCast(end));
 }
 
+pub fn nodeSlice(self: *const Semantic, node: Ast.Node.Index) []const u8 {
+    return self.nodeSpan(node).snippet(self.ast.source);
+}
+
 /// Find the symbol bound to an identifier name that was declared in some scope.
 ///
 /// To find a binding that is referrable within a scope, but that may not have


### PR DESCRIPTION
Allow whitelisting specific types which may be `undefined`. By default `std.Thread.Pool` is ignored.

```zig
const std = @import("std");
fn main() !void {
  var pool: std.Thread.Pool = undefined;
  try pool.init(.{ .allocator = std.heap.page_allocator }); // now allowed
}
```