### PR TITLE
ci: re-enable lint job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,11 +72,7 @@ jobs:
   # https://imgflip.com/i/9eygz0
   lint:
     name: Lint Changed
-    # TODO: un-comment after fully migrating to 0.15.
-    # as of writing, zlint uses the 0.14 parser, which breaks when parsing `usingnamespace`
-    # (it was a keyword, now its an identifier)
-    # if: ${{ github.event_name == 'pull_request' }}
-    if: false
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const Build = std.Build;
 const Module = std.Build.Module;
 const codegen = @import("tasks/codegen_task.zig");

--- a/src/Semantic.zig
+++ b/src/Semantic.zig
@@ -147,7 +147,6 @@ const _tokenizer = @import("Semantic/tokenizer.zig");
 const TokenIndex = _ast.TokenIndex;
 
 // re-exports
-const util = @import("util");
 const zig = std.zig;
 pub const Ast = zig.Ast;
 pub const Builder = @import("Semantic/Builder.zig");

--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -1908,7 +1908,6 @@ const Error = @import("../Error.zig");
 const _source = @import("../source.zig");
 const _span = @import("../span.zig");
 const LabeledSpan = _span.LabeledSpan;
-const Span = _span.Span;
 
 const util = @import("util");
 const IS_DEBUG = util.IS_DEBUG;

--- a/src/linter/rules/allocator_first_param.zig
+++ b/src/linter/rules/allocator_first_param.zig
@@ -48,10 +48,8 @@
 //! ```
 
 const std = @import("std");
-const util = @import("util");
 const Semantic = @import("../../Semantic.zig");
 const _rule = @import("../rule.zig");
-const _span = @import("../../span.zig");
 const ast_utils = @import("../ast_utils.zig");
 
 const Ast = Semantic.Ast;

--- a/src/linter/rules/case_convention.zig
+++ b/src/linter/rules/case_convention.zig
@@ -33,7 +33,6 @@ const std = @import("std");
 const util = @import("util");
 const Semantic = @import("../../Semantic.zig");
 const _rule = @import("../rule.zig");
-const _span = @import("../../span.zig");
 const ast_utils = @import("../ast_utils.zig");
 
 const Ast = Semantic.Ast;

--- a/src/linter/rules/duplicate_case.zig
+++ b/src/linter/rules/duplicate_case.zig
@@ -46,14 +46,9 @@
 
 const std = @import("std");
 const util = @import("util");
-const ast_utils = @import("../ast_utils.zig");
-const _source = @import("../../source.zig");
 const _rule = @import("../rule.zig");
 const _span = @import("../../span.zig");
 
-const Loc = Semantic.Token.Loc;
-const Span = _span.Span;
-const LabeledSpan = _span.LabeledSpan;
 const LinterContext = @import("../lint_context.zig");
 const Rule = _rule.Rule;
 const NodeWrapper = _rule.NodeWrapper;
@@ -61,12 +56,8 @@ const NodeWrapper = _rule.NodeWrapper;
 const Semantic = @import("../../Semantic.zig");
 const Ast = Semantic.Ast;
 const Node = Ast.Node;
-const TokenIndex = Ast.TokenIndex;
-const Symbol = Semantic.Symbol;
-const Scope = Semantic.Scope;
 
 const Error = @import("../../Error.zig");
-const Cow = util.Cow(false);
 const AstComparator = @import("../../visit/AstComparator.zig");
 
 const DuplicateCase = @This();

--- a/src/linter/rules/duplicate_case.zig
+++ b/src/linter/rules/duplicate_case.zig
@@ -45,9 +45,7 @@
 //! ```
 
 const std = @import("std");
-const util = @import("util");
 const _rule = @import("../rule.zig");
-const _span = @import("../../span.zig");
 
 const LinterContext = @import("../lint_context.zig");
 const Rule = _rule.Rule;

--- a/src/linter/rules/no_print.zig
+++ b/src/linter/rules/no_print.zig
@@ -62,7 +62,6 @@
 //! ```
 
 const std = @import("std");
-const util = @import("util");
 const ast_utils = @import("../ast_utils.zig");
 const _rule = @import("../rule.zig");
 const _span = @import("../../span.zig");

--- a/src/linter/rules/no_print.zig
+++ b/src/linter/rules/no_print.zig
@@ -64,11 +64,9 @@
 const std = @import("std");
 const util = @import("util");
 const ast_utils = @import("../ast_utils.zig");
-const _source = @import("../../source.zig");
 const _rule = @import("../rule.zig");
 const _span = @import("../../span.zig");
 
-const Loc = Semantic.Token.Loc;
 const Span = _span.Span;
 const LabeledSpan = _span.LabeledSpan;
 const LinterContext = @import("../lint_context.zig");
@@ -77,13 +75,9 @@ const NodeWrapper = _rule.NodeWrapper;
 
 const Semantic = @import("../../Semantic.zig");
 const Ast = Semantic.Ast;
-const Node = Ast.Node;
 const TokenIndex = Ast.TokenIndex;
-const Symbol = Semantic.Symbol;
-const Scope = Semantic.Scope;
 
 const Error = @import("../../Error.zig");
-const Cow = util.Cow(false);
 const eql = std.mem.eql;
 
 pub const meta: Rule.Meta = .{

--- a/src/linter/rules/no_return_try.zig
+++ b/src/linter/rules/no_return_try.zig
@@ -44,7 +44,6 @@ const _rule = @import("../rule.zig");
 const _span = @import("../../span.zig");
 
 const Ast = Semantic.Ast;
-const Node = Ast.Node;
 const LinterContext = @import("../lint_context.zig");
 const LabeledSpan = _span.LabeledSpan;
 const Rule = _rule.Rule;

--- a/src/linter/rules/no_return_try.zig
+++ b/src/linter/rules/no_return_try.zig
@@ -43,7 +43,6 @@ const Semantic = @import("../../Semantic.zig");
 const _rule = @import("../rule.zig");
 const _span = @import("../../span.zig");
 
-const Ast = Semantic.Ast;
 const LinterContext = @import("../lint_context.zig");
 const LabeledSpan = _span.LabeledSpan;
 const Rule = _rule.Rule;

--- a/src/linter/rules/no_unresolved.zig
+++ b/src/linter/rules/no_unresolved.zig
@@ -36,7 +36,6 @@ const std = @import("std");
 const util = @import("util");
 const path = std.fs.path;
 
-const Ast = @import("../../Semantic.zig").Ast;
 const LinterContext = @import("../lint_context.zig");
 const Rule = @import("../rule.zig").Rule;
 const NodeWrapper = @import("../rule.zig").NodeWrapper;

--- a/src/linter/rules/suppressed_errors.zig
+++ b/src/linter/rules/suppressed_errors.zig
@@ -69,7 +69,6 @@ const LinterContext = @import("../lint_context.zig");
 const Rule = _rule.Rule;
 const LabeledSpan = _span.LabeledSpan;
 const NodeWrapper = _rule.NodeWrapper;
-const NULL_NODE = Semantic.NULL_NODE;
 const Error = @import("../../Error.zig");
 const Cow = util.Cow(false);
 

--- a/src/linter/rules/unsafe_undefined.zig
+++ b/src/linter/rules/unsafe_undefined.zig
@@ -140,7 +140,6 @@ const Semantic = @import("../../Semantic.zig");
 const Symbol = Semantic.Symbol;
 
 const Ast = Semantic.Ast;
-const Node = Ast.Node;
 const Token = Semantic.Token;
 const TokenIndex = Ast.TokenIndex;
 const LinterContext = @import("../lint_context.zig");

--- a/src/printer/Printer.zig
+++ b/src/printer/Printer.zig
@@ -168,4 +168,3 @@ const std = @import("std");
 const io = std.Io;
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
-const stringify = std.json.stringify;

--- a/src/reporter/Reporter.zig
+++ b/src/reporter/Reporter.zig
@@ -240,7 +240,6 @@ const util = @import("util");
 const formatters = @import("./formatter.zig");
 const Chameleon = @import("chameleon");
 const Error = @import("../Error.zig");
-const StringWriter = @import("./StringWriter.zig");
 const Allocator = std.mem.Allocator;
 const FormatError = formatters.FormatError;
 

--- a/src/source.zig
+++ b/src/source.zig
@@ -4,7 +4,6 @@ const Io = std.Io;
 
 const Allocator = std.mem.Allocator;
 const Arc = ptrs.Arc;
-const assert = std.debug.assert;
 
 pub const ArcStr = Arc([:0]u8);
 

--- a/src/visit/AstComparator.zig
+++ b/src/visit/AstComparator.zig
@@ -231,5 +231,4 @@ const std = @import("std");
 const mem = std.mem;
 const Ast = @import("../Semantic.zig").Ast;
 const Node = Ast.Node;
-const NodeList = Ast.NodeList;
 const TokenIndex = Ast.TokenIndex;

--- a/tasks/codegen_task.zig
+++ b/tasks/codegen_task.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const c = @import("constants.zig");
 const Build = std.Build;
 const Module = Build.Module;

--- a/tasks/docgen.zig
+++ b/tasks/docgen.zig
@@ -7,14 +7,12 @@ const std = @import("std");
 const io = std.Io;
 const gen = @import("./gen_utils.zig");
 const zlint = @import("zlint");
-const RULE_DOCS_DIR = @import("./constants.zig").@"docs/rules";
 const log = std.log;
 const mem = std.mem;
 const path = std.fs.path;
 
 const Allocator = mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
-const Writer = io.File.Writer;
 const Schema = zlint.json.Schema;
 
 const panic = std.debug.panic;

--- a/test/semantic/ecosystem_coverage.zig
+++ b/test/semantic/ecosystem_coverage.zig
@@ -16,7 +16,6 @@ const REPOS_DIR = "zig-out/repos";
 // SAFETY: globalSetup is always run before this is read
 var repos: std.json.Parsed([]Repo) = undefined;
 
-const SemanticError = zlint.semantic.Semantic.Builder.SemanticError;
 var is_tty: bool = false;
 
 pub fn globalSetup(alloc: Allocator) !void {

--- a/test/utils.zig
+++ b/test/utils.zig
@@ -4,7 +4,6 @@ const path = std.fs.path;
 
 const Allocator = std.mem.Allocator;
 
-const print = std.debug.print;
 
 pub const string = []const u8;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI so the lint job now runs on pull requests, helping catch issues earlier.
  * Cleaned up unused internal imports and aliases across the codebase.
  * Simplified a few build, reporting, printing, and test declarations without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->