### PR TITLE
ci: add linux riscv64 and loongarch64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,14 @@ jobs:
       matrix:
         os: [linux, windows, macos]
         arch: [aarch64, x86_64]
+        # riscv64 and loongarch64 are published for Linux only (there are no
+        # macOS/Windows builds for those arches), so add them as explicit
+        # combinations instead of expanding the full os/arch grid.
+        include:
+          - os: linux
+            arch: riscv64
+          - os: linux
+            arch: loongarch64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/tasks/install.sh
+++ b/tasks/install.sh
@@ -65,6 +65,12 @@ case $platform in
 'Linux aarch64' | 'Linux arm64')
     target=linux-aarch64
     ;;
+'Linux riscv64')
+    target=linux-riscv64
+    ;;
+'Linux loongarch64')
+    target=linux-loongarch64
+    ;;
 'MINGW64'*)
     target=windows-x86_64
     ;;


### PR DESCRIPTION
This adds release binaries for linux loongarch64 and riscv64. I don't have loongarch64 hardware, but I've tested the riscv64 binary on my spacemit SOC and it works fine. This should also allow use with these architectures using [mise](https://mise.jdx.dev/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Linux build and release coverage to include additional architectures: **riscv64** and **loongarch64**.
  * Updated the installation script to correctly detect these architectures and download the matching binary for each platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->