### PR TITLE
fix(linter): u.b. in `FixBuilder.noop()`

### DIFF
--- a/src/linter/fix.zig
+++ b/src/linter/fix.zig
@@ -52,7 +52,7 @@ pub const Fix = struct {
         pub fn noop(_: Builder) Fix {
             return Fix{
                 // SAFETY: noop fixes never have their meta field accessed
-                .meta = undefined,
+                .meta = .disabled,
                 .span = Span.EMPTY,
                 .replacement = EMPTY,
             };
@@ -191,6 +191,7 @@ pub const Fixer = struct {
                 );
             }
             self.unfixed_errors.deinit(allocator);
+            self.* = undefined;
         }
     };
 

--- a/src/linter/rules/avoid_as.zig
+++ b/src/linter/rules/avoid_as.zig
@@ -282,6 +282,11 @@ test AvoidAs {
             .src = "const Foo = struct { x: u32 = @as(u32, 1) };",
             .expected = "const Foo = struct { x: u32 = 1 };",
         },
+        .{
+            .src = "const Foo = struct { x: u32 = @as(u32) };",
+            .expected = "const Foo = struct { x: u32 = @as(u32) };",
+            .fails_lint = true,
+        },
     };
 
     try runner

--- a/src/linter/tester.zig
+++ b/src/linter/tester.zig
@@ -42,6 +42,9 @@ pub const FixCase = struct {
     /// What kind of fix should have been provided. Leave this as `null` if you
     /// don't care.
     kind: ?Fix.Kind = null,
+    /// Set to `true` if the fixed source still violates the rule. Useful for
+    /// noop-fixer testing.
+    fails_lint: bool = false,
 };
 
 pub fn init(alloc: Allocator, rule: Rule) RuleTester {
@@ -204,9 +207,26 @@ fn runImpl(self: *RuleTester) LintTesterError!void {
 
             var fixer: Fixer = .{ .allocator = self.alloc };
             var fixed = try fixer.applyFixes(case.src, fix_errors.items);
+            defer fixed.deinit(self.alloc);
             const unfixed = fixed.unfixed_errors.items;
 
             // TODO: check fix kind.
+
+            if (case.fails_lint) {
+                if (fixed.did_fix) {
+                    defer fixed.deinit(self.alloc);
+                    self.diagnostic.message = Cow.fmt(
+                        self.alloc,
+                        "Expected case #{d} not to fix any violations, but some fixes were applied.\n\n{s}",
+                        .{ i + 1, case.src },
+                    ) catch @panic("OOM");
+                    return error.FixMismatch;
+                }
+                for (fixed.unfixed_errors.items) |*err| {
+                    err.deinit(self.alloc);
+                }
+                continue;
+            }
 
             if (unfixed.len > 0) {
                 defer if (fixed.did_fix) fixed.source.deinit(self.alloc);
@@ -221,7 +241,6 @@ fn runImpl(self: *RuleTester) LintTesterError!void {
                 ) catch @panic("OOM");
                 return error.FixFailed;
             }
-            defer fixed.deinit(self.alloc);
             if (!fixed.did_fix) {
                 self.diagnostic.message = Cow.fmt(
                     self.alloc,


### PR DESCRIPTION
## What This PR Does
Fixes #378 

Fixes a reachable `unreachable` statement caused by no-op fixers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when lint fixes are cleaned up and invalid results are discarded.
  - Corrected handling for incomplete type-cast expressions in struct field initializers.

- **Tests**
  - Expanded lint coverage for cases where a violation is correctly detected but cannot be automatically fixed.
  - Improved test validation for fixes that do not fully resolve a lint issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->