### PR TITLE
fix(lint): disable directive comment parsing causing hang

### DIFF
--- a/src/lint.zig
+++ b/src/lint.zig
@@ -13,6 +13,6 @@ test {
     std.testing.refAllDeclsRecursive(@import("linter/rules.zig"));
 
     // Test suites
-    _ = @import("linter/test/disabling_rules_test.zig");
-    _ = @import("linter/test/fix_test.zig");
+    std.testing.refAllDecls(@import("linter/test/disabling_rules_test.zig"));
+    std.testing.refAllDecls(@import("linter/test/fix_test.zig"));
 }

--- a/src/linter/disable_directives/Parser.zig
+++ b/src/linter/disable_directives/Parser.zig
@@ -69,9 +69,18 @@ pub fn parse(self: *DisableDirectivesParser, allocator: Allocator, line_comment:
 
     // consume /\s*//[/!]?\s*/
     self.eatWhitespace(); // "\s*"
+    if (self.remaining().len < MIN_LEN) {
+        @branchHint(.unlikely);
+        return null;
+    }
     self.eatMany("//", false) orelse return null; // "//"
-    self.eat('!') orelse {}; // maybe '!' for module doc comments
-    self.eat('/') orelse {}; // maybe '/' for 'normal' doc comments
+    switch (self.curr()) {
+        // never out of bounds b/c of len check after whitespace
+        '!', // maybe a module doc comment
+        '/', // maybe a container/fn doc comment
+        => self.cursor += 1,
+        else => {},
+    }
     self.eatWhitespace(); // "\s*"
 
     // consume /zlint-disable[-next-line]/. determines directive kind.
@@ -95,7 +104,11 @@ pub fn parse(self: *DisableDirectivesParser, allocator: Allocator, line_comment:
         const start = self.cursor;
         while (self.cursor < self.span.end) : (self.cursor += 1) {
             switch (self.curr()) {
-                'a'...'z', 'A'...'Z', '-' => {},
+                'a'...'z', 'A'...'Z' => {},
+                '-' => {
+                    if (self.peek() == '-') break;
+                    // continue
+                },
                 else => break,
             }
         }
@@ -103,7 +116,9 @@ pub fn parse(self: *DisableDirectivesParser, allocator: Allocator, line_comment:
         try self.rules.append(alloc, Span.new(@intCast(start), @intCast(self.cursor)));
         self.eat(',') orelse {};
         self.eatWhitespace();
+        if (self.eatMany("--", false)) |_| break;
     }
+
     return self.build(allocator);
 }
 
@@ -137,6 +152,17 @@ fn eat(self: *DisableDirectivesParser, expected: u8) ?void {
     } else {
         return null;
     }
+}
+
+/// Safely read the next character. Returns `null` if we're at the end of the
+/// source slice.
+inline fn peek(self: *const DisableDirectivesParser) ?u8 {
+    const next_pos = self.cursor + 1;
+    if (next_pos >= self.span.end) {
+        @branchHint(.unlikely);
+        return null;
+    }
+    return self.source[next_pos];
 }
 
 /// Try to consume a slice. If found, the cursor is moved past `expected`,

--- a/src/linter/disable_directives/Parser.zig
+++ b/src/linter/disable_directives/Parser.zig
@@ -113,6 +113,13 @@ pub fn parse(self: *DisableDirectivesParser, allocator: Allocator, line_comment:
             }
         }
         self.cursor = @min(self.cursor, self.span.end);
+        // Skip unrecognized characters (digits, underscores, etc.) that the
+        // inner loop cannot consume.
+        if (self.cursor == start) {
+            @branchHint(.cold);
+            self.cursor += 1;
+            continue;
+        }
         try self.rules.append(alloc, Span.new(@intCast(start), @intCast(self.cursor)));
         self.eat(',') orelse {};
         self.eatWhitespace();

--- a/src/linter/disable_directives/Parser.zig
+++ b/src/linter/disable_directives/Parser.zig
@@ -69,7 +69,7 @@ pub fn parse(self: *DisableDirectivesParser, allocator: Allocator, line_comment:
 
     // consume /\s*//[/!]?\s*/
     self.eatWhitespace(); // "\s*"
-    if (self.remaining().len < MIN_LEN) {
+    if (self.cursor == self.span.end or (self.span.end - self.cursor) < MIN_LEN) {
         @branchHint(.unlikely);
         return null;
     }

--- a/src/linter/disable_directives/Parser_test.zig
+++ b/src/linter/disable_directives/Parser_test.zig
@@ -15,6 +15,8 @@ const TestCase = struct {
 
 /// For when you don't care about the parsed comment's span
 const NULL_SPAN = Span{ .start = 0, .end = 0 };
+const global: DisableDirectiveComment = .{ .kind = .global, .span = NULL_SPAN };
+const line: DisableDirectiveComment = .{ .kind = .line, .span = NULL_SPAN };
 
 fn runTests(cases: []const TestCase) !void {
     for (cases) |case| {
@@ -74,9 +76,6 @@ test "line directives that disable all rules" {
 }
 
 test "comments" {
-    const global: DisableDirectiveComment = .{ .kind = .global, .span = NULL_SPAN };
-    const line: DisableDirectiveComment = .{ .kind = .line, .span = NULL_SPAN };
-
     const cases = &[_]TestCase{
         .{ .src = "// zlint-disable -- unsafe-undefined", .expected = global },
         .{ .src = "// zlint-disable-next-line -- unsafe-undefined", .expected = line },
@@ -142,6 +141,50 @@ test "disabling specific rules" {
                     Span.new(17, 20),
                     Span.new(22, 25),
                     Span.new(27, 30),
+                }),
+            },
+        },
+    };
+    try runTests(cases);
+}
+
+test "non-letter characters in rule list do not cause infinite loop" {
+    // Digits, underscores, and other non-letter/non-hyphen characters are not
+    // valid in rule names. The parser must skip them rather than loop forever
+    // on a zero-length token.
+    const cases = &[_]TestCase{
+        // pure digit token — skipped entirely, no rules parsed
+        .{
+            .src = "// zlint-disable 123",
+            .expected = global,
+        },
+        // leading underscore is skipped; "foo" is still captured
+        .{
+            .src = "// zlint-disable _foo",
+            .expected = .{
+                .kind = .global,
+                .span = NULL_SPAN,
+                .disabled_rules = @constCast(&[_]Span{Span.new(18, 21)}),
+            },
+        },
+        // valid rule name preceded by digit garbage — digit skipped, rule captured
+        .{
+            .src = "// zlint-disable 1foo",
+            .expected = .{
+                .kind = .global,
+                .span = NULL_SPAN,
+                .disabled_rules = @constCast(&[_]Span{Span.new(18, 21)}),
+            },
+        },
+        // valid rule mixed with an all-digit token
+        .{
+            .src = "// zlint-disable foo 42 bar",
+            .expected = .{
+                .kind = .global,
+                .span = NULL_SPAN,
+                .disabled_rules = @constCast(&[_]Span{
+                    Span.new(17, 20),
+                    Span.new(24, 27),
                 }),
             },
         },

--- a/src/linter/disable_directives/Parser_test.zig
+++ b/src/linter/disable_directives/Parser_test.zig
@@ -82,7 +82,18 @@ test "comments" {
         .{ .src = "// zlint-disable-next-line -- unsafe-undefined", .expected = line },
         .{ .src = "// zlint-disable --", .expected = global },
         .{ .src = "// zlint-disable -- foo bar baz", .expected = global },
+        .{ .src = "// zlint-disable-- foo bar baz", .expected = global },
+        .{ .src = "// zlint-disable --foo bar baz", .expected = global },
         .{ .src = "// zlint-disable     --   foo bar baz", .expected = global },
+        // space omission: rule name directly followed by '--' (no space before comment marker)
+        .{
+            .src = "// zlint-disable-next-line unsafe-undefined-- now heres a comment",
+            .expected = .{
+                .kind = .line,
+                .span = NULL_SPAN,
+                .disabled_rules = @constCast(&[_]Span{Span.new(27, 43)}),
+            },
+        },
     };
 
     try runTests(cases);
@@ -134,6 +145,18 @@ test "disabling specific rules" {
                 }),
             },
         },
+    };
+    try runTests(cases);
+}
+
+test "empty comments" {
+    const cases = &[_]TestCase{
+        .{ .src = "//", .expected = null },
+        .{ .src = "///", .expected = null },
+        .{ .src = "//!", .expected = null },
+        .{ .src = "// ", .expected = null },
+        .{ .src = "/// ", .expected = null },
+        .{ .src = "//! ", .expected = null },
     };
     try runTests(cases);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -22,4 +22,5 @@ test {
     std.testing.refAllDecls(@import("util"));
     std.testing.refAllDeclsRecursive(printer);
     std.testing.refAllDeclsRecursive(json);
+    std.testing.refAllDecls(lint);
 }


### PR DESCRIPTION
## What This PR Does
Fixes a bug in the disable directives caused by missing whitespace between a rule name and a `--` comment separator. It caused the parser to loop forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced disable directive parsing with stricter validation and improved bounds checking for better robustness in edge cases.

* **Tests**
  * Expanded test coverage for disable directive parsing, including empty comments and whitespace variation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->