### PR TITLE
fix(sema): handle non-full var decls in destructuring patterns

### DIFF
--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -766,22 +766,32 @@ fn visitAssignDestructure(
 
     for (destructure.ast.variables) |var_id| {
         const main_token: TokenIndex = ast.nodeMainToken(var_id);
-        const decl: full.VarDecl = ast.fullVarDecl(var_id) orelse {
-            return SemanticError.FullMismatch;
-        };
-        const identifier = try self.assertToken(main_token + 1, .identifier);
+        if (ast.fullVarDecl(var_id)) |decl| {
+            const identifier = try self.assertToken(main_token + 1, .identifier);
 
-        // note: intentionally not using bindSymbol (for now, at least)
-        _ = try self.declareSymbol(.{
-            .declaration_node = var_id,
-            .identifier = identifier,
-            .visibility = if (decl.visib_token != null) .public else .private,
-            .flags = .{
-                .s_variable = true,
-                .s_comptime = is_comptime,
-                .s_const = token_tags[main_token] == .keyword_const,
-            },
-        });
+            // note: intentionally not using bindSymbol (for now, at least)
+            _ = try self.declareSymbol(.{
+                .declaration_node = var_id,
+                .identifier = identifier,
+                .visibility = if (decl.visib_token != null) .public else .private,
+                .flags = .{
+                    .s_variable = true,
+                    .s_comptime = is_comptime,
+                    .s_const = token_tags[main_token] == .keyword_const,
+                },
+            });
+        } else if (ast.nodeTag(var_id) == .identifier) {
+            // Destructuring allows arbitrary lvalue expressions; at minimum `identifier`
+            // covers `_` (discard) and assignment to existing names. Match plain `=`:
+            // LHS is a write, not a read.
+            const flags = self._curr_reference_flags;
+            defer self._curr_reference_flags = flags;
+            self._curr_reference_flags.write = true;
+            self._curr_reference_flags.read = false;
+            try self.visit(var_id);
+        } else {
+            return SemanticError.FullMismatch;
+        }
     }
     try self.visit(destructure.ast.value_expr);
 }

--- a/src/Semantic/test/symbol_decl_test.zig
+++ b/src/Semantic/test/symbol_decl_test.zig
@@ -50,6 +50,13 @@ test "Symbol flags - variable declarations" {
             .{ .s_const = false, .s_variable = true },
         },
         .{
+            \\fn foo() void {
+            \\  _, const x = .{ @as(u32, 1), @as(u32, 2) };
+            \\}
+            ,
+            .{ .s_const = true, .s_variable = true },
+        },
+        .{
             "fn foo() u32 { comptime var x = 1; return x; }",
             .{ .s_variable = true, .s_comptime = true },
         },

--- a/test/snapshots/semantic-coverage/bun.snap
+++ b/test/snapshots/semantic-coverage/bun.snap
@@ -1,57 +1,34 @@
-Passed: 94.651955% (1115/1178)
+Passed: 96.77419% (1140/1178)
 Panics: 0% (0/1178)
 
 src/allocators/BufferFallbackAllocator.zig: error.AnalysisFailed
 src/allocators/MimallocArena.zig: error.AnalysisFailed
 src/allocators/allocation_scope.zig: error.AnalysisFailed
 src/bun.js/DeprecatedStrong.zig: error.AnalysisFailed
-src/bun.js/api/BunObject.zig: error.FullMismatch
 src/bun.js/api/MarkdownObject.zig: error.AnalysisFailed
 src/bun.js/api/bun/socket.zig: error.AnalysisFailed
 src/bun.js/api/server/ServerWebSocket.zig: error.AnalysisFailed
 src/bun.js/node/node_fs_stat_watcher.zig: error.AnalysisFailed
-src/bun.js/node/util/parse_args.zig: error.FullMismatch
 src/bun.js/rare_data.zig: error.AnalysisFailed
 src/bun.js/test/Execution.zig: error.AnalysisFailed
-src/bun.js/test/bun_test.zig: error.FullMismatch
-src/bun.js/test/expect.zig: error.FullMismatch
+src/bun.js/test/bun_test.zig: error.AnalysisFailed
 src/bun.js/test/timers/FakeTimers.zig: error.AnalysisFailed
 src/bun.js/webcore/Blob.zig: error.AnalysisFailed
-src/bun.js/webcore/ByteStream.zig: error.FullMismatch
 src/bun.js/webcore/Request.zig: error.AnalysisFailed
 src/bun.js/webcore/Response.zig: error.AnalysisFailed
 src/bun.js/webcore/ResumableSink.zig: error.AnalysisFailed
-src/cli.zig: error.FullMismatch
-src/cli/audit_command.zig: error.FullMismatch
-src/cli/pack_command.zig: error.FullMismatch
-src/cli/pm_view_command.zig: error.FullMismatch
-src/cli/why_command.zig: error.FullMismatch
 src/collections/array_list.zig: error.AnalysisFailed
 src/collections/baby_list.zig: error.AnalysisFailed
 src/collections/multi_array_list.zig: error.AnalysisFailed
-src/css/css_parser.zig: error.FullMismatch
-src/css/small_list.zig: error.FullMismatch
-src/css/values/number.zig: error.FullMismatch
 src/fs.zig: error.AnalysisFailed
 src/http/websocket_client/WebSocketProxy.zig: error.AnalysisFailed
 src/http/websocket_client/WebSocketProxyTunnel.zig: error.AnalysisFailed
-src/install/PackageInstaller.zig: error.FullMismatch
-src/install/PackageManager/PackageManagerEnqueue.zig: error.FullMismatch
-src/install/PackageManager/install_with_manager.zig: error.FullMismatch
-src/install/PackageManager/patchPackage.zig: error.FullMismatch
-src/install/extract_tarball.zig: error.FullMismatch
-src/install/lockfile.zig: error.FullMismatch
-src/install/lockfile/CatalogMap.zig: error.FullMismatch
-src/install/lockfile/bun.lock.zig: error.FullMismatch
-src/install/npm.zig: error.FullMismatch
-src/install/pnpm.zig: error.FullMismatch
 src/interchange/yaml.zig: error.FullMismatch
 src/ptr/external_shared.zig: error.AnalysisFailed
 src/ptr/owned.zig: error.AnalysisFailed
 src/ptr/raw_ref_count.zig: error.AnalysisFailed
 src/ptr/shared.zig: error.AnalysisFailed
 src/safety/alloc.zig: error.AnalysisFailed
-src/shell/Builtin.zig: error.FullMismatch
 src/shell/ParsedShellScript.zig: error.AnalysisFailed
 src/shell/builtin/ls.zig: error.AnalysisFailed
 src/shell/interpreter.zig: error.AnalysisFailed
@@ -61,6 +38,4 @@ src/sql/mysql/MySQLQuery.zig: error.AnalysisFailed
 src/sql/mysql/MySQLRequestQueue.zig: error.AnalysisFailed
 src/sql/mysql/js/JSMySQLConnection.zig: error.AnalysisFailed
 src/sql/mysql/js/JSMySQLQuery.zig: error.AnalysisFailed
-src/string.zig: error.FullMismatch
-src/sys/Error.zig: error.FullMismatch
 src/threading/guarded.zig: error.AnalysisFailed

--- a/test/snapshots/semantic-coverage/ghostty.snap
+++ b/test/snapshots/semantic-coverage/ghostty.snap
@@ -1,7 +1,6 @@
-Passed: 99.36508% (626/630)
+Passed: 99.5238% (627/630)
 Panics: 0% (0/630)
 
 src/cli/list_themes.zig: error.FullMismatch
-src/font/face.zig: error.FullMismatch
 src/terminal/PageList.zig: error.FullMismatch
 src/terminal/Parser.zig: error.FullMismatch

--- a/test/snapshots/semantic-coverage/zig.snap
+++ b/test/snapshots/semantic-coverage/zig.snap
@@ -1,47 +1,20 @@
-Passed: 97.07384% (2853/2939)
+Passed: 98.12862% (2884/2939)
 Panics: 0% (0/2939)
 
-doc/langref/destructuring_mixed.zig: error.FullMismatch
-doc/langref/destructuring_to_existing.zig: error.FullMismatch
-doc/langref/destructuring_vectors.zig: error.FullMismatch
 doc/langref/invalid_doc-comment.zig: error.AnalysisFailed
 doc/langref/unattached_doc-comment.zig: error.AnalysisFailed
 doc/langref/var_must_be_initialized.zig: error.AnalysisFailed
 lib/compiler/aro/aro/Driver.zig: error.FullMismatch
-lib/compiler/aro/aro/Parser.zig: error.FullMismatch
 lib/compiler/aro/aro/Preprocessor.zig: error.FullMismatch
 lib/compiler/aro/aro/Tree.zig: error.FullMismatch
-lib/compiler/aro/aro/TypeStore.zig: error.FullMismatch
-lib/compiler/aro/aro/text_literal.zig: error.FullMismatch
-lib/compiler/reduce/Walk.zig: error.FullMismatch
 lib/compiler_rt/divmodei4.zig: error.FullMismatch
 lib/fuzzer.zig: error.FullMismatch
 lib/std/Io/Threaded.zig: error.FullMismatch
-lib/std/Progress.zig: error.FullMismatch
 lib/std/Target/Query.zig: error.FullMismatch
-lib/std/compress/flate/Compress.zig: error.FullMismatch
 lib/std/math/big/int.zig: error.FullMismatch
-lib/std/os/linux/IoUring/test.zig: error.FullMismatch
 lib/std/zig/Ast.zig: error.FullMismatch
-lib/std/zig/AstGen.zig: error.FullMismatch
-lib/std/zig/AstRlAnnotate.zig: error.FullMismatch
-src/Sema.zig: error.FullMismatch
-src/Zcu.zig: error.FullMismatch
-src/codegen/aarch64/Select.zig: error.FullMismatch
-src/codegen/aarch64/encoding.zig: error.FullMismatch
 src/codegen/x86_64/CodeGen.zig: error.FullMismatch
-src/crash_report.zig: error.FullMismatch
-src/link/Coff.zig: error.FullMismatch
-src/link/Dwarf.zig: error.FullMismatch
-src/link/Elf/Atom.zig: error.FullMismatch
-src/link/Elf2.zig: error.FullMismatch
-src/link/MappedFile.zig: error.FullMismatch
-src/link/Wasm/Flush.zig: error.FullMismatch
-src/link/Wasm/Object.zig: error.FullMismatch
-src/main.zig: error.FullMismatch
-test/behavior/destructure.zig: error.FullMismatch
 test/cases/compile_errors/Issue_6823_dont_allow_._to_be_followed_by_.zig: error.AnalysisFailed
-test/cases/compile_errors/assign_to_constant_destructure.zig: error.FullMismatch
 test/cases/compile_errors/attempted_double_ampersand.zig: error.AnalysisFailed
 test/cases/compile_errors/chained_comparison_operators.zig: error.AnalysisFailed
 test/cases/compile_errors/const_is_a_statement_not_an_expression.zig: error.AnalysisFailed
@@ -74,15 +47,11 @@ test/cases/compile_errors/implicit_semicolon-while-continue_expression.zig: erro
 test/cases/compile_errors/implicit_semicolon-while-continue_statement.zig: error.AnalysisFailed
 test/cases/compile_errors/implicit_semicolon-while_expression.zig: error.AnalysisFailed
 test/cases/compile_errors/implicit_semicolon-while_statement.zig: error.AnalysisFailed
-test/cases/compile_errors/invalid_destructure_astgen.zig: error.FullMismatch
-test/cases/compile_errors/invalid_destructure_sema.zig: error.FullMismatch
 test/cases/compile_errors/invalid_float_literal.zig: error.AnalysisFailed
 test/cases/compile_errors/invalid_pointer_syntax.zig: error.AnalysisFailed
 test/cases/compile_errors/non-extern_function_with_var_args.zig: error.AnalysisFailed
 test/cases/compile_errors/normal_string_with_newline.zig: error.AnalysisFailed
-test/cases/compile_errors/redundant_comptime_keyword.zig: error.FullMismatch
 test/cases/compile_errors/reject_extern_function_definitions_with_body.zig: error.AnalysisFailed
-test/cases/compile_errors/runtime_condition_comptime_type_in_destructure.zig: error.FullMismatch
 test/cases/compile_errors/tab_inside_comment.zig: error.AnalysisFailed
 test/cases/compile_errors/tab_inside_doc_comment.zig: error.AnalysisFailed
 test/cases/compile_errors/tab_inside_multiline_string.zig: error.AnalysisFailed


### PR DESCRIPTION
## What This PR Does

Fixes a bug in semantic analysis where discarded destructured binding pattners were not handled properly, such as this one:

```zig
 _, const x = .{ @as(u32, 1), @as(u32, 2) };
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined destructuring assignment logic to handle varied left-hand side patterns more flexibly, expanding compatibility with different variable declaration styles.

* **Tests**
  * Expanded test suite coverage for tuple-like variable destructuring scenarios and symbol flag validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->