### PR TITLE
Detect returned stack slices

### DIFF
--- a/src/linter/rules/returned_stack_reference.zig
+++ b/src/linter/rules/returned_stack_reference.zig
@@ -52,6 +52,7 @@ const util = @import("util");
 const Semantic = @import("../../Semantic.zig");
 const _rule = @import("../rule.zig");
 const _span = @import("../../span.zig");
+const ast_utils = @import("../ast_utils.zig");
 const walk = @import("../../visit/walk.zig");
 
 const Ast = Semantic.Ast;
@@ -84,9 +85,13 @@ fn stackRefDiagnostic(
         "Returning a slice to stack-allocated memory is undefined behavior."
     else
         "Returning a reference to stack-allocated memory is undefined behavior.";
+    const primary_label = if (is_slice)
+        "This slice refers to a local variable"
+    else
+        "This pointer refers to a local variable";
 
     var labels: [2]LabeledSpan = undefined;
-    labels[0] = ctx.labelN(node, "This pointer refers to a local variable", .{});
+    labels[0] = ctx.labelN(node, primary_label, .{});
     if (decl_loc) |loc| {
         labels[1] = LabeledSpan{ .span = loc, .label = .static("Variable is declared locally here") };
     }
@@ -194,9 +199,6 @@ const StackReferenceVisitor = struct {
         switch (self.ast.nodeTag(node)) {
             .@"return" => self.return_depth += 1,
             .call, .call_comma, .call_one, .call_one_comma => self.call_depth += 1,
-            .slice, .slice_open, .slice_sentinel => {
-                // todo: check inside slices and array literals for identifier references
-            },
             else => {},
         }
     }
@@ -219,6 +221,17 @@ const StackReferenceVisitor = struct {
                 self.ctx.report(stackRefDiagnostic(self.ctx, node, info.decl_loc, false));
             }
             return .Skip;
+        }
+        return .Continue;
+    }
+
+    pub fn visitSlice(self: *StackReferenceVisitor, node: Node.Index, slice: *const Ast.full.Slice) Err!walk.WalkState {
+        if (self.return_depth == 0 or self.call_depth > 0) return .Continue;
+
+        const sliced = ast_utils.getLeftmostIdentifier(self.ctx, slice.ast.sliced, true) orelse return .Continue;
+        const info = self.isDeclaredLocally(sliced);
+        if (info.is_local) {
+            self.ctx.report(stackRefDiagnostic(self.ctx, node, info.decl_loc, true));
         }
         return .Continue;
     }
@@ -325,6 +338,11 @@ test ReturnedStackReference {
         \\}
         ,
         "fn foo(buf: []u8) []u8 { return buf[0..]; }",
+        \\const Foo = struct { items: []const u8 };
+        \\fn foo(input: Foo) []const u8 {
+        \\  return input.items[0..];
+        \\}
+        ,
         "fn foo() []u8  { return &[_]u8{}; }",
         "fn foo() [2]u8 { return [2]u8{1, 2}; }",
         \\fn len(slice: *[]const u8) usize {
@@ -421,6 +439,27 @@ test ReturnedStackReference {
         \\fn foo() Foo {
         \\  const local: u32 = 1;
         \\  return .{ .x = &local };
+        \\}
+        ,
+        \\fn foo() []u32 {
+        \\  var x: [1]u32 = .{1};
+        \\  return x[0..];
+        \\}
+        ,
+        \\fn foo() []u32 {
+        \\  var x: [2]u32 = .{ 1, 2 };
+        \\  return x[0..1];
+        \\}
+        ,
+        \\fn foo() [:0]u8 {
+        \\  var x: [2:0]u8 = .{ 1, 2 };
+        \\  return x[0..2 :0];
+        \\}
+        ,
+        \\const Foo = struct { items: []const u8 };
+        \\fn foo() Foo {
+        \\  var buf: [2]u8 = .{ 1, 2 };
+        \\  return .{ .items = buf[0..] };
         \\}
     };
 

--- a/src/linter/rules/snapshots/returned-stack-reference.snap
+++ b/src/linter/rules/snapshots/returned-stack-reference.snap
@@ -72,3 +72,47 @@
    ·                     ╰── This pointer refers to a local variable
    ╰────
 
+  𝙭 returned-stack-reference: Returning a slice to stack-allocated memory is undefined behavior.
+   ╭─[returned-stack-reference.zig:2:7]
+ 1 │ fn foo() []u32 {
+ 2 │   var x: [1]u32 = .{1};
+   ·       ┬
+   ·       ╰── Variable is declared locally here
+ 3 │   return x[0..];
+   ·          ───┬───
+   ·             ╰── This slice refers to a local variable
+   ╰────
+
+  𝙭 returned-stack-reference: Returning a slice to stack-allocated memory is undefined behavior.
+   ╭─[returned-stack-reference.zig:2:7]
+ 1 │ fn foo() []u32 {
+ 2 │   var x: [2]u32 = .{ 1, 2 };
+   ·       ┬
+   ·       ╰── Variable is declared locally here
+ 3 │   return x[0..1];
+   ·          ───┬───
+   ·             ╰── This slice refers to a local variable
+   ╰────
+
+  𝙭 returned-stack-reference: Returning a slice to stack-allocated memory is undefined behavior.
+   ╭─[returned-stack-reference.zig:2:7]
+ 1 │ fn foo() [:0]u8 {
+ 2 │   var x: [2:0]u8 = .{ 1, 2 };
+   ·       ┬
+   ·       ╰── Variable is declared locally here
+ 3 │   return x[0..2 :0];
+   ·          ─────┬─────
+   ·               ╰── This slice refers to a local variable
+   ╰────
+
+  𝙭 returned-stack-reference: Returning a slice to stack-allocated memory is undefined behavior.
+   ╭─[returned-stack-reference.zig:3:7]
+ 2 │ fn foo() Foo {
+ 3 │   var buf: [2]u8 = .{ 1, 2 };
+   ·       ─┬─
+   ·        ╰── Variable is declared locally here
+ 4 │   return .{ .items = buf[0..] };
+   ·                      ────┬────
+   ·                          ╰── This slice refers to a local variable
+   ╰────
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Detect returned slices of stack-local values in `returned-stack-reference` via the walker `visitSlice` hook.
- Add slice-specific diagnostic label text.
- Cover open, bounded, sentinel, and struct-field returned slice cases in RuleTester snapshots.

## Verification
- `/tmp/zig-download/zig-x86_64-linux-0.16.0/zig fmt src/linter/rules/returned_stack_reference.zig`
- `/tmp/zig-download/zig-x86_64-linux-0.16.0/zig build test --error-style minimal --summary all`
- `/tmp/zig-download/zig-x86_64-linux-0.16.0/zig build check --summary all --error-style minimal`
- `git diff --check`
- `/tmp/zig-download/zig-x86_64-linux-0.16.0/zig fmt --check src test/harness build.zig build.zig.zon`

Note: `just` and `typos` were not installed in the environment, so I used a temporary Zig 0.16.0 toolchain under `/tmp` for verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3389-a5ea-70eb-b3c6-99104ea30bac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3389-a5ea-70eb-b3c6-99104ea30bac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

