### PR TITLE
fix leak in playground wasm interop

### DIFF
--- a/apps/site/static/js/worker.js
+++ b/apps/site/static/js/worker.js
@@ -22,15 +22,16 @@ globalThis.onmessage = async (ev) => {
   const array = new Uint8Array(wexp.memory.buffer, ptr, zigSrc.length);
   new TextEncoder().encodeInto(zigSrc, array);
 
-  const resultPtr = wexp.analyze(ptr, array.byteLength);
-  const resultView = new DataView(wexp.memory.buffer, resultPtr, 4);
+  const resultStructPtr = wexp.analyze(ptr, array.byteLength);
+  const resultView = new DataView(wexp.memory.buffer, resultStructPtr, 8);
   const resultStringLen = resultView.getUint32(0, true);
-  const resultStringPtr = resultPtr + 4;
+  const resultStringPtr = resultView.getUint32(4, true);
   const result = new TextDecoder().decode(new Uint8Array(wexp.memory.buffer, resultStringPtr, resultStringLen));
 
   postMessage({ result });
 
-  wexp.free_string(ptr);
+  wexp.free_string(ptr, zigSrc.length);
+  wexp.free_string(resultStringPtr, zigSrc.length);
 };
 
 

--- a/apps/site/static/js/worker.js
+++ b/apps/site/static/js/worker.js
@@ -31,10 +31,5 @@ globalThis.onmessage = async (ev) => {
   postMessage({ result });
 
   wexp.free_string(ptr, zigSrc.length);
-  wexp.free_string(resultStringPtr, zigSrc.length);
+  wexp.free_string(resultStringPtr, resultStringLen);
 };
-
-
-
-
-// what you want with result

--- a/src/root_wasm.zig
+++ b/src/root_wasm.zig
@@ -24,7 +24,7 @@ const AnalyzeRes = extern struct {
 
 export var analyze_res = AnalyzeRes{ .len = 0, .ptr = null };
 
-/// caller must free result.ptr with free_string! (tbh haven't tested)
+/// caller must free result.ptr with free_string!
 export fn analyze(ptr: [*]const u8, len: usize) *AnalyzeRes {
     const input = ptr[0..len];
     const result = std.heap.wasm_allocator.dupe(u8, input) catch @panic("OOM");

--- a/src/root_wasm.zig
+++ b/src/root_wasm.zig
@@ -19,16 +19,16 @@ export fn free_string(ptr: [*]const u8, len: usize) void {
 
 const AnalyzeRes = extern struct {
     len: u32,
-    ptr: [*]const u8,
+    ptr: ?[*]const u8,
 };
 
-/// result must be returned with free_string! (tbh haven't tested)
-export fn analyze(ptr: [*]const u8, len: usize) [*]const u8 {
-    _ = ptr;
-    _ = len;
-    const fake_result = "hello world!";
-    const result = std.heap.wasm_allocator.allocWithOptions(u8, @sizeOf(usize) + fake_result.len, @alignOf(usize), null) catch @panic("OOM");
-    @memcpy(result[0..@sizeOf(usize)], &std.mem.toBytes(fake_result.len));
-    @memcpy(result[@sizeOf(usize)..], fake_result);
-    return result.ptr;
+export var analyze_res = AnalyzeRes{ .len = 0, .ptr = null };
+
+/// caller must free result.ptr with free_string! (tbh haven't tested)
+export fn analyze(ptr: [*]const u8, len: usize) *AnalyzeRes {
+    const input = ptr[0..len];
+    const result = std.heap.wasm_allocator.dupe(u8, input) catch @panic("OOM");
+    analyze_res.ptr = result.ptr;
+    analyze_res.len = @intCast(result.len);
+    return &analyze_res;
 }


### PR DESCRIPTION
- forgot to pass length to free and JS didn't care, so it wasn't freeing
- removed stupid DST in favor of static transfer global