### PR TITLE
ASCII Formatting

### DIFF
--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -191,6 +191,7 @@ test parse {
         try t.expectEqual(expected.verbose, opts.verbose);
         try t.expectEqual(expected.print_ast, opts.print_ast);
         try t.expectEqual(expected.args.items.len, opts.args.items.len);
+        try t.expectEqual(expected.format, opts.format);
         for (0..expected.args.items.len) |i| {
             try t.expectEqualStrings(
                 expected.args.items[i],

--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -14,7 +14,7 @@ quiet: bool = false,
 /// This is primarily for debugging purposes.
 print_ast: bool = false,
 /// How diagnostics are formatted.
-format: formatter.Kind = .graphical,
+format: formatter.Kind = .ascii,
 /// Print a summary about # of warnings and errors. Only applies for some formats.
 summary: bool = true,
 /// Instead of walking directories in cwd, read names of files to lint from stdin.
@@ -32,7 +32,7 @@ pub const usage =
 ;
 const help =
     \\--print-ast <file>  Parse a file and print its AST as JSON
-    \\-f, --format <fmt>  Choose an output format (default, graphical, json, github, gh)
+    \\-f, --format <fmt>  Choose an output format (ascii, unicode, github, json)
     \\--no-summary        Do not print a summary after linting
     \\-S, --stdin         Lint filepaths received from stdin (newline separated)
     \\--fix               Apply automatic fixes where possible
@@ -94,7 +94,7 @@ fn parse(alloc: Allocator, args_iter: anytype, err: ?*Error) ParseError!Options 
                 }
                 return error.InvalidArg;
             };
-            opts.format = formatter.Kind.fromString(fmt) orelse {
+            opts.format = std.meta.stringToEnum(formatter.Kind, fmt) orelse {
                 if (err) |e| {
                     e.* = Error.fmt(alloc, "Invalid format name: {s}. Valid names are {s}.", .{ arg, FORMAT_NAMES }) catch @panic("OOM");
                 }
@@ -136,7 +136,7 @@ inline fn eq(arg: anytype, name: @TypeOf(arg)) bool {
     return std.mem.eql(u8, arg, name);
 }
 // TODO: comptime string concat on format names
-const FORMAT_NAMES: []const u8 = "default, graphical, github, gh";
+const FORMAT_NAMES: []const u8 = "ascii, unicode, github, json";
 
 const Options = @This();
 const std = @import("std");

--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -90,13 +90,13 @@ fn parse(alloc: Allocator, args_iter: anytype, err: ?*Error) ParseError!Options 
             // TODO: comptime string concat on format names
             const fmt = argv.next() orelse {
                 if (err) |e| {
-                    e.* = Error.fmt(alloc, "Invalid format name: {s}. Valid names are {s}.", .{ arg, FORMAT_NAMES }) catch @panic("OOM");
+                    e.* = Error.fmt(alloc, "expected [{s}] after '{s}'", .{ FORMAT_NAMES, arg }) catch @panic("OOM");
                 }
                 return error.InvalidArg;
             };
             opts.format = std.meta.stringToEnum(formatter.Kind, fmt) orelse {
                 if (err) |e| {
-                    e.* = Error.fmt(alloc, "Invalid format name: {s}. Valid names are {s}.", .{ arg, FORMAT_NAMES }) catch @panic("OOM");
+                    e.* = Error.fmt(alloc, "expected [{s}] after '{s}', found '{s}'", .{ FORMAT_NAMES, arg, fmt }) catch @panic("OOM");
                 }
                 return error.InvalidArgValue;
             };
@@ -136,7 +136,7 @@ inline fn eq(arg: anytype, name: @TypeOf(arg)) bool {
     return std.mem.eql(u8, arg, name);
 }
 // TODO: comptime string concat on format names
-const FORMAT_NAMES: []const u8 = "ascii, unicode, github, json";
+const FORMAT_NAMES: []const u8 = "ascii|unicode|github|json";
 
 const Options = @This();
 const std = @import("std");
@@ -208,5 +208,13 @@ test "invalid --format" {
         error.InvalidArgValue,
         parse(t.allocator, argv, &err),
     );
-    try t.expect(std.mem.indexOf(u8, err.message.borrow(), "Invalid format name") != null);
+
+    const expected = try std.fmt.allocPrint(
+        t.allocator,
+        comptime "expected [{s}] after '--format', found 'this-is-not-a-valid-format'",
+        .{FORMAT_NAMES},
+    );
+    defer t.allocator.free(expected);
+    const actual = err.message.borrow();
+    try t.expectEqualSlices(u8, expected, actual);
 }

--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -162,10 +162,14 @@ test parse {
 
     const test_cases = [_]Case{
         .{ "", .{} },
-        .{ "zlint", .{} },
+        .{ "zlint", .{ .format = formatter.Kind.ascii } },
         .{ "zlint --", .{} },
         .{ "zlint --print-ast", .{ .print_ast = true } },
         .{ "zlint --fix", .{ .fix = true } },
+        .{ "zlint --format ascii", .{ .format = formatter.Kind.ascii } },
+        .{ "zlint --format unicode", .{ .format = formatter.Kind.unicode } },
+        .{ "zlint --format github", .{ .format = formatter.Kind.github } },
+        .{ "zlint --format json", .{ .format = formatter.Kind.json } },
         .{ "zlint --no-summary", .{ .summary = false } },
         .{ "zlint --verbose", .{ .verbose = true } },
         .{ "zlint -V", .{ .verbose = true } },

--- a/src/reporter/Reporter.zig
+++ b/src/reporter/Reporter.zig
@@ -33,11 +33,15 @@ pub const Reporter = struct {
     }
 
     pub fn initKind(kind: formatters.Kind, writer: *io.Writer, allocator: Allocator) Allocator.Error!Reporter {
+        // TODO: any non-falsy value should turn off colors
+        const color = !util.env.checkEnvFlag("NO_COLOR", .enabled);
+
         switch (kind) {
-            .graphical => {
-                // TODO: check terminal support for unicode characters
-                // TODO: any non-falsy value should turn off colors
-                const color = !util.env.checkEnvFlag("NO_COLOR", .enabled);
+            .ascii => {
+                const f = formatters.Graphical.ascii(allocator, color);
+                return init(formatters.Graphical, f, writer, allocator);
+            },
+            .unicode => {
                 const f = formatters.Graphical.unicode(allocator, color);
                 return init(formatters.Graphical, f, writer, allocator);
             },

--- a/src/reporter/formatter.zig
+++ b/src/reporter/formatter.zig
@@ -9,26 +9,10 @@ pub const Meta = struct {
 };
 
 pub const Kind = enum {
-    graphical,
+    ascii,
+    unicode,
     github,
     json,
-
-    const FormatMap = std.StaticStringMapWithEql(
-        Kind,
-        std.static_string_map.eqlAsciiIgnoreCase,
-    );
-    const formats = FormatMap.initComptime(&[_]struct { []const u8, Kind }{
-        .{ "github", .github },
-        .{ "gh", .github },
-        .{ "json", .json },
-        .{ "graphical", .graphical },
-        .{ "default", .graphical },
-    });
-
-    /// Get a formatter kind by name. Names are case-insensitive.
-    pub fn fromString(str: []const u8) ?Kind {
-        return formats.get(str);
-    }
 };
 
 pub const FormatError = io.Writer.Error || Allocator.Error;

--- a/src/root.zig
+++ b/src/root.zig
@@ -19,9 +19,17 @@ pub const printer = struct {
 
 pub const walk = @import("visit/walk.zig");
 
+pub const cli = struct {
+    pub const LintConfig = @import("cli/lint_config.zig");
+    pub const Options = @import("cli/Options.zig");
+    // TODO: Uncomment when cli/test/print_ast_test.zig is fixed.
+    //pub const PrintCommand = @import("cli/print_command.zig");
+};
+
 test {
     std.testing.refAllDecls(@import("util"));
     std.testing.refAllDeclsRecursive(printer);
     std.testing.refAllDeclsRecursive(zig);
     std.testing.refAllDeclsRecursive(json);
+    std.testing.refAllDeclsRecursive(cli);
 }


### PR DESCRIPTION
# Motivation

I had a tough time getting the graphical format to display correctly on Windows. Common terminals like Windows Terminal and the built-in terminal in VS Code just don't seem to handle unicode very well out of the box, and the output becomes noisy garbage in those terminals:

<img width="709" height="188" alt="image" src="https://github.com/user-attachments/assets/90e88af5-e494-4833-94ce-8852a33a9b4c" />


The github and JSON format is not really appropriate for manual use in the terminal, so getting the graphical output to render correctly would definitely be preffered. I could get it to render unicode correctly with [ConEmu](https://conemu.github.io/), but I personally don't want to switch to another terminal for that reason, and I think other Windows users would agree. As I dug into the zlint implementation, I did notice that there is an ASCII renderer, but seemingly no way to select it when you run zlint.

# Changes

I have split the `graphical` option into `ascii` and `unicode`, with `ascii` being the default, as I believe that should give the best out-of-the-box experience for any terminal user.

At the same time, I removed some of the aliases to simplify the format enum, which also allows us to simplify the arg parsing code.

Finally, I tried to extend the test cases and run them, but ran into issues doing so. With some help from our AI overlords, I was guided through some updates to the root.zig file, in order to include these tests in the suite being executed when running `zig build test`. To be fully honest, I'm a bit confused with how tests are being executed in Zig at this point. I think they must have changed this in 0.15.x. I don't recall it being this complicated. 😅  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NO_COLOR environment support to control output colors.
  * Explicit ascii and unicode output modes available.

* **Changes**
  * Default CLI output format changed from graphical to ascii.
  * CLI format options updated to: ascii, unicode, github, json.
  * Improved, clearer error messages for invalid format selections.

* **Tests**
  * Updated tests to cover new defaults and all supported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->