### PR TITLE
chore(ci): upgrade outdated GitHub Actions

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -18,17 +18,17 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
 
       - name: Fix typos
-        uses: crate-ci/typos@v1.26.8
+        uses: crate-ci/typos@v1.48.0
         with:
           write_changes: true
       - run: zig fmt src test/harness tasks build.zig build.zig.zon
 
       - run: rm -f ./typos
 
-      - uses: autofix-ci/action@dd55f44df8f7cdb7a6bf74c78677eb8acd40cd0a
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,9 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Install tooling
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v4
         with:
           just-version: ${{ env.JUST_VERSION }}
       - uses: mlugg/setup-zig@v2
@@ -55,9 +55,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Install tooling
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v4
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
@@ -79,9 +79,9 @@ jobs:
     if: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Install tooling
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v4
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
@@ -98,9 +98,9 @@ jobs:
       matrix:
         optimize: ["ReleaseSafe", "ReleaseFast"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Install tooling
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v4
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
@@ -118,12 +118,12 @@ jobs:
     name: Docs + JSON Schema
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Install tooling
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v4
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -19,12 +19,12 @@ jobs:
     name: Collect and upload test coverage
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install kcov
         run: |
           sudo apt-get update
           sudo apt-get install -y kcov
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v4
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
@@ -32,7 +32,7 @@ jobs:
       - run: just submodules
       - run: zig build
       - run: just coverage
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v7
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -16,7 +16,7 @@ jobs:
       id-token: write # to verify the deployment originates from an appropriate source
       contents: read # to read the contents of the repo
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
@@ -24,7 +24,7 @@ jobs:
       - name: bun install
         run: bun install --frozen-lockfile
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: apps/site/build
           key: docs

--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -37,7 +37,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
@@ -47,7 +47,7 @@ jobs:
   check-vscode:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
@@ -60,7 +60,7 @@ jobs:
   check-site:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,5 +16,5 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
             arch: loongarch64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
@@ -60,14 +60,14 @@ jobs:
           mv zig-out/bin/${binary_name} zig-out/bin/${{ env.BINARY_NAME }}
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v4
         env:
           BINARY_NAME: ${{ steps.binary_name.outputs.binary_name }}
         with:
           subject-path: zig-out/bin/${{ env.BINARY_NAME }}
 
       - name: Upload zlint binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           BINARY_NAME: ${{ steps.binary_name.outputs.binary_name }}
         with:
@@ -83,15 +83,15 @@ jobs:
       - build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: zlint-*
           path: zig-out/dist
           merge-multiple: true
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: zig-out/dist/*


### PR DESCRIPTION
## Summary
- Bumps every outdated action across the 7 workflow files to its latest release: `actions/checkout` v4→v7, `actions/cache` v4→v6, `actions/attest-build-provenance` v1→v4, `actions/upload-artifact` v4→v7, `actions/download-artifact` v4→v8, `codecov/codecov-action` v4→v7, `softprops/action-gh-release` v2→v3, `extractions/setup-just` v2→v4, `crate-ci/typos` v1.26.8→v1.48.0.
- Updates SHA-pinned actions to newer commits: `taiki-e/checkout-action` → v1.4.2, `actions/labeler` → v6.1.0, `autofix-ci/action` → v1.3.4 (previously pinned to an untagged 2024 commit).
- All bumps were checked against upstream changelogs — they're Node 20→24 runtime updates or additive/opt-in features, none affecting how this repo invokes them.

## Test plan
- [x] `actionlint` run over `.github/workflows/` (only pre-existing unrelated warning)
- [ ] CI runs green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several automation workflows to use newer, supported action versions across CI, docs, code coverage, pull requests, and releases.
  * Kept existing build, test, lint, documentation, and release behavior the same while improving maintenance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->