### PR TITLE
fix(sema): fix several Builder bugs and add regression tests

### DIFF
--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -73,6 +73,7 @@ pub fn init(gpa: Allocator) SemanticBuilder {
 }
 
 pub fn withSource(self: *SemanticBuilder, source: *const _source.Source) void {
+    if (self._source_code) |*s| s.deinit();
     self._source_code = source.contents.clone();
     self._source_path = source.pathname;
 }
@@ -377,6 +378,7 @@ fn visitNode(self: *SemanticBuilder, node_id: NodeIndex) SemanticError!void {
             const prev = self.setScopeFlag(.s_comptime, false);
             defer self.restoreScopeFlag(.s_comptime, prev);
             self._next_block_scope_flags = .{ .s_test = true, .s_block = true };
+            defer self._next_block_scope_flags = .{};
             // TODO: record .s_test symbol references when test name is an `.identifier`
             return self.visit(ast.nodeData(node_id).opt_token_and_node[1]);
         },
@@ -574,8 +576,9 @@ fn visitContainer(self: *SemanticBuilder, node: NodeIndex, container: full.Conta
     }
 
     self.currentContainerSymbolFlags().set(symbol_flags, true);
+    const prev_symbol_flags = self._curr_symbol_flags;
     self._curr_symbol_flags.set(symbol_flags, true);
-    defer self._curr_symbol_flags.set(symbol_flags, true);
+    defer self._curr_symbol_flags = prev_symbol_flags;
 
     try self.enterScope(.{
         .flags = scope_flags.merge(.{ .s_block = true }),
@@ -591,21 +594,13 @@ fn visitErrorSetDecl(self: *SemanticBuilder, node_id: NodeIndex) !void {
 
     var curr_tok = self.getNodeData(node_id).token_and_token[1];
     util.debugAssert(tags[curr_tok] == Token.Tag.r_brace, "error_set_decl rhs should be an rbrace token.", .{});
-    curr_tok -= 1;
 
     try self.enterScope(.{ .flags = .{ .s_error = true } });
     defer self.exitScope();
     self.currentContainerSymbolFlags().s_error = true;
 
-    while (true) : (curr_tok -= 1) {
-        // NOTE: causes an out-of-bounds access in release builds, but the
-        // assertion never fails in debug builds. TODO: investigate and report
-        // to Zig team.
-        util.assert(
-            curr_tok > 0,
-            "an brace should always be encountered when walking an error declaration's members in a syntactically-valid program.",
-            .{},
-        );
+    while (curr_tok > 0) {
+        curr_tok -= 1;
         switch (tags[curr_tok]) {
             .identifier => {
                 _ = try self.declareMemberSymbol(.{
@@ -1009,19 +1004,20 @@ fn visitSwitchCase(self: *SemanticBuilder, node: NodeIndex, case: full.SwitchCas
 
     if (case.payload_token) |payload_token| {
         const tags = self.AST().tokens.items(.tag);
-        try self.enterScope(.{});
         var ident = payload_token;
         if (tags[ident] == .asterisk) ident += 1;
         if (tags[ident] != .identifier) return SemanticError.MissingIdentifier;
+        try self.enterScope(.{});
+        defer self.exitScope();
         _ = try self.bindSymbol(.{
             .declaration_node = node,
             .identifier = ident,
             .flags = .{ .s_payload = true, .s_const = true },
         });
+        return self.visit(case.ast.target_expr);
     }
-    defer if (case.payload_token != null) self.exitScope();
 
-    try self.visit(case.ast.target_expr);
+    return self.visit(case.ast.target_expr);
 }
 
 fn visitCatch(self: *SemanticBuilder, node_id: NodeIndex) !void {
@@ -1135,9 +1131,9 @@ fn visitFnDecl(self: *SemanticBuilder, node_id: NodeIndex) callconv(util.@"inlin
     // TODO: bound name vs escaped name
     const debug_name: ?[]const u8 = if (proto.name_token == null) "<anonymous fn>" else null;
 
-    const prev_symbol_flags = self._curr_reference_flags;
+    const prev_symbol_flags = self._curr_symbol_flags;
     self._curr_symbol_flags.set(Symbol.Flags.s_container, false);
-    defer self._curr_reference_flags = prev_symbol_flags;
+    defer self._curr_symbol_flags = prev_symbol_flags;
 
     var flags: Symbol.Flags = .{ .s_fn = true };
     if (proto.extern_export_inline_token) |tok| {
@@ -1661,11 +1657,15 @@ fn recordImport(self: *SemanticBuilder, node: NodeIndex) Allocator.Error!void {
         const loc: Token.Loc = self._semantic.tokens().items(.loc)[ast.nodeMainToken(specifier_node)];
         try e.labels.append(self._gpa, LabeledSpan.unlabeled(@intCast(loc.start), @intCast(loc.end)));
         try self._errors.append(self._gpa, e);
+        return;
     }
 
     var specifier = self.tokenSlice(ast.nodeMainToken(specifier_node));
     specifier = std.mem.trim(u8, specifier, "\"");
-    const is_file = specifier.len > 4 and specifier[specifier.len - 4] == '.';
+    const is_file = if (std.mem.lastIndexOfScalar(u8, specifier, '.')) |dot|
+        dot > 0 and dot < specifier.len - 1
+    else
+        false;
     try self._semantic.modules.imports.append(self._gpa, ModuleRecord.ImportEntry{
         .specifier = specifier,
         .node = node,
@@ -1764,7 +1764,6 @@ fn addAstError(self: *SemanticBuilder, ast: *const Ast, ast_err: Ast.Error) Allo
         ast.renderError(ast_err, &allocating.writer) catch break :blk &.{};
         break :blk allocating.toOwnedSlice() catch break :blk &.{};
     };
-    errdefer self._gpa.free(message);
 
     var err = Error.new(message, self._gpa);
     errdefer err.deinit(self._gpa);
@@ -1784,22 +1783,6 @@ fn addAstError(self: *SemanticBuilder, ast: *const Ast, ast_err: Ast.Error) Allo
     if (self._source_path) |path| err.source_name = try self._gpa.dupe(u8, path);
 
     try self._errors.append(self._gpa, err);
-}
-
-/// Record an error encountered during parsing or analysis.
-///
-/// All parameters are borrowed. Errors own their data, so each parameter gets cloned onto the heap.
-fn addError(self: *SemanticBuilder, message: []const u8, labels: []Span, help: ?[]const u8) Allocator.Error!void {
-    const alloc = self._errors.allocator;
-    const heap_message = try alloc.dupeZ(u8, message);
-    const heap_labels = try alloc.dupe(Span, labels);
-    const heap_help = if (help) |h| alloc.dupeZ(h) else null;
-    const err = try Error{
-        .message = .{ .str = heap_message, .static = false },
-        .labels = heap_labels,
-        .help = heap_help,
-    };
-    try self._errors.append(err);
 }
 
 // =========================================================================

--- a/src/Semantic/test/modules_test.zig
+++ b/src/Semantic/test/modules_test.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const test_util = @import("util.zig");
 
+const _source = @import("../../source.zig");
 const Semantic = @import("../../Semantic.zig");
 
 const t = std.testing;
@@ -29,4 +30,140 @@ test "@import(\"foo.zig\")" {
     try t.expectEqualStrings("foo.zig", import.specifier);
     try t.expectEqual(.file, import.kind);
     try t.expect(import.node != Semantic.NULL_NODE);
+}
+
+// ---------------------------------------------------------------------------
+// Import extension detection handles extensions of any length
+// ---------------------------------------------------------------------------
+
+test "@import: .zon extension -> file kind" {
+    const src =
+        \\const cfg = @import("build.zig.zon");
+    ;
+    var sem = try test_util.build(src);
+    defer sem.deinit();
+    try t.expectEqual(@as(usize, 1), sem.modules.imports.items.len);
+    try t.expectEqual(Semantic.ModuleRecord.ImportEntry.Kind.file, sem.modules.imports.items[0].kind);
+}
+
+test "@import: .c extension -> file kind (previously misclassified)" {
+    const src =
+        \\const c = @import("foo.c");
+    ;
+    var sem = try test_util.build(src);
+    defer sem.deinit();
+    try t.expectEqual(@as(usize, 1), sem.modules.imports.items.len);
+    try t.expectEqual(Semantic.ModuleRecord.ImportEntry.Kind.file, sem.modules.imports.items[0].kind);
+}
+
+test "@import: .h extension -> file kind (previously misclassified)" {
+    const src =
+        \\const h = @import("foo.h");
+    ;
+    var sem = try test_util.build(src);
+    defer sem.deinit();
+    try t.expectEqual(@as(usize, 1), sem.modules.imports.items.len);
+    try t.expectEqual(Semantic.ModuleRecord.ImportEntry.Kind.file, sem.modules.imports.items[0].kind);
+}
+
+test "@import: module name with no extension -> module kind" {
+    const src =
+        \\const std = @import("std");
+        \\const builtin = @import("builtin");
+    ;
+    var sem = try test_util.build(src);
+    defer sem.deinit();
+    try t.expectEqual(@as(usize, 2), sem.modules.imports.items.len);
+    for (sem.modules.imports.items) |imp| {
+        try t.expectEqual(Semantic.ModuleRecord.ImportEntry.Kind.module, imp.kind);
+    }
+}
+
+test "@import: trailing dot is not a file extension" {
+    // Path-like specifier that ends in a dot - should not crash and should
+    // not be classified as a file.
+    const src =
+        \\const weird = @import("weird.");
+    ;
+    var sem = try test_util.build(src);
+    defer sem.deinit();
+    try t.expectEqual(@as(usize, 1), sem.modules.imports.items.len);
+    try t.expectEqual(Semantic.ModuleRecord.ImportEntry.Kind.module, sem.modules.imports.items[0].kind);
+}
+
+test "@import: leading dot only is not a file extension" {
+    const src =
+        \\const dot = @import(".hidden");
+    ;
+    var sem = try test_util.build(src);
+    defer sem.deinit();
+    try t.expectEqual(@as(usize, 1), sem.modules.imports.items.len);
+    try t.expectEqual(Semantic.ModuleRecord.ImportEntry.Kind.module, sem.modules.imports.items[0].kind);
+}
+
+// ---------------------------------------------------------------------------
+// recordImport no longer appends bogus entries after reporting an error for a
+// non-string specifier.
+// ---------------------------------------------------------------------------
+
+test "@import non-string specifier does not add import entry" {
+    const src =
+        \\const spec = "std";
+        \\const std = @import(spec);
+    ;
+    var result = try test_util.buildWithErrors(src);
+    defer result.deinit();
+    // Builder reports the error.
+    try t.expect(result.hasErrors());
+    // No import entry was recorded.
+    try t.expectEqual(@as(usize, 0), result.value.modules.imports.items.len);
+}
+
+// ---------------------------------------------------------------------------
+// withSource is safe when called multiple times (no ArcStr leak)
+// ---------------------------------------------------------------------------
+
+test "withSource: multiple calls do not leak ArcStr" {
+    const a_src = try t.allocator.dupeZ(u8, "const x = 0;");
+    const a_path = try t.allocator.dupe(u8, "a.zig");
+    var a = try _source.Source.fromString(t.allocator, a_src, a_path);
+    defer a.deinit();
+
+    const b_src = try t.allocator.dupeZ(u8, "const y = 0;");
+    const b_path = try t.allocator.dupe(u8, "b.zig");
+    var b = try _source.Source.fromString(t.allocator, b_src, b_path);
+    defer b.deinit();
+
+    var builder = Semantic.Builder.init(t.allocator);
+    defer builder.deinit();
+
+    builder.withSource(&a);
+    builder.withSource(&b);
+
+    // Actually build something so the Semantic is well-formed for deinit.
+    var result = try builder.build(b.text());
+    defer result.deinit();
+}
+
+// ---------------------------------------------------------------------------
+// addAstError handles parse errors cleanly (regression guard against a
+// double-free caught by the testing allocator).
+// ---------------------------------------------------------------------------
+
+test "addAstError handles parse error without double-free" {
+    const src = "const x =";
+    var result = try test_util.buildWithErrors(src);
+    defer result.deinit();
+    try t.expect(result.hasErrors());
+}
+
+test "addAstError handles multiple parse errors without leaking" {
+    const src =
+        \\const x =
+        \\const y =
+        \\fn foo(
+    ;
+    var result = try test_util.buildWithErrors(src);
+    defer result.deinit();
+    try t.expect(result.hasErrors());
 }

--- a/src/Semantic/test/symbol_decl_test.zig
+++ b/src/Semantic/test/symbol_decl_test.zig
@@ -277,3 +277,139 @@ test "control flow payloads - value and error" {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// visitContainer must restore `_curr_symbol_flags` rather than re-applying
+// it, or container bits latch on for declarations that follow the container
+// visit. declareSymbol merges `_curr_symbol_flags` into each new symbol's
+// flags, so the leak would taint subsequent sibling members.
+// ---------------------------------------------------------------------------
+
+test "visitContainer: sibling members after a nested enum do not inherit s_enum" {
+    const src =
+        \\pub const Foo = struct {
+        \\    pub const Kind = enum { a, b };
+        \\    pub const x: u32 = 0;
+        \\};
+    ;
+    var sem = try build(src);
+    defer sem.deinit();
+
+    const kind = sem.symbols.getSymbolNamed("Kind") orelse return error.SymbolNotFound;
+    const x = sem.symbols.getSymbolNamed("x") orelse return error.SymbolNotFound;
+
+    const flags = sem.symbols.symbols.items(.flags);
+    try t.expect(flags[kind.int()].s_enum);
+    try t.expect(!flags[x.int()].s_enum);
+    try t.expect(!flags[x.int()].s_struct);
+    try t.expect(!flags[x.int()].s_union);
+}
+
+test "visitContainer: sibling members after a nested union do not inherit s_union" {
+    const src =
+        \\pub const Foo = struct {
+        \\    pub const U = union { a: u32, b: u32 };
+        \\    pub const y: u32 = 0;
+        \\};
+    ;
+    var sem = try build(src);
+    defer sem.deinit();
+
+    const u = sem.symbols.getSymbolNamed("U") orelse return error.SymbolNotFound;
+    const y = sem.symbols.getSymbolNamed("y") orelse return error.SymbolNotFound;
+    const flags = sem.symbols.symbols.items(.flags);
+    try t.expect(flags[u.int()].s_union);
+    try t.expect(!flags[y.int()].s_union);
+}
+
+// ---------------------------------------------------------------------------
+// visitFnDecl save/restore path: previously `prev_symbol_flags` captured
+// `_curr_reference_flags` but the next line mutated `_curr_symbol_flags`.
+// The defer restored reference flags (no-op), leaving symbol flags desynced.
+// Exercise the save/restore in a nested container: repeated sibling fns must
+// each correctly record as s_fn on their own symbol, and a sibling const
+// must keep its expected flag shape.
+// ---------------------------------------------------------------------------
+
+test "visitFnDecl: multiple sibling fns in a container keep correct flags" {
+    const src =
+        \\pub const Foo = struct {
+        \\    pub fn a() void {}
+        \\    pub fn b() void {}
+        \\    pub const c: u32 = 0;
+        \\};
+    ;
+    var sem = try build(src);
+    defer sem.deinit();
+
+    const a = sem.symbols.getSymbolNamed("a") orelse return error.SymbolNotFound;
+    const b = sem.symbols.getSymbolNamed("b") orelse return error.SymbolNotFound;
+    const c = sem.symbols.getSymbolNamed("c") orelse return error.SymbolNotFound;
+
+    const flags = sem.symbols.symbols.items(.flags);
+    try t.expect(flags[a.int()].s_fn);
+    try t.expect(flags[b.int()].s_fn);
+    // c is a const variable, not a function
+    try t.expect(!flags[c.int()].s_fn);
+    try t.expect(flags[c.int()].s_const);
+    try t.expect(flags[c.int()].s_variable);
+}
+
+// ---------------------------------------------------------------------------
+// visitSwitchCase previously had an unbalanced scope stack on the
+// MissingIdentifier early-return path because the exitScope defer was
+// registered after the early return. Lock in the payload scoping behavior.
+// ---------------------------------------------------------------------------
+
+test "visitSwitchCase: valid payload declares scoped binding" {
+    const src =
+        \\fn foo(x: anyerror!u32) void {
+        \\    switch (x) {
+        \\        else => |v| {
+        \\            _ = v;
+        \\        },
+        \\    }
+        \\}
+    ;
+    var sem = try build(src);
+    defer sem.deinit();
+
+    const v = sem.symbols.getSymbolNamed("v") orelse return error.SymbolNotFound;
+    const flags = sem.symbols.symbols.items(.flags);
+    try t.expect(flags[v.int()].s_payload);
+    try t.expect(flags[v.int()].s_const);
+}
+
+test "visitSwitchCase: pointer payload declares scoped binding" {
+    const src =
+        \\fn foo(x: *u32) void {
+        \\    switch (x.*) {
+        \\        else => |*p| {
+        \\            _ = p;
+        \\        },
+        \\    }
+        \\}
+    ;
+    var sem = try build(src);
+    defer sem.deinit();
+
+    const p = sem.symbols.getSymbolNamed("p") orelse return error.SymbolNotFound;
+    const flags = sem.symbols.symbols.items(.flags);
+    try t.expect(flags[p.int()].s_payload);
+}
+
+test "visitSwitchCase: no payload leaves scope stack intact" {
+    const src =
+        \\fn foo(x: u32) void {
+        \\    switch (x) {
+        \\        0 => {},
+        \\        else => {},
+        \\    }
+        \\}
+    ;
+    var sem = try build(src);
+    defer sem.deinit();
+    // Build returned cleanly; previously this path didn't touch the buggy
+    // defer but we lock it in as a regression guard.
+    try t.expect(sem.symbols.getSymbolNamed("foo") != null);
+}

--- a/src/Semantic/test/util.zig
+++ b/src/Semantic/test/util.zig
@@ -11,6 +11,24 @@ const print = std.debug.print;
 
 var buf: [1024]u8 = undefined;
 
+/// Build a Semantic from source, returning the raw Result so tests can
+/// inspect errors. Unlike `build`, this does not fail on analysis errors —
+/// callers are expected to assert on `result.hasErrors()` themselves.
+pub fn buildWithErrors(src: [:0]const u8) !Semantic.Builder.Result {
+    var builder = Semantic.Builder.init(t.allocator);
+    errdefer builder.deinit();
+    var source = try _source.Source.fromString(
+        t.allocator,
+        try t.allocator.dupeZ(u8, src),
+        try t.allocator.dupe(u8, "test.zig"),
+    );
+    defer source.deinit();
+    builder.withSource(&source);
+    const result = try builder.build(src);
+    builder.deinit();
+    return result;
+}
+
 pub fn build(src: [:0]const u8) !Semantic {
     const w = std.fs.File.stderr().writer(&buf);
     var stderr = w.interface;


### PR DESCRIPTION
## Summary

Fixes a cluster of bugs in `Semantic.Builder` found while auditing memory safety and flag-propagation paths — double-free in `addAstError`, stale source leak in `withSource`, sibling-flag contamination in `visitContainer`/`visitFnDecl`, unbalanced scope stack in `visitSwitchCase`, token-walk underflow in `visitErrorSetDecl`, leaking test-block scope flags, bogus import entry after non-string `@import` specifier, and mis-classification of `.zon`/`.c`/`.h` file imports. Also deletes an unused `addError` helper that didn't compile.

Regression tests are placed next to existing coverage: extension and builder-lifecycle tests in `modules_test.zig`, container/fn/switch flag tests in `symbol_decl_test.zig`. A shared `buildWithErrors` helper in `test/util.zig` lets error-path tests inspect `Builder.Result` directly.

## Test plan

- [x] \`zig build test\` passes
- [ ] \`zig build test-e2e\` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential memory leaks in source lifecycle management
  * Improved error handling for import declarations
  * Enhanced symbol flag scoping across nested declarations and containers

* **Tests**
  * Added comprehensive regression tests for import classification
  * Added tests validating symbol scoping behavior
  * Strengthened test coverage for error handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->