### PR TITLE
fix(cli): fix new-rule script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ temp/
 *.tmp
 
 vendor
+openspec

--- a/tasks/new-rule.ts
+++ b/tasks/new-rule.ts
@@ -2,7 +2,6 @@
 
 import path from 'path'
 import fs from 'fs'
-import assert from 'assert'
 
 const RULES_DIR = 'src/linter/rules'
 const RULES_MODULE = 'src/linter/rules.zig'

--- a/tasks/new-rule.ts
+++ b/tasks/new-rule.ts
@@ -6,7 +6,7 @@ import assert from 'assert'
 
 const RULES_DIR = 'src/linter/rules'
 const RULES_MODULE = 'src/linter/rules.zig'
-const CONFIG_PATH = 'src/linter/config/rules_config.zig'
+const CONFIG_PATH = 'src/linter/config/rules_config_rules.zig'
 const p = (...segs: string[]) => path.join(__dirname, '..', ...segs)
 
 class RuleData {
@@ -63,19 +63,11 @@ async function main(argv: string[]) {
  * ```
  */
 const updateConfig = async (rule: RuleData) => {
-    let ruleConfig = await fs.promises.readFile(p(CONFIG_PATH), 'utf-8');
-    const pattern = "pub const RulesConfig = struct {"
-    let insertAt = ruleConfig.indexOf(pattern)
-    assert(insertAt > 0)
-    insertAt += pattern.length
-    do {
-        insertAt++
-    } while (ruleConfig[insertAt] !== '\n')
-    ruleConfig = ruleConfig.slice(0, insertAt) +
-        `    ${rule.underscored}: RuleConfig(rules.${rule.StructName}) = .{},` +
-        ruleConfig.slice(insertAt)
-
-    await fs.promises.writeFile(p(CONFIG_PATH), ruleConfig)
+    await fs.promises.appendFile(
+        p(CONFIG_PATH),
+        `${rule.underscored}: RuleConfig(rules.${rule.StructName}) = .{},`,
+        { flush: true }
+    )
 }
 
 const createRule = ({ name, StructName, underscored, camelCaseName }: RuleData) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an ignore rule to keep an additional local path out of version control.
* **Bug Fixes**
  * Improved how newly added lint rules are registered, so updates are applied more reliably to the rules configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->