### PR TITLE
feat(linter): add `returned-stack-reference` rule

### DIFF
--- a/docs/rules/returned-stack-reference.md
+++ b/docs/rules/returned-stack-reference.md
@@ -1,0 +1,55 @@
+# `returned-stack-reference`
+
+> Category: nursery
+>
+> Enabled by default?: No
+
+## What This Rule Does
+
+Checks for functions that return references to stack-allocated memory.
+
+It is illegal to use stack-allocated memory outside of the function that
+allocated it. Once that function returns and the stack is popped, the memory
+is no longer valid and may cause segfaults or undefined behavior.
+
+```zig
+const std = @import("std");
+fn foo() *u32 {
+  var x: u32 = 1; // x is on the stack
+  return &x;
+}
+fn bar() void {
+  const x = foo();
+  std.debug.print("{d}\n", .{x}); // crashes
+}
+```
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```zig
+const std = @import("std");
+fn foo() *u32 {
+  var x: u32 = 1;
+  return &x;
+}
+fn bar() []u32 {
+  var x: [1]u32 = .{1};
+  return x[0..];
+}
+```
+
+Examples of **correct** code for this rule:
+
+```zig
+fn foo() *u32 {
+  var x = std.heap.page_allocator.create(u32);
+  x.* = 1;
+  return x;
+}
+```
+
+## Configuration
+
+This rule has no configuration.

--- a/docs/rules/unsafe-undefined.md
+++ b/docs/rules/unsafe-undefined.md
@@ -17,8 +17,7 @@ builds.
 
 There are some cases where using `undefined` makes sense, such as array
 initialization. Some cases are implicitly allowed, but others should be
-communicated to other programmers via a safety comment. Adding `SAFETY:
-<reason>` before the line using `undefined` will not trigger a rule
+communicated to other programmers via a safety comment. Adding `SAFETY: <reason>` before the line using `undefined` will not trigger a rule
 violation.
 
 ```zig

--- a/src/linter/config/rules_config.zig
+++ b/src/linter/config/rules_config.zig
@@ -17,4 +17,5 @@ pub const RulesConfig = struct {
     empty_file: RuleConfig(rules.EmptyFile) = .{},
     avoid_as: RuleConfig(rules.AvoidAs) = .{},
     case_convention: RuleConfig(rules.CaseConvention) = .{},
+    returned_stack_reference: RuleConfig(rules.ReturnedStackReference) = .{},
 };

--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -104,6 +104,15 @@ pub inline fn labelT(
     };
 }
 
+// pub inline fn sliceOf(
+//     self: *const Context,
+//     comptime kind: enum { node, token },
+//     id: u32,
+// ) LabeledSpan {
+//     const span = if (kind == .node)
+//         self.semantic.nodeSpan()
+// }
+
 /// Create a new `Error` with a static message string.
 pub fn diagnostic(
     self: *Context,
@@ -114,7 +123,14 @@ pub fn diagnostic(
 ) Error {
     var e = Error.newStatic(message);
     e.labels.ensureTotalCapacityPrecise(self.gpa, spans.len) catch @panic("OOM");
-    e.labels.appendSliceAssumeCapacity(&spans);
+
+    const info = @typeInfo(@TypeOf(spans));
+    if (info == .pointer and info.pointer.size == .slice) {
+        e.labels.appendSliceAssumeCapacity(spans);
+    } else {
+        e.labels.appendSliceAssumeCapacity(&spans);
+    }
+
     return e;
 }
 
@@ -122,7 +138,14 @@ pub fn diagnostic(
 pub fn diagnosticf(self: *Context, comptime template: []const u8, args: anytype, spans: anytype) Error {
     var e = Error.fmt(self.gpa, template, args) catch @panic("OOM");
     e.labels.ensureTotalCapacityPrecise(self.gpa, spans.len) catch @panic("OOM");
-    e.labels.appendSliceAssumeCapacity(&spans);
+
+    const info = @typeInfo(@TypeOf(spans));
+    if (info == .pointer and info.pointer.size == .slice) {
+        e.labels.appendSliceAssumeCapacity(spans);
+    } else {
+        e.labels.appendSliceAssumeCapacity(&spans);
+    }
+
     return e;
 }
 

--- a/src/linter/rule.zig
+++ b/src/linter/rule.zig
@@ -69,6 +69,7 @@ pub const Rule = struct {
         restriction,
         pedantic,
         style,
+        nursery,
     };
 
     pub const WithSeverity = struct {

--- a/src/linter/rules.zig
+++ b/src/linter/rules.zig
@@ -11,3 +11,4 @@ pub const UselessErrorReturn = @import("./rules/useless_error_return.zig");
 pub const EmptyFile = @import("./rules/empty_file.zig");
 pub const AvoidAs = @import("./rules/avoid_as.zig");
 pub const CaseConvention = @import("./rules/case_convention.zig");
+pub const ReturnedStackReference = @import("./rules/returned_stack_reference.zig");

--- a/src/linter/rules/returned_stack_reference.zig
+++ b/src/linter/rules/returned_stack_reference.zig
@@ -1,0 +1,260 @@
+//! ## What This Rule Does
+//! Checks for functions that return references to stack-allocated memory.
+//!
+//! It is illegal to use stack-allocated memory outside of the function that
+//! allocated it. Once that function returns and the stack is popped, the memory
+//! is no longer valid and may cause segfaults or undefined behavior.
+//!
+//! ```zig
+//! const std = @import("std");
+//! fn foo() *u32 {
+//!   var x: u32 = 1; // x is on the stack
+//!   return &x;
+//! }
+//! fn bar() void {
+//!   const x = foo();
+//!   std.debug.print("{d}\n", .{x}); // crashes
+//! }
+//! ```
+//!
+//! ## Examples
+//!
+//! Examples of **incorrect** code for this rule:
+//! ```zig
+//! const std = @import("std");
+//! fn foo() *u32 {
+//!   var x: u32 = 1;
+//!   return &x;
+//! }
+//! fn bar() []u32 {
+//!   var x: [1]u32 = .{1};
+//!   return x[0..];
+//! }
+//! ```
+//!
+//! Examples of **correct** code for this rule:
+//! ```zig
+//! fn foo() *u32 {
+//!   var x = std.heap.page_allocator.create(u32);
+//!   x.* = 1;
+//!   return x;
+//! }
+//! ```
+
+const std = @import("std");
+const util = @import("util");
+const _source = @import("../../source.zig");
+const semantic = @import("../../semantic.zig");
+const _rule = @import("../rule.zig");
+const _span = @import("../../span.zig");
+const ast_utils = @import("../ast_utils.zig");
+const walk = @import("../../visit/walk.zig");
+
+const Ast = std.zig.Ast;
+const Node = Ast.Node;
+const Symbol = semantic.Symbol;
+const Scope = semantic.Scope;
+const Loc = std.zig.Loc;
+const Span = _span.Span;
+const LabeledSpan = _span.LabeledSpan;
+const LinterContext = @import("../lint_context.zig");
+const Rule = _rule.Rule;
+const NodeWrapper = _rule.NodeWrapper;
+
+const Error = @import("../../Error.zig");
+const Cow = util.Cow(false);
+
+// Rule metadata
+const ReturnedStackReference = @This();
+pub const meta: Rule.Meta = .{
+    .name = "returned-stack-reference",
+    // TODO: set the category to an appropriate value
+    .category = .nursery,
+    .default = .off,
+};
+
+fn stackRefDiagnostic(ctx: *LinterContext, node: Node.Index, decl_loc: ?Span, comptime is_slice: bool) Error {
+    const msg = if (is_slice)
+        "Returning a slice to stack-allocated memory is undefined behavior."
+    else
+        "Returning a reference to stack-allocated memory is undefined behavior.";
+
+    var labels: [2]LabeledSpan = undefined;
+    labels[0] = ctx.spanN(node);
+    if (decl_loc) |loc| {
+        labels[1] = LabeledSpan{ .span = loc };
+    }
+    const label_slice: []const LabeledSpan = labels[0..if (decl_loc) |_| 2 else 1];
+
+    return ctx.diagnostic(
+        msg,
+        label_slice[0..],
+    );
+}
+
+pub fn runOnNode(_: *const ReturnedStackReference, wrapper: NodeWrapper, ctx: *LinterContext) void {
+    const node = wrapper.node;
+    const node_id = wrapper.idx;
+    if (node.tag != .fn_decl) return;
+
+    var buffer: [1]Ast.Node.Index = undefined;
+    const func = ctx.ast().fullFnProto(&buffer, node_id) orelse return;
+    if (!ast_utils.isPointerType(ctx, func.ast.return_type)) return;
+
+    const func_body = wrapper.node.data.rhs;
+    std.debug.assert(func_body != semantic.Semantic.NULL_NODE);
+    const links = &ctx.semantic.node_links;
+    // FIXME: this is the fn body's parent
+    const body_scope = links.getScope(func_body) orelse return;
+
+    var stackfb = std.heap.stackFallback(256, ctx.gpa);
+    const allocator = stackfb.get();
+
+    var visitor = StackReferenceVisitor.init(
+        ctx,
+        Scope.Id.new(body_scope.int() + 1),
+    );
+    var walker = StackReferenceWalker.initAtNode(
+        allocator,
+        ctx.ast(),
+        &visitor,
+        func_body,
+    ) catch return;
+    defer walker.deinit();
+    walker.walk() catch return;
+}
+
+const StackReferenceWalker = walk.Walker(StackReferenceVisitor, StackReferenceVisitor.Err);
+const StackReferenceVisitor = struct {
+    fn_body_scope: Scope.Id,
+    ctx: *LinterContext,
+    return_depth: u8,
+    tags: []const Node.Tag,
+    data: []const Node.Data,
+
+    fn init(ctx: *LinterContext, fn_body_scope: Scope.Id) StackReferenceVisitor {
+        return .{
+            .ctx = ctx,
+            .return_depth = 0,
+            .tags = ctx.ast().nodes.items(.tag),
+            .data = ctx.ast().nodes.items(.data),
+            .fn_body_scope = fn_body_scope,
+        };
+    }
+
+    pub const Err = error{};
+
+    pub fn enterNode(self: *StackReferenceVisitor, node: Node.Index) Err!void {
+        switch (self.tags[node]) {
+            .@"return" => {
+                self.return_depth += 1;
+            },
+            .address_of,
+            => |tag| {
+                if (self.return_depth == 0) return;
+                const deref_target = self.data[node].lhs;
+                const info = self.isDeclaredLocally(deref_target);
+                if (info.is_local) {
+                    const diagnostic = if (tag == .address_of)
+                        stackRefDiagnostic(self.ctx, node, info.decl_loc, false)
+                    else
+                        stackRefDiagnostic(self.ctx, node, info.decl_loc, true);
+                    self.ctx.report(diagnostic);
+                }
+            },
+            .slice,
+            .slice_open,
+            .slice_sentinel,
+            => {
+                // todo: check inside slices and array literals for identifier references
+            },
+            else => {},
+        }
+    }
+
+    pub fn exitNode(self: *StackReferenceVisitor, node: Node.Index) void {
+        if (self.tags[node] == .@"return") {
+            self.return_depth -= 1;
+        }
+    }
+
+    const IsLocal = struct {
+        is_local: bool,
+        decl_loc: ?Span = null,
+        const no: IsLocal = .{ .is_local = false };
+    };
+    pub fn isDeclaredLocally(
+        self: *StackReferenceVisitor,
+        node: Node.Index,
+    ) IsLocal {
+        const sema = self.ctx.semantic;
+        std.debug.assert(node != semantic.Semantic.NULL_NODE);
+        if (self.tags[node] != .identifier) return .no;
+
+        const symbols = sema.symbols.symbols.slice();
+        const scopes: []const Scope.Id = symbols.items(.scope);
+        const tokens: []const util.NominalId(Ast.TokenIndex).Optional = symbols.items(.token);
+
+        const scope_id = sema.node_links.getScope(node) orelse return .no;
+        const name = sema.nodeSlice(node);
+        const symbol_id = sema.resolveBinding(scope_id, name, .{}) orelse return .no;
+
+        const declared_in: Scope.Id = scopes[symbol_id.into(usize)];
+        const ident_token = tokens[symbol_id.into(usize)].unwrap() orelse return .no;
+        if (comptime util.IS_DEBUG) {
+            const decl_ident = self.ctx.semantic.tokenSlice(ident_token.int());
+            util.assert(std.mem.eql(u8, decl_ident, name), "{s} != {s}", .{ decl_ident, name });
+        }
+
+        const decl_span = sema.tokenSpan(ident_token.into(Ast.TokenIndex));
+        const is_local = sema.scopes.isParentOf(self.fn_body_scope, declared_in);
+
+        return .{ .is_local = is_local, .decl_loc = decl_span };
+    }
+};
+
+pub fn rule(self: *ReturnedStackReference) Rule {
+    return Rule.init(self);
+}
+
+const RuleTester = @import("../tester.zig");
+test ReturnedStackReference {
+    const t = std.testing;
+
+    var returned_stack_reference = ReturnedStackReference{};
+    var runner = RuleTester.init(t.allocator, returned_stack_reference.rule());
+    defer runner.deinit();
+
+    // Code your rule should pass on
+    const pass = &[_][:0]const u8{
+        // TODO: add test cases
+        \\const std = @import("std");
+        \\fn foo(allocator: std.mem.Allocator) *u32 {
+        \\  var x: *u32 = allocator.create(u32);
+        \\  x.* = 1;
+        \\  return x;
+        \\}
+        ,
+        "fn foo(buf: []u8) []u8 { return buf[0..]; }",
+        "fn foo() []u8 { return &[_]u8{}; }",
+    };
+
+    // Code your rule should fail on
+    const fail = &[_][:0]const u8{
+        // TODO: add test cases
+        "fn foo() *u32 { var x: u32 = 1; return &x; }",
+        "fn foo() !*u32 { var x: u32 = 1; return &x; }",
+        // FIXME
+        // "fn foo() error{}!*u32 { var x: u32 = 1; return &x; }",
+        // \\const Foo = struct { x: *u32 };
+        // \\fn foo() Foo {
+        // \\  const local: u32 = 1;
+        // \\  return .{ .x = &local };
+        // \\}
+    };
+
+    try runner
+        .withPass(pass)
+        .withFail(fail)
+        .run();
+}

--- a/src/linter/rules/snapshots/returned-stack-reference.snap
+++ b/src/linter/rules/snapshots/returned-stack-reference.snap
@@ -1,0 +1,14 @@
+  𝙭 returned-stack-reference: Returning a reference to stack-allocated memory is undefined behavior.
+   ╭─[returned-stack-reference.zig:1:21]
+ 1 │ fn foo() *u32 { var x: u32 = 1; return &x; }
+   ·                     ─
+   ·                                        ──
+   ╰────
+
+  𝙭 returned-stack-reference: Returning a reference to stack-allocated memory is undefined behavior.
+   ╭─[returned-stack-reference.zig:1:22]
+ 1 │ fn foo() !*u32 { var x: u32 = 1; return &x; }
+   ·                      ─
+   ·                                         ──
+   ╰────
+

--- a/src/semantic/NodeLinks.zig
+++ b/src/semantic/NodeLinks.zig
@@ -58,6 +58,20 @@ pub inline fn setScope(self: *NodeLinks, node_id: NodeIndex, scope_id: Scope.Id)
     self.scopes.items[node_id] = scope_id;
 }
 
+pub inline fn getScope(self: *const NodeLinks, node_id: NodeIndex) ?Scope.Id {
+    if (node_id == ROOT_NODE_ID) {
+        @branchHint(.cold);
+        return null;
+    }
+    assert(
+        node_id < self.scopes.items.len,
+        "Node id out of bounds (id {d} >= {d})",
+        .{ node_id, self.scopes.items.len },
+    );
+    const scope_id = self.scopes.items[node_id];
+    return if (scope_id == ROOT_SCOPE_ID) null else scope_id;
+}
+
 pub inline fn setParent(self: *NodeLinks, child_id: NodeIndex, parent_id: NodeIndex) void {
     assert(child_id != parent_id, "AST nodes cannot be children of themselves", .{});
     assert(child_id != NULL_NODE, "Re-assigning the root node's parent is illegal behavior", .{});

--- a/src/semantic/Scope.zig
+++ b/src/semantic/Scope.zig
@@ -126,11 +126,22 @@ pub const Tree = struct {
         return self.bindings.items[scope_id.int()].items;
     }
 
+    /// Iterate over parent scopes, starting at `scope_id`. `scope_id` is the first
+    /// item yielded.
     pub fn iterParents(self: *const Scope.Tree, scope_id: Scope.Id) ScopeParentIterator {
         return .{
             .curr = scope_id.into(Id.Optional),
             .parents = self.scopes.items(.parent),
         };
+    }
+
+    /// Returns `true` if `parent_id` contains `child_id` as a descendant.
+    pub fn isParentOf(self: *const Scope.Tree, parent_id: Scope.Id, child_id: Scope.Id) bool {
+        var it = self.iterParents(child_id);
+        while (it.next()) |scope| {
+            if (scope == parent_id) return true;
+        }
+        return false;
     }
 
     pub fn deinit(self: *Scope.Tree, alloc: Allocator) void {

--- a/zlint.schema.json
+++ b/zlint.schema.json
@@ -218,6 +218,28 @@
                         }
                     ]
                 },
+                "returned-stack-reference": {
+                    "description": "## What This Rule Does\nChecks for functions that return references to stack-allocated memory.\n\nIt is illegal to use stack-allocated memory outside of the function that\nallocated it. Once that function returns and the stack is popped, the memory\nis no longer valid and may cause segfaults or undefined behavior.\n\n```zig\nconst std = @import(\"std\");\nfn foo() *u32 {\n  var x: u32 = 1; // x is on the stack\n  return &x;\n}\nfn bar() void {\n  const x = foo();\n  std.debug.print(\"{d}\\n\", .{x}); // crashes\n}\n```\n\n## Examples\n\nExamples of **incorrect** code for this rule:\n```zig\nconst std = @import(\"std\");\nfn foo() *u32 {\n  var x: u32 = 1;\n  return &x;\n}\nfn bar() []u32 {\n  var x: [1]u32 = .{1};\n  return x[0..];\n}\n```\n\nExamples of **correct** code for this rule:\n```zig\nfn foo() *u32 {\n  var x = std.heap.page_allocator.create(u32);\n  x.* = 1;\n  return x;\n}\n```",
+                    "default": "off",
+                    "markdownDescription": "## What This Rule Does\nChecks for functions that return references to stack-allocated memory.\n\nIt is illegal to use stack-allocated memory outside of the function that\nallocated it. Once that function returns and the stack is popped, the memory\nis no longer valid and may cause segfaults or undefined behavior.\n\n```zig\nconst std = @import(\"std\");\nfn foo() *u32 {\n  var x: u32 = 1; // x is on the stack\n  return &x;\n}\nfn bar() void {\n  const x = foo();\n  std.debug.print(\"{d}\\n\", .{x}); // crashes\n}\n```\n\n## Examples\n\nExamples of **incorrect** code for this rule:\n```zig\nconst std = @import(\"std\");\nfn foo() *u32 {\n  var x: u32 = 1;\n  return &x;\n}\nfn bar() []u32 {\n  var x: [1]u32 = .{1};\n  return x[0..];\n}\n```\n\nExamples of **correct** code for this rule:\n```zig\nfn foo() *u32 {\n  var x = std.heap.page_allocator.create(u32);\n  x.* = 1;\n  return x;\n}\n```",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Error.Severity"
+                        },
+                        {
+                            "type": "array",
+                            "items": false,
+                            "prefixItems": [
+                                {
+                                    "$ref": "#/definitions/Error.Severity"
+                                },
+                                {
+                                    "$ref": "#/definitions/linter.rules.returned_stack_reference"
+                                }
+                            ]
+                        }
+                    ]
+                },
                 "no-unresolved": {
                     "description": "## What This Rule Does\n\nChecks for imports to files that do not exist.\n\nThis rule only checks for file-based imports. Modules added by `build.zig`\nare not checked. More precisely, imports to paths ending in `.zig` will be\nresolved. This rule checks that a file exists at the imported path and is\nnot a directory. Symlinks are allowed but are not followed.\n\n## Examples\nAssume the following directory structure:\n```plaintext\n.\n├── foo.zig\n├── mod\n│   └── bar.zig\n├── not_a_file.zig\n│   └── baz.zig\n└── root.zig\n```\n\nExamples of **incorrect** code for this rule:\n```zig\n// root.zig\nconst x = @import(\"mod/foo.zig\");    // foo.zig is in the root directory.\nconst y = @import(\"not_a_file.zig\"); // directory, not a file\n```\n\nExamples of **correct** code for this rule:\n```zig\n// root.zig\nconst x = @import(\"foo.zig\");\nconst y = @import(\"mod/bar.zig\");\n```",
                     "default": "error",
@@ -416,6 +438,11 @@
                     "default": true
                 }
             }
+        },
+        "linter.rules.returned_stack_reference": {
+            "type": "object",
+            "title": "returned-stack-reference config",
+            "properties": {}
         }
     }
 }


### PR DESCRIPTION
## What This PR Does
Adds a new rule, `returned-stack-reference`, that looks for functions that return pointers to stack-allocated memory.

This is quite difficult to get right without a type checker and full comptime analysis, so I expect this rule to have quite a few false negatives.

Closes #295
