### PR TITLE
fix(sema): bind payload symbols in while loops

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "zig.zls.enableBuildOnSave": true,
     "zig.zls.buildOnSaveStep": "check",
     "zls.zigExePath": "./vendor/zig14/zig",
     "files.exclude": {
@@ -9,5 +8,6 @@
     },
     "search.exclude": {
         "bun.lock": true
-    }
+    },
+    "zig.buildOnSaveProvider": "zls"
 }

--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -603,7 +603,7 @@ fn visitErrorSetDecl(self: *SemanticBuilder, node_id: NodeIndex) !void {
         curr_tok -= 1;
         switch (tags[curr_tok]) {
             .identifier => {
-                _ = try self.declareMemberSymbol(.{
+                try self.declareMemberSymbol(.{
                     .declaration_node = node_id,
                     .identifier = curr_tok,
                     .visibility = Symbol.Visibility.public,
@@ -613,7 +613,6 @@ fn visitErrorSetDecl(self: *SemanticBuilder, node_id: NodeIndex) !void {
             .comma, .doc_comment => {},
             .l_brace => break,
             else => {
-                @branchHint(.unlikely);
                 // in debug builds we want to know if we're missing something or
                 // handling errors incorrectly. in release mode we can safely
                 // ignore it.
@@ -648,7 +647,7 @@ fn visitContainerField(self: *SemanticBuilder, node_id: NodeIndex, field: full.C
     // NOTE: container fields are always public
     const identifier = self.expectToken(main_token, .identifier);
 
-    _ = try self.declareMemberSymbol(.{
+    try self.declareMemberSymbol(.{
         .identifier = identifier,
         .flags = .{
             .s_comptime = field.comptime_token != null,
@@ -893,10 +892,22 @@ fn visitStructInit(self: *SemanticBuilder, _: NodeIndex, @"struct": full.StructI
 // ============================== STATEMENTS ===============================
 
 fn visitWhile(self: *SemanticBuilder, _: NodeIndex, while_stmt: full.While) callconv(util.@"inline") !void {
-    try self.visit(while_stmt.ast.cond_expr);
-    try self.visitOptional(while_stmt.ast.cont_expr);
-    try self.visit(while_stmt.ast.then_expr);
-    try self.visitOptional(while_stmt.ast.else_expr);
+    const ast = while_stmt.ast;
+    try self.visit(ast.cond_expr);
+    try self.visitOptional(ast.cont_expr);
+    {
+        try self.enterScope(.{});
+        defer self.exitScope();
+        if (while_stmt.payload_token) |payload| {
+            _ = try self.declareSymbol(.{
+                .declaration_node = ast.then_expr,
+                .identifier = payload,
+                .flags = .{ .s_payload = true, .s_const = true },
+            });
+        }
+        try self.visit(ast.then_expr);
+    }
+    try self.visitOptional(ast.else_expr);
 }
 
 fn visitFor(self: *SemanticBuilder, node: NodeIndex, for_stmt: full.For) callconv(util.@"inline") !void {
@@ -1470,11 +1481,11 @@ fn bindSymbol(self: *SemanticBuilder, opts: DeclareSymbol) Allocator.Error!Symbo
 }
 
 /// Declare a new symbol in the current scope/AST node and record it as a member to
-/// the most recent container symbol. Returns the new member symbol's ID.
+/// the most recent container symbol.
 fn declareMemberSymbol(
     self: *SemanticBuilder,
     opts: DeclareSymbol,
-) Allocator.Error!Symbol.Id {
+) Allocator.Error!void {
     var options = opts;
     options.flags.s_member = true;
     const member_symbol_id = try self.declareSymbol(options);
@@ -1482,8 +1493,6 @@ fn declareMemberSymbol(
     const container_symbol_id = self.currentContainerSymbolUnwrap();
     assert(!self._semantic.symbols.get(container_symbol_id).flags.s_member);
     try self._semantic.symbols.addMember(self._gpa, member_symbol_id, container_symbol_id);
-
-    return member_symbol_id;
 }
 
 /// Declare a symbol in the current scope. Symbols created this way are not

--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -894,17 +894,20 @@ fn visitStructInit(self: *SemanticBuilder, _: NodeIndex, @"struct": full.StructI
 fn visitWhile(self: *SemanticBuilder, _: NodeIndex, while_stmt: full.While) callconv(util.@"inline") !void {
     const ast = while_stmt.ast;
     try self.visit(ast.cond_expr);
-    try self.visitOptional(ast.cont_expr);
     {
+        const tags = self.AST().tokens.items(.tag);
         try self.enterScope(.{});
         defer self.exitScope();
         if (while_stmt.payload_token) |payload| {
+            const identifier = if (tags[payload] == .identifier) payload else payload + 1;
+            if (tags[identifier] != .identifier) return error.MissingIdentifier;
             _ = try self.declareSymbol(.{
                 .declaration_node = ast.then_expr,
-                .identifier = payload,
+                .identifier = identifier,
                 .flags = .{ .s_payload = true, .s_const = true },
             });
         }
+        try self.visitOptional(ast.cont_expr);
         try self.visit(ast.then_expr);
     }
     try self.visitOptional(ast.else_expr);

--- a/src/Semantic/test/symbol_decl_test.zig
+++ b/src/Semantic/test/symbol_decl_test.zig
@@ -205,6 +205,63 @@ test "Symbol flags - control flow payloads" {
             ,
             .{ .s_payload = true, .s_const = true },
         },
+        .{
+            "fn foo(ptr: ?*u32) void { while (ptr) |*x| { _ = x; } }",
+            .{ .s_payload = true, .s_const = true },
+        },
+        .{
+            \\fn use(_: u32) void {}
+            \\fn foo(cond: ?u32) void {
+            \\  while (cond) |x| : (use(x)) { _ = x; }
+            \\}
+            ,
+            .{ .s_payload = true, .s_const = true },
+        },
+        // pointer capture + cont_expr referencing the payload: exercises both fixes together
+        .{
+            \\fn use(_: *u32) void {}
+            \\fn foo(ptr: ?*u32) void {
+            \\  while (ptr) |*x| : (use(x)) { _ = x; }
+            \\}
+            ,
+            .{ .s_payload = true, .s_const = true },
+        },
+        // while with error-union payload and else capture; ensure normal payload still binds
+        .{
+            \\fn next() anyerror!?u32 { return 1; }
+            \\fn foo() void {
+            \\  while (next() catch null) |x| {
+            \\    _ = x;
+            \\  } else {
+            \\    return;
+            \\  }
+            \\}
+            ,
+            .{ .s_payload = true, .s_const = true },
+        },
+        // labeled while with payload
+        .{
+            \\fn foo(cond: ?u32) void {
+            \\  outer: while (cond) |x| {
+            \\    _ = x;
+            \\    break :outer;
+            \\  }
+            \\}
+            ,
+            .{ .s_payload = true, .s_const = true },
+        },
+        // nested while; inner payload `x` shadows outer — inner (most recently declared) is looked up first
+        .{
+            \\fn foo(a: ?u32, b: ?u32) void {
+            \\  while (a) |_| {
+            \\    while (b) |x| {
+            \\      _ = x;
+            \\    }
+            \\  }
+            \\}
+            ,
+            .{ .s_payload = true, .s_const = true },
+        },
         // for
         .{
             "fn foo() void { for(0..10) |x| { _ = x; } }",

--- a/src/Semantic/test/symbol_decl_test.zig
+++ b/src/Semantic/test/symbol_decl_test.zig
@@ -194,17 +194,17 @@ test "Symbol flags - control flow payloads" {
         },
         // while
         // FIXME: x not bound
-        // .{
-        //     \\const std = @import("std");
-        //     \\fn foo(map: std.StringHashMap(u32)) void {
-        //     \\  var it = map.entries();
-        //     \\  while(it.next()) |x| {
-        //     \\    std.debug.print("{d}\n", .{x.valuePtr.*});
-        //     \\  }
-        //     \\}
-        //     ,
-        //     .{ .s_payload = true, .s_const = true },
-        // },
+        .{
+            \\const std = @import("std");
+            \\fn foo(map: std.StringHashMap(u32)) void {
+            \\  var it = map.entries();
+            \\  while(it.next()) |x| {
+            \\    std.debug.print("{d}\n", .{x.valuePtr.*});
+            \\  }
+            \\}
+            ,
+            .{ .s_payload = true, .s_const = true },
+        },
         // for
         .{
             "fn foo() void { for(0..10) |x| { _ = x; } }",

--- a/src/printer/Printer.zig
+++ b/src/printer/Printer.zig
@@ -123,7 +123,7 @@ pub inline fn pComma(self: *Printer) void {
 /// be printed.
 pub fn pushObject(self: *Printer) !void {
     try self.container_stack.append(self.alloc, ContainerKind.object);
-    _ = try self.writer.write("{");
+    try self.writer.writeAll("{");
     try self.pIndent();
 }
 
@@ -131,7 +131,7 @@ pub fn pushObject(self: *Printer) !void {
 /// be printed.
 pub fn pushArray(self: *Printer, comptime indent: bool) !void {
     try self.container_stack.append(self.alloc, ContainerKind.array);
-    _ = try self.writer.write("[");
+    try self.writer.writeAll("[");
     if (indent) {
         try self.pIndent();
     }
@@ -142,14 +142,13 @@ pub fn pushArray(self: *Printer, comptime indent: bool) !void {
 pub fn pop(self: *Printer) void {
     const kind = self.container_stack.pop() orelse @panic("container stack is empty");
     self.pIndent() catch @panic("failed to write indent after container end");
-    const res = switch (kind) {
-        ContainerKind.object => self.writer.write("}"),
-        ContainerKind.array => self.writer.write("]"),
-    };
+    switch (kind) {
+        ContainerKind.object => self.writer.writeAll("}") catch @panic("failed to write container end"),
+        ContainerKind.array => self.writer.writeAll("]") catch @panic("failed to write container end"),
+    }
     if (self.container_stack.items.len > 0) {
         self.pComma();
     }
-    _ = res catch @panic("failed to write container end");
 }
 
 pub fn popIndent(self: *Printer) void {

--- a/src/util.zig
+++ b/src/util.zig
@@ -45,9 +45,13 @@ pub inline fn assert(condition: bool, comptime fmt: []const u8, args: anytype) v
     }
 }
 
+/// Assert that `condition` is true, panicking in debug builds if it is not.
+/// Unlike `assert`, `debugAssert` will not trigger undefined behavior for
+/// `false` conditions in release builds.
 pub inline fn debugAssert(condition: bool, comptime fmt: []const u8, args: anytype) void {
-    if (comptime IS_DEBUG) {
-        if (!condition) std.debug.panic(fmt, args);
+    if (!condition) {
+        @branchHint(.cold); // panic sets .cold, but that's lost in release builds.
+        if (comptime IS_DEBUG) std.debug.panic(fmt, args);
     }
 }
 

--- a/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
@@ -91,8 +91,8 @@
       "flags": ["variable"], 
       "references": [
         {"symbol":5,"scope":2,"node":"identifier","identifier":"a","flags":["call"]}, 
-        {"symbol":5,"scope":3,"node":"identifier","identifier":"a","flags":["call"]}, 
-        {"symbol":5,"scope":3,"node":"identifier","identifier":"a","flags":["call"]}, 
+        {"symbol":5,"scope":4,"node":"identifier","identifier":"a","flags":["call"]}, 
+        {"symbol":5,"scope":4,"node":"identifier","identifier":"a","flags":["call"]}, 
         {"symbol":5,"scope":2,"node":"identifier","identifier":"a","flags":["call"]}, 
         
       ], 
@@ -109,9 +109,9 @@
       "flags": ["variable"], 
       "references": [
         {"symbol":6,"scope":2,"node":"identifier","identifier":"b","flags":["call"]}, 
-        {"symbol":6,"scope":3,"node":"identifier","identifier":"b","flags":["call"]}, 
-        {"symbol":6,"scope":3,"node":"identifier","identifier":"b","flags":["read"]}, 
-        {"symbol":6,"scope":3,"node":"identifier","identifier":"b","flags":["call"]}, 
+        {"symbol":6,"scope":4,"node":"identifier","identifier":"b","flags":["call"]}, 
+        {"symbol":6,"scope":4,"node":"identifier","identifier":"b","flags":["read"]}, 
+        {"symbol":6,"scope":4,"node":"identifier","identifier":"b","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -143,8 +143,8 @@
       "flags": ["variable"], 
       "references": [
         {"symbol":8,"scope":2,"node":"identifier","identifier":"c","flags":["call"]}, 
-        {"symbol":8,"scope":3,"node":"identifier","identifier":"c","flags":["call"]}, 
-        {"symbol":8,"scope":3,"node":"identifier","identifier":"c","flags":["read"]}, 
+        {"symbol":8,"scope":4,"node":"identifier","identifier":"c","flags":["call"]}, 
+        {"symbol":8,"scope":4,"node":"identifier","identifier":"c","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -212,11 +212,21 @@
             "children": [
               {
                 "id": 3, 
-                "flags": ["block"], 
+                "flags": [], 
                 "bindings": {
                   
                 }, 
-                "children": [], 
+                "children": [
+                  {
+                    "id": 4, 
+                    "flags": ["block"], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [], 
+                    
+                  }, 
+                ], 
                 
               }, 
             ], 

--- a/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/fibonacci.zig.snap
@@ -127,7 +127,7 @@
       "flags": ["variable"], 
       "references": [
         {"symbol":7,"scope":2,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":7,"scope":2,"node":"identifier","identifier":"i","flags":["read","write"]}, 
+        {"symbol":7,"scope":3,"node":"identifier","identifier":"i","flags":["read","write"]}, 
         
       ], 
       "members": [], 

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
@@ -194,7 +194,7 @@
       "flags": ["variable"], 
       "references": [
         {"symbol":12,"scope":10,"node":"identifier","identifier":"x","flags":["read"]}, 
-        {"symbol":12,"scope":11,"node":"identifier","identifier":"x","flags":["read","write"]}, 
+        {"symbol":12,"scope":12,"node":"identifier","identifier":"x","flags":["read","write"]}, 
         {"symbol":12,"scope":13,"node":"identifier","identifier":"x","flags":["read"]}, 
         
       ], 
@@ -211,7 +211,7 @@
       "flags": ["variable"], 
       "references": [
         {"symbol":13,"scope":10,"node":"identifier","identifier":"y","flags":["read"]}, 
-        {"symbol":13,"scope":11,"node":"identifier","identifier":"y","flags":["read","write"]}, 
+        {"symbol":13,"scope":12,"node":"identifier","identifier":"y","flags":["read","write"]}, 
         {"symbol":13,"scope":13,"node":"identifier","identifier":"y","flags":["read"]}, 
         
       ], 
@@ -302,7 +302,7 @@
       "flags": ["variable"], 
       "references": [
         {"symbol":19,"scope":15,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":19,"scope":15,"node":"identifier","identifier":"i","flags":["read","write"]}, 
+        {"symbol":19,"scope":16,"node":"identifier","identifier":"i","flags":["read","write"]}, 
         {"symbol":19,"scope":17,"node":"identifier","identifier":"i","flags":["read"]}, 
         
       ], 
@@ -436,20 +436,20 @@
             "children": [
               {
                 "id": 11, 
-                "flags": ["block"], 
-                "bindings": {
-                  
-                }, 
-                "children": [], 
-                
-              }, {
-                "id": 12, 
                 "flags": [], 
                 "bindings": {
                   
                 }, 
                 "children": [
                   {
+                    "id": 12, 
+                    "flags": ["block"], 
+                    "bindings": {
+                      
+                    }, 
+                    "children": [], 
+                    
+                  }, {
                     "id": 13, 
                     "flags": ["block"], 
                     "bindings": {

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
@@ -319,7 +319,7 @@
         "node": 3, 
         "kind": "module", 
         
-      , 
+      }, 
     ], 
   }, 
   "scopes": {

--- a/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
+++ b/test/snapshots/snapshot-coverage/simple/pass/loops_while.zig.snap
@@ -11,7 +11,7 @@
         
       ], 
       "members": [], 
-      "exports": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,18], 
+      "exports": [1,2,3,4,5,6,7,9,10,11,12,13,14,15,19], 
       
     }, 
     {
@@ -22,10 +22,10 @@
       "scope": 0, 
       "flags": ["variable","const"], 
       "references": [
-        {"symbol":1,"scope":3,"node":"identifier","identifier":"std","flags":["call"]}, 
-        {"symbol":1,"scope":5,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":4,"node":"identifier","identifier":"std","flags":["call"]}, 
         {"symbol":1,"scope":6,"node":"identifier","identifier":"std","flags":["call"]}, 
-        {"symbol":1,"scope":10,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":8,"node":"identifier","identifier":"std","flags":["call"]}, 
+        {"symbol":1,"scope":13,"node":"identifier","identifier":"std","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -55,9 +55,9 @@
       "flags": ["variable"], 
       "references": [
         {"symbol":3,"scope":2,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":3,"scope":3,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":3,"scope":3,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":3,"scope":3,"node":"identifier","identifier":"i","flags":["read","write"]}, 
+        {"symbol":3,"scope":4,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":3,"scope":4,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":3,"scope":4,"node":"identifier","identifier":"i","flags":["read","write"]}, 
         
       ], 
       "members": [], 
@@ -69,10 +69,10 @@
       "debugName": "", 
       "token": 29, 
       "declNode": "simple_var_decl", 
-      "scope": 3, 
+      "scope": 4, 
       "flags": ["variable","const"], 
       "references": [
-        {"symbol":4,"scope":3,"node":"identifier","identifier":"power_of_two","flags":["read"]}, 
+        {"symbol":4,"scope":4,"node":"identifier","identifier":"power_of_two","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -98,12 +98,12 @@
       "debugName": "", 
       "token": 64, 
       "declNode": "simple_var_decl", 
-      "scope": 5, 
+      "scope": 6, 
       "flags": ["variable"], 
       "references": [
-        {"symbol":6,"scope":5,"node":"identifier","identifier":"map","flags":["call"]}, 
-        {"symbol":6,"scope":5,"node":"identifier","identifier":"map","flags":["call"]}, 
-        {"symbol":6,"scope":5,"node":"identifier","identifier":"map","flags":["call"]}, 
+        {"symbol":6,"scope":6,"node":"identifier","identifier":"map","flags":["call"]}, 
+        {"symbol":6,"scope":6,"node":"identifier","identifier":"map","flags":["call"]}, 
+        {"symbol":6,"scope":6,"node":"identifier","identifier":"map","flags":["call"]}, 
         
       ], 
       "members": [], 
@@ -115,10 +115,26 @@
       "debugName": "", 
       "token": 96, 
       "declNode": "simple_var_decl", 
-      "scope": 5, 
+      "scope": 6, 
       "flags": ["variable","const"], 
       "references": [
-        {"symbol":7,"scope":5,"node":"identifier","identifier":"iter","flags":["call"]}, 
+        {"symbol":7,"scope":6,"node":"identifier","identifier":"iter","flags":["call"]}, 
+        
+      ], 
+      "members": [], 
+      "exports": [], 
+      
+    }, 
+    {
+      "name": "ent", 
+      "debugName": "", 
+      "token": 113, 
+      "declNode": "block_semicolon", 
+      "scope": 7, 
+      "flags": ["payload","const"], 
+      "references": [
+        {"symbol":8,"scope":8,"node":"identifier","identifier":"ent","flags":["read"]}, 
+        {"symbol":8,"scope":8,"node":"identifier","identifier":"ent","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -130,10 +146,10 @@
       "debugName": "", 
       "token": 117, 
       "declNode": "simple_var_decl", 
-      "scope": 6, 
+      "scope": 8, 
       "flags": ["variable","const"], 
       "references": [
-        {"symbol":8,"scope":6,"node":"identifier","identifier":"k","flags":["read"]}, 
+        {"symbol":9,"scope":8,"node":"identifier","identifier":"k","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -145,10 +161,10 @@
       "debugName": "", 
       "token": 125, 
       "declNode": "simple_var_decl", 
-      "scope": 6, 
+      "scope": 8, 
       "flags": ["variable","const"], 
       "references": [
-        {"symbol":9,"scope":6,"node":"identifier","identifier":"v","flags":["read"]}, 
+        {"symbol":10,"scope":8,"node":"identifier","identifier":"v","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -174,12 +190,12 @@
       "debugName": "", 
       "token": 158, 
       "declNode": "simple_var_decl", 
-      "scope": 8, 
+      "scope": 10, 
       "flags": ["variable"], 
       "references": [
-        {"symbol":11,"scope":8,"node":"identifier","identifier":"x","flags":["read"]}, 
-        {"symbol":11,"scope":9,"node":"identifier","identifier":"x","flags":["read","write"]}, 
-        {"symbol":11,"scope":10,"node":"identifier","identifier":"x","flags":["read"]}, 
+        {"symbol":12,"scope":10,"node":"identifier","identifier":"x","flags":["read"]}, 
+        {"symbol":12,"scope":11,"node":"identifier","identifier":"x","flags":["read","write"]}, 
+        {"symbol":12,"scope":13,"node":"identifier","identifier":"x","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -191,12 +207,12 @@
       "debugName": "", 
       "token": 165, 
       "declNode": "simple_var_decl", 
-      "scope": 8, 
+      "scope": 10, 
       "flags": ["variable"], 
       "references": [
-        {"symbol":12,"scope":8,"node":"identifier","identifier":"y","flags":["read"]}, 
-        {"symbol":12,"scope":9,"node":"identifier","identifier":"y","flags":["read","write"]}, 
-        {"symbol":12,"scope":10,"node":"identifier","identifier":"y","flags":["read"]}, 
+        {"symbol":13,"scope":10,"node":"identifier","identifier":"y","flags":["read"]}, 
+        {"symbol":13,"scope":11,"node":"identifier","identifier":"y","flags":["read","write"]}, 
+        {"symbol":13,"scope":13,"node":"identifier","identifier":"y","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -208,10 +224,10 @@
       "debugName": "", 
       "token": 194, 
       "declNode": "simple_var_decl", 
-      "scope": 10, 
+      "scope": 13, 
       "flags": ["variable","const"], 
       "references": [
-        {"symbol":13,"scope":10,"node":"identifier","identifier":"my_xy","flags":["read"]}, 
+        {"symbol":14,"scope":13,"node":"identifier","identifier":"my_xy","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -237,10 +253,10 @@
       "debugName": "", 
       "token": 217, 
       "declNode": "identifier", 
-      "scope": 11, 
+      "scope": 14, 
       "flags": ["const","fn_param"], 
       "references": [
-        {"symbol":15,"scope":12,"node":"identifier","identifier":"begin","flags":["read"]}, 
+        {"symbol":16,"scope":15,"node":"identifier","identifier":"begin","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -252,10 +268,10 @@
       "debugName": "", 
       "token": 221, 
       "declNode": "identifier", 
-      "scope": 11, 
+      "scope": 14, 
       "flags": ["const","fn_param"], 
       "references": [
-        {"symbol":16,"scope":12,"node":"identifier","identifier":"end","flags":["read"]}, 
+        {"symbol":17,"scope":15,"node":"identifier","identifier":"end","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -267,10 +283,10 @@
       "debugName": "", 
       "token": 225, 
       "declNode": "identifier", 
-      "scope": 11, 
+      "scope": 14, 
       "flags": ["const","fn_param"], 
       "references": [
-        {"symbol":17,"scope":13,"node":"identifier","identifier":"number","flags":["read"]}, 
+        {"symbol":18,"scope":17,"node":"identifier","identifier":"number","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -282,12 +298,12 @@
       "debugName": "", 
       "token": 232, 
       "declNode": "simple_var_decl", 
-      "scope": 12, 
+      "scope": 15, 
       "flags": ["variable"], 
       "references": [
-        {"symbol":18,"scope":12,"node":"identifier","identifier":"i","flags":["read"]}, 
-        {"symbol":18,"scope":12,"node":"identifier","identifier":"i","flags":["read","write"]}, 
-        {"symbol":18,"scope":13,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":19,"scope":15,"node":"identifier","identifier":"i","flags":["read"]}, 
+        {"symbol":19,"scope":15,"node":"identifier","identifier":"i","flags":["read","write"]}, 
+        {"symbol":19,"scope":17,"node":"identifier","identifier":"i","flags":["read"]}, 
         
       ], 
       "members": [], 
@@ -303,7 +319,7 @@
         "node": 3, 
         "kind": "module", 
         
-      }, 
+      , 
     ], 
   }, 
   "scopes": {
@@ -314,8 +330,8 @@
       "std": 1, 
       "simpleWhile": 2, 
       "whileWithClosure": 5, 
-      "whileWithExpr": 10, 
-      "rangeHasNumber": 14, 
+      "whileWithExpr": 11, 
+      "rangeHasNumber": 15, 
       
     }, 
     "children": [
@@ -336,12 +352,22 @@
             "children": [
               {
                 "id": 3, 
-                "flags": ["block"], 
+                "flags": [], 
                 "bindings": {
-                  "power_of_two": 4, 
                   
                 }, 
-                "children": [], 
+                "children": [
+                  {
+                    "id": 4, 
+                    "flags": ["block"], 
+                    "bindings": {
+                      "power_of_two": 4, 
+                      
+                    }, 
+                    "children": [], 
+                    
+                  }, 
+                ], 
                 
               }, 
             ], 
@@ -350,14 +376,14 @@
         ], 
         
       }, {
-        "id": 4, 
+        "id": 5, 
         "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
-            "id": 5, 
+            "id": 6, 
             "flags": ["function","block"], 
             "bindings": {
               "map": 6, 
@@ -366,14 +392,25 @@
             }, 
             "children": [
               {
-                "id": 6, 
-                "flags": ["block"], 
+                "id": 7, 
+                "flags": [], 
                 "bindings": {
-                  "k": 8, 
-                  "v": 9, 
+                  "ent": 8, 
                   
                 }, 
-                "children": [], 
+                "children": [
+                  {
+                    "id": 8, 
+                    "flags": ["block"], 
+                    "bindings": {
+                      "k": 9, 
+                      "v": 10, 
+                      
+                    }, 
+                    "children": [], 
+                    
+                  }, 
+                ], 
                 
               }, 
             ], 
@@ -382,23 +419,23 @@
         ], 
         
       }, {
-        "id": 7, 
+        "id": 9, 
         "flags": ["function"], 
         "bindings": {
           
         }, 
         "children": [
           {
-            "id": 8, 
+            "id": 10, 
             "flags": ["function","block"], 
             "bindings": {
-              "x": 11, 
-              "y": 12, 
+              "x": 12, 
+              "y": 13, 
               
             }, 
             "children": [
               {
-                "id": 9, 
+                "id": 11, 
                 "flags": ["block"], 
                 "bindings": {
                   
@@ -406,13 +443,23 @@
                 "children": [], 
                 
               }, {
-                "id": 10, 
-                "flags": ["block"], 
+                "id": 12, 
+                "flags": [], 
                 "bindings": {
-                  "my_xy": 13, 
                   
                 }, 
-                "children": [], 
+                "children": [
+                  {
+                    "id": 13, 
+                    "flags": ["block"], 
+                    "bindings": {
+                      "my_xy": 14, 
+                      
+                    }, 
+                    "children": [], 
+                    
+                  }, 
+                ], 
                 
               }, 
             ], 
@@ -421,40 +468,58 @@
         ], 
         
       }, {
-        "id": 11, 
+        "id": 14, 
         "flags": ["function"], 
         "bindings": {
-          "begin": 15, 
-          "end": 16, 
-          "number": 17, 
+          "begin": 16, 
+          "end": 17, 
+          "number": 18, 
           
         }, 
         "children": [
           {
-            "id": 12, 
+            "id": 15, 
             "flags": ["function","block"], 
             "bindings": {
-              "i": 18, 
+              "i": 19, 
               
             }, 
             "children": [
               {
-                "id": 13, 
-                "flags": ["block"], 
+                "id": 16, 
+                "flags": [], 
                 "bindings": {
                   
                 }, 
                 "children": [
                   {
-                    "id": 14, 
-                    "flags": [], 
+                    "id": 17, 
+                    "flags": ["block"], 
                     "bindings": {
                       
                     }, 
                     "children": [
                       {
-                        "id": 15, 
-                        "flags": ["block"], 
+                        "id": 18, 
+                        "flags": [], 
+                        "bindings": {
+                          
+                        }, 
+                        "children": [
+                          {
+                            "id": 19, 
+                            "flags": ["block"], 
+                            "bindings": {
+                              
+                            }, 
+                            "children": [], 
+                            
+                          }, 
+                        ], 
+                        
+                      }, {
+                        "id": 20, 
+                        "flags": [], 
                         "bindings": {
                           
                         }, 
@@ -462,14 +527,6 @@
                         
                       }, 
                     ], 
-                    
-                  }, {
-                    "id": 16, 
-                    "flags": [], 
-                    "bindings": {
-                      
-                    }, 
-                    "children": [], 
                     
                   }, 
                 ], 


### PR DESCRIPTION
## What This PR Does
Updates the semantic builder to bind payload symbols in while loops.

```zig
while (it.next) |el| // <- now bound
  // ...
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VSCode development settings for build configuration

* **Tests**
  * Enabled control flow payload test coverage

* **Documentation**
  * Expanded debugging function documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->