### PR TITLE
fix(reporter): prevent u32 underflow panic on empty zlint.json

### DIFF
--- a/src/cli/lint_config.zig
+++ b/src/cli/lint_config.zig
@@ -147,11 +147,14 @@ fn getReportForParseError(
     diagnostics: *const json.Diagnostics,
 ) Error {
     const offset: u32 = @truncate(diagnostics.getByteOffset());
-    var span = Span.sized(offset -| 1, 1);
+    const src_len: u32 = @intCast(source.len);
+    const clamped_offset = @min(offset, src_len);
+    var span = Span.sized(clamped_offset -| 1, 1);
+    span.end = @min(span.end, src_len);
 
     const message = switch (e) {
         error.UnknownField => blk: {
-            if (mem.lastIndexOfAny(u8, source[0..offset], &std.ascii.whitespace)) |start| {
+            if (mem.lastIndexOfAny(u8, source[0..clamped_offset], &std.ascii.whitespace)) |start| {
                 span.start = @intCast(start + 1);
             }
             const field = source[span.start..span.end];
@@ -268,4 +271,38 @@ test resolveLintConfig {
 
     try t.expectStringEndsWith(config.path.?, expected_path);
     try t.expectEqual(.warning, config.config.rules.rules.unsafe_undefined.severity);
+}
+
+// Regression test for https://github.com/DonIsaac/zlint/issues/360: an empty
+// zlint.json produced a label span past the end of the (empty) source, which
+// caused a `u32` underflow panic when the graphical formatter rendered it.
+test "resolveLintConfig with an empty zlint.json does not crash the formatter" {
+    const GraphicalFormatter = @import("../reporter.zig").formatter.Graphical;
+
+    const cwd = Dir.cwd();
+    const fixtures_dir = try cwd.realPathFileAlloc(t.io, "test/fixtures/config-empty", t.allocator);
+    defer t.allocator.free(fixtures_dir);
+
+    var arena = ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
+
+    var err: Error = undefined;
+    try t.expectError(error.UnexpectedEndOfInput, resolveLintConfig(
+        &arena,
+        t.io,
+        try cwd.openDir(t.io, fixtures_dir, .{}),
+        "zlint.json",
+        t.allocator,
+        &err,
+    ));
+    defer err.deinit(t.allocator);
+
+    try t.expectEqual(0, err.source.?.deref().*.len);
+    try t.expectEqual(1, err.labels.items.len);
+    try t.expectEqual(Span.EMPTY, err.labels.items[0].span);
+
+    var fmt = GraphicalFormatter.unicode(t.allocator, false);
+    var w = std.Io.Writer.Allocating.init(t.allocator);
+    defer w.deinit();
+    try fmt.format(&w.writer, err);
 }

--- a/src/reporter/formatters/GraphicalFormatter.zig
+++ b/src/reporter/formatters/GraphicalFormatter.zig
@@ -75,6 +75,8 @@ fn renderContext(self: *GraphicalFormatter, w: *io.Writer, e: *Error) FormatErro
     if (e.labels.items.len == 0 or e.source == null) return;
 
     const src: []const u8 = e.source.?.deref().*;
+    // No source text means there are no lines to render a code frame for.
+    if (src.len == 0) return;
 
     std.sort.insertion(LabeledSpan, e.labels.items, {}, labelsLt);
 
@@ -314,7 +316,7 @@ fn contextFor(
     assert(linebuf.len == expected_lines);
 
     // happens sometimes when reporting missing semicolon parse errors.
-    if (start == src.len) start -= 1;
+    if (start == src.len and start > 0) start -= 1;
 
     // expand start/end to cover the entire line
     while (start > 0) : (start -= 1) {


### PR DESCRIPTION
## Summary
- An empty (or whitespace-only) `zlint.json` produced a label span exceeding the empty source's length, causing a `u32` underflow panic in `GraphicalFormatter.contextFor` instead of a clean diagnostic.
- Clamps the label span to the source length in `getReportForParseError`, guards the underflow in `contextFor`, and skips code-frame rendering entirely when the source is empty.
- Adds a regression test using a new empty-config fixture, verifying the diagnostic renders without panicking.

Fixes #360

## Test plan
- [x] `zig build test` — all 141 tests pass
- [x] Manually reproduced the issue's repro steps (`touch zlint.json` + lint) — now prints an `invalid-config` diagnostic and exits 1 instead of panicking (exit 134)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error reporting for empty configuration files so spans stay within valid bounds.
  * Prevented crashes in formatted error output when the source content is empty.
* **Tests**
  * Added a regression test covering empty configuration input to verify the error is reported safely and can be displayed without failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->