### PR TITLE
fix(sema): forward references never resolve to container fields

### DIFF
--- a/src/Semantic.zig
+++ b/src/Semantic.zig
@@ -98,7 +98,7 @@ pub fn getBinding(self: *const Semantic, scope_id: Scope.Id, name: []const u8) ?
     return null;
 }
 
-const BindingQuery = struct {
+pub const BindingQuery = struct {
     /// Symbols that have these flags will be skipped.
     exclude: Symbol.Flags = .{},
 };

--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -147,7 +147,7 @@ pub fn build(builder: *SemanticBuilder, source: [:0]const u8) SemanticError!Resu
     }
 
     // resolve references to symbols declared in root
-    try builder.resolveReferencesInCurrentScope();
+    try builder.resolveReferencesInCurrentScope(.{ .exclude = .{ .s_member = true } });
     // Take whatever references still haven't been resolved and move them to
     // Semantic.
     const unresolved_frame_count = builder._unresolved_references.len();
@@ -1344,7 +1344,7 @@ fn enterScope(self: *SemanticBuilder, opts: CreateScope) !void {
 /// Exit the current scope. It is a bug to pop the root scope.
 inline fn exitScope(self: *SemanticBuilder) void {
     self.assertCtx(self._scope_stack.items.len > 1, "Invariant violation: cannot pop the root scope", .{});
-    self.resolveReferencesInCurrentScope() catch @panic("OOM");
+    self.resolveReferencesInCurrentScope(.{ .exclude = .{ .s_member = true } }) catch @panic("OOM");
     _ = self._scope_stack.pop();
 }
 
@@ -1552,13 +1552,14 @@ fn recordReference(self: *SemanticBuilder, opts: CreateReference) SemanticError!
     return ref_id;
 }
 
-fn resolveReferencesInCurrentScope(self: *SemanticBuilder) Allocator.Error!void {
+fn resolveReferencesInCurrentScope(self: *SemanticBuilder, query: Semantic.BindingQuery) Allocator.Error!void {
     var stacka = std.heap.stackFallback(64, self._gpa);
     const stack = stacka.get();
     //
     const curr = self._unresolved_references.curr();
     const parent = self._unresolved_references.parent();
     const names = self.symbolTable().symbols.items(.name);
+    const flags = self.symbolTable().symbols.items(.flags);
     const bindings: []const Symbol.Id = self.scopeTree().getBindings(self.currentScope());
     var references = self.symbolTable().references;
     const ref_names: []const []const u8 = references.items(.identifier);
@@ -1571,6 +1572,7 @@ fn resolveReferencesInCurrentScope(self: *SemanticBuilder) Allocator.Error!void 
     defer stack.free(resolved_map);
 
     for (bindings) |binding| {
+        if (!query.exclude.isEmpty() and flags[binding.int()].contains(query.exclude)) continue;
         const name: []const u8 = names[binding.int()];
         for (0..curr.items.len) |i| {
             if (resolved_map[i] or name.len == 0) continue;

--- a/src/Semantic/test/symbol_ref_test.zig
+++ b/src/Semantic/test/symbol_ref_test.zig
@@ -655,6 +655,51 @@ test "Reference flags - `x` - arrays, slices, etc" {
     });
 }
 
+// A bare identifier bubbling out of a container method must resolve to the real
+// (later-declared) sibling declaration, never to a same-named container field.
+// See https://github.com/DonIsaac/zlint/issues/366.
+test "forward references never resolve to container fields" {
+    const src =
+        \\const Inner = struct {
+        \\    limit: u32,
+        \\    fn f() u32 { return limit; }
+        \\};
+        \\const limit: u32 = 10;
+        \\pub fn main() void { _ = Inner.f(); _ = Inner{ .limit = 1 }; }
+    ;
+    var sema = try build(src);
+    defer sema.deinit();
+
+    const names = sema.symbols.symbols.items(.name);
+    const flags = sema.symbols.symbols.items(.flags);
+
+    // `getSymbolNamed("limit")` returns the field, bound first, so distinguish the
+    // two `limit` symbols by their `s_member` flag.
+    var found_root = false;
+    var found_field = false;
+    var it = sema.symbols.iter();
+    while (it.next()) |symbol| {
+        const id = symbol.into(usize);
+        if (!std.mem.eql(u8, names[id], "limit")) continue;
+        const refs = sema.symbols.getReferences(symbol);
+        if (flags[id].s_member) {
+            found_field = true;
+            t.expectEqual(0, refs.len) catch |e| {
+                print("field `limit` should have 0 references, got {d}\n", .{refs.len});
+                return e;
+            };
+        } else {
+            found_root = true;
+            t.expectEqual(1, refs.len) catch |e| {
+                print("root `limit` should have 1 reference, got {d}\n", .{refs.len});
+                return e;
+            };
+        }
+    }
+    try t.expect(found_root);
+    try t.expect(found_field);
+}
+
 test "symbols referenced before their declaration" {
     const sources = [_][:0]const u8{
         \\const y = x;


### PR DESCRIPTION
## What This PR Does
Fixes #366

A bare identifier bubbling out of a container method wrongly resolved to a same-named container *field* instead of the real, later-declared sibling declaration — producing a false `unused-decls` positive that would delete used code.

```zig
const Inner = struct {
    limit: u32,
    fn f() u32 { return limit; } // `limit` resolved to the field, not the const below
};
const limit: u32 = 10; // falsely reported unused
```

The fix excludes `s_member` symbols from deferred reference resolution in `resolveReferencesInCurrentScope`, matching the guard the eager path already applies, and adds a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reference resolution to prevent forward references from incorrectly resolving to container fields.
  * Ensured references resolve to the intended root declarations when similarly named member fields exist.

* **Tests**
  * Added coverage verifying correct handling of forward references and container member names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->