### PR TITLE
fix(sema): properly handle reassignment destructurings

### DIFF
--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -783,14 +783,51 @@ fn visitAssignDestructure(
         } else {
             // Destructuring allows arbitrary lvalue expressions: identifiers (`_`, existing
             // names), field access, indexing, etc. Match plain `=` — LHS is a write, not a read.
-            const flags = self._curr_reference_flags;
-            defer self._curr_reference_flags = flags;
-            self._curr_reference_flags.write = true;
-            self._curr_reference_flags.read = false;
-            try self.visit(var_id);
+            try self.visitAssignmentTarget(var_id);
         }
     }
     try self.visit(destructure.ast.value_expr);
+}
+
+/// Non-`var`/`const` destructuring targets: identifiers are writes; `a.b` / `a[i]` / `*p` use
+/// read flags for address operands (same idea as `visitSlice`).
+fn visitAssignmentTarget(self: *SemanticBuilder, node_id: NodeIndex) SemanticError!void {
+    if (node_id == NULL_NODE) return;
+
+    const ast = self.AST();
+    switch (ast.nodeTag(node_id)) {
+        .array_access => {
+            const left, const right = ast.nodeData(node_id).node_and_node;
+            const prev = self.takeReferenceFlags();
+            defer self._curr_reference_flags = prev;
+            self._curr_reference_flags.read = true;
+            self._curr_reference_flags.write = false;
+            self._curr_reference_flags.call = false;
+            try self.visit(left);
+            try self.visit(right);
+        },
+        .field_access => try self.visitAssignmentTargetReadOperand(ast.nodeData(node_id).node_and_token[0]),
+        .deref => try self.visitAssignmentTargetReadOperand(ast.nodeData(node_id).node),
+        .grouped_expression, .unwrap_optional => {
+            try self.visitAssignmentTarget(ast.nodeData(node_id).node_and_token[0]);
+        },
+        else => {
+            const prev = self.takeReferenceFlags();
+            defer self._curr_reference_flags = prev;
+            self._curr_reference_flags.write = true;
+            self._curr_reference_flags.read = false;
+            try self.visit(node_id);
+        },
+    }
+}
+
+fn visitAssignmentTargetReadOperand(self: *SemanticBuilder, node_id: NodeIndex) SemanticError!void {
+    const prev = self.takeReferenceFlags();
+    defer self._curr_reference_flags = prev;
+    self._curr_reference_flags.read = true;
+    self._curr_reference_flags.write = false;
+    self._curr_reference_flags.call = false;
+    try self.visit(node_id);
 }
 
 // ========================= VARIABLE/FIELD REFERENCES  ========================

--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -780,17 +780,14 @@ fn visitAssignDestructure(
                     .s_const = token_tags[main_token] == .keyword_const,
                 },
             });
-        } else if (ast.nodeTag(var_id) == .identifier) {
-            // Destructuring allows arbitrary lvalue expressions; at minimum `identifier`
-            // covers `_` (discard) and assignment to existing names. Match plain `=`:
-            // LHS is a write, not a read.
+        } else {
+            // Destructuring allows arbitrary lvalue expressions: identifiers (`_`, existing
+            // names), field access, indexing, etc. Match plain `=` — LHS is a write, not a read.
             const flags = self._curr_reference_flags;
             defer self._curr_reference_flags = flags;
             self._curr_reference_flags.write = true;
             self._curr_reference_flags.read = false;
             try self.visit(var_id);
-        } else {
-            return SemanticError.FullMismatch;
         }
     }
     try self.visit(destructure.ast.value_expr);

--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -1889,6 +1889,7 @@ test {
     t.refAllDecls(@import("test/symbol_decl_test.zig"));
     t.refAllDecls(@import("test/symbol_ref_test.zig"));
     t.refAllDecls(@import("test/members_and_exports_test.zig"));
+    t.refAllDecls(@import("test/assign_destructure_test.zig"));
 }
 test "Struct/enum fields are bound bound to the struct/enums's member table" {
     const alloc = std.testing.allocator;

--- a/src/Semantic/test/assign_destructure_test.zig
+++ b/src/Semantic/test/assign_destructure_test.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const test_util = @import("util.zig");
 
+const Reference = @import("../Reference.zig");
+
 const t = std.testing;
 
 // Tuple destructuring may assign through non-identifier lvalues (e.g. field access).
@@ -19,4 +21,60 @@ test "assign destructure: field access lvalues" {
     var semantic = try test_util.build(src);
     defer semantic.deinit();
     try t.expectEqual(0, semantic.symbols.unresolved_references.items.len);
+}
+
+// `getPtr(q).a` is a field access whose receiver is a call; receiver/args must be reads, not writes.
+test "assign destructure: call + field access lvalues" {
+    const src =
+        \\const S = struct { a: u32, b: u32 };
+        \\fn getPtr(p: *S) *S {
+        \\    return p;
+        \\}
+        \\fn foo(q: *S) void {
+        \\    getPtr(q).a, getPtr(q).b = .{ 1, 2 };
+        \\}
+    ;
+
+    var semantic = try test_util.build(src);
+    defer semantic.deinit();
+    const symbols = semantic.symbols;
+    try t.expectEqual(0, symbols.unresolved_references.items.len);
+
+    try t.expect(symbols.getSymbolNamed("q") != null);
+    const q_sym = symbols.getSymbolNamed("q").?;
+    var refs = symbols.iterReferences(q_sym);
+    try t.expectEqual(2, refs.len());
+    while (refs.next()) |ref| {
+        try t.expectEqual(Reference.Flags{ .read = true }, ref.flags);
+    }
+
+    try t.expect(symbols.getSymbolNamed("getPtr") != null);
+    const get_ptr_sym = symbols.getSymbolNamed("getPtr").?;
+    var get_ptr_refs = symbols.iterReferences(get_ptr_sym);
+    try t.expectEqual(2, get_ptr_refs.len());
+    while (get_ptr_refs.next()) |ref| {
+        try t.expectEqual(Reference.Flags{ .call = true }, ref.flags);
+    }
+}
+
+test "assign destructure: array index operand is read, not write" {
+    const src =
+        \\fn foo() void {
+        \\    var x: [2]u32 = .{ 1, 2 };
+        \\    var i: u32 = 0;
+        \\    x[i], x[1] = .{ 3, 4 };
+        \\}
+    ;
+
+    var semantic = try test_util.build(src);
+    defer semantic.deinit();
+    const symbols = semantic.symbols;
+    try t.expectEqual(0, symbols.unresolved_references.items.len);
+
+    try t.expect(symbols.getSymbolNamed("i") != null);
+    const i_sym = symbols.getSymbolNamed("i").?;
+    var refs = symbols.iterReferences(i_sym);
+    try t.expectEqual(1, refs.len());
+    const ref = refs.next().?;
+    try t.expectEqual(Reference.Flags{ .read = true }, ref.flags);
 }

--- a/src/Semantic/test/assign_destructure_test.zig
+++ b/src/Semantic/test/assign_destructure_test.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const test_util = @import("util.zig");
+
+const t = std.testing;
+
+// Tuple destructuring may assign through non-identifier lvalues (e.g. field access).
+// The semantic walker must traverse these like a plain `=` LHS instead of failing analysis.
+test "assign destructure: field access lvalues" {
+    const src =
+        \\const S = struct {
+        \\    a: u32,
+        \\    b: u32,
+        \\};
+        \\fn foo(s: *S) void {
+        \\    s.a, s.b = .{ 1, 2 };
+        \\}
+    ;
+
+    var semantic = try test_util.build(src);
+    defer semantic.deinit();
+    try t.expectEqual(0, semantic.symbols.unresolved_references.items.len);
+}

--- a/src/Semantic/test/symbol_ref_test.zig
+++ b/src/Semantic/test/symbol_ref_test.zig
@@ -581,6 +581,38 @@ test "Reference flags - `x` - arrays, slices, etc" {
             ,
             .{ .type = true },
         },
+        // writing through an index: `x[i] = v` — LHS array-access visits the
+        // receiver under the assignment's write flag, so `x` is recorded as a
+        // write (not a read).
+        .{
+            \\fn foo() void {
+            \\  var x = [_]u32{1, 2, 3};
+            \\  x[0] = 4;
+            \\}
+            ,
+            .{ .write = true },
+        },
+        // compound-assignment through an index: `x[i] += v` — LHS is both read
+        // and written.
+        .{
+            \\fn foo() void {
+            \\  var x = [_]u32{1, 2, 3};
+            \\  x[0] += 1;
+            \\}
+            ,
+            .{ .read = true, .write = true },
+        },
+        // `x` inside an array literal that is itself indexed in-place. The
+        // parser requires parens around the literal before the `[0]`; without
+        // them this is a syntax error. `x` is only read as an element value.
+        .{
+            \\fn foo() u32 {
+            \\  const x: u32 = 1;
+            \\  return ([_]u32{ x, 2, 3 })[0];
+            \\}
+            ,
+            .{ .read = true },
+        },
     });
 }
 

--- a/test/snapshots/semantic-coverage/bun.snap
+++ b/test/snapshots/semantic-coverage/bun.snap
@@ -23,7 +23,7 @@ src/collections/multi_array_list.zig: error.AnalysisFailed
 src/fs.zig: error.AnalysisFailed
 src/http/websocket_client/WebSocketProxy.zig: error.AnalysisFailed
 src/http/websocket_client/WebSocketProxyTunnel.zig: error.AnalysisFailed
-src/interchange/yaml.zig: error.FullMismatch
+src/interchange/yaml.zig: error.AnalysisFailed
 src/ptr/external_shared.zig: error.AnalysisFailed
 src/ptr/owned.zig: error.AnalysisFailed
 src/ptr/raw_ref_count.zig: error.AnalysisFailed

--- a/test/snapshots/semantic-coverage/ghostty.snap
+++ b/test/snapshots/semantic-coverage/ghostty.snap
@@ -1,6 +1,3 @@
-Passed: 99.5238% (627/630)
+Passed: 100% (630/630)
 Panics: 0% (0/630)
 
-src/cli/list_themes.zig: error.FullMismatch
-src/terminal/PageList.zig: error.FullMismatch
-src/terminal/Parser.zig: error.FullMismatch

--- a/test/snapshots/semantic-coverage/zig.snap
+++ b/test/snapshots/semantic-coverage/zig.snap
@@ -1,19 +1,9 @@
-Passed: 98.12862% (2884/2939)
+Passed: 98.46887% (2894/2939)
 Panics: 0% (0/2939)
 
 doc/langref/invalid_doc-comment.zig: error.AnalysisFailed
 doc/langref/unattached_doc-comment.zig: error.AnalysisFailed
 doc/langref/var_must_be_initialized.zig: error.AnalysisFailed
-lib/compiler/aro/aro/Driver.zig: error.FullMismatch
-lib/compiler/aro/aro/Preprocessor.zig: error.FullMismatch
-lib/compiler/aro/aro/Tree.zig: error.FullMismatch
-lib/compiler_rt/divmodei4.zig: error.FullMismatch
-lib/fuzzer.zig: error.FullMismatch
-lib/std/Io/Threaded.zig: error.FullMismatch
-lib/std/Target/Query.zig: error.FullMismatch
-lib/std/math/big/int.zig: error.FullMismatch
-lib/std/zig/Ast.zig: error.FullMismatch
-src/codegen/x86_64/CodeGen.zig: error.FullMismatch
 test/cases/compile_errors/Issue_6823_dont_allow_._to_be_followed_by_.zig: error.AnalysisFailed
 test/cases/compile_errors/attempted_double_ampersand.zig: error.AnalysisFailed
 test/cases/compile_errors/chained_comparison_operators.zig: error.AnalysisFailed


### PR DESCRIPTION
Fixes a bug in semantic where destructuring re-assignments were not being bound properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected destructuring assignment so complex left-hand targets (field/deref, array index, call-based receivers) report read/write references accurately.

* **Refactor**
  * Unified assignment-target handling to support more lvalue forms and consistent reference flag behavior.

* **Tests**
  * Added semantic tests covering destructuring with non-identifier LHS, call receivers, and index-read semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->