### PR TITLE
refactor: clean up span usage and creation

### DIFF
--- a/src/Error.zig
+++ b/src/Error.zig
@@ -49,9 +49,10 @@ pub fn deinit(self: *Error, alloc: std.mem.Allocator) void {
     if (self.source_name) |src_name| alloc.free(src_name);
     if (self.source) |*src| src.deinit();
     for (self.labels.items) |*label| {
-        if (label.label) |*label_text| label_text.deinit(alloc);
+        label.deinit(alloc);
     }
     self.labels.deinit(alloc);
+    self.* = undefined;
 }
 
 pub fn jsonStringify(self: *const Error, jw: anytype) !void {

--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -1689,7 +1689,7 @@ fn recordImport(self: *SemanticBuilder, node: NodeIndex) Allocator.Error!void {
         @branchHint(.cold);
         var e = Error.newStatic("@import specifiers must be string literals.");
         const loc: Token.Loc = self._semantic.tokens().items(.loc)[ast.nodeMainToken(specifier_node)];
-        try e.labels.append(self._gpa, LabeledSpan.unlabeled(@intCast(loc.start), @intCast(loc.end)));
+        try e.labels.append(self._gpa, LabeledSpan.from(loc));
         try self._errors.append(self._gpa, e);
         return;
     }
@@ -1807,7 +1807,7 @@ fn addAstError(self: *SemanticBuilder, ast: *const Ast, ast_err: Ast.Error) Allo
     {
         const byte_offset: Ast.ByteOffset = ast.tokens.items(.start)[ast_err.token];
         const loc = ast.tokenLocation(byte_offset, ast_err.token);
-        const span = LabeledSpan.unlabeled(@intCast(loc.line_start), @intCast(loc.line_end));
+        const span = LabeledSpan.from(loc);
         try err.labels.ensureTotalCapacityPrecise(self._gpa, 1);
         err.labels.appendAssumeCapacity(span);
     }

--- a/src/linter/disable_directives/Parser.zig
+++ b/src/linter/disable_directives/Parser.zig
@@ -220,24 +220,24 @@ test parse {
         // global directives
         TestCase{
             "//zlint-disable",
-            .{ .kind = .global, .span = .{ .start = 0, .end = 15 } },
+            .{ .kind = .global, .span = .new(0, 15) },
             &[_][]const u8{},
         },
         TestCase{
             "// zlint-disable",
-            .{ .kind = .global, .span = .{ .start = 0, .end = 16 } },
+            .{ .kind = .global, .span = .new(0, 16) },
             &[_][]const u8{},
         },
         TestCase{
             "// zlint-disable -- unsafe-undefined",
-            .{ .kind = .global, .span = .{ .start = 0, .end = 16 } },
+            .{ .kind = .global, .span = .new(0, 16) },
             &[_][]const u8{},
         },
         TestCase{
             "// zlint-disable unsafe-undefined",
             .{
                 .kind = .global,
-                .span = .{ .start = 0, .end = 33 },
+                .span = .new(0, 33),
                 .disabled_rules = @constCast(&[_]Span{Span.new(17, 33)}),
             },
             &[_][]const u8{
@@ -248,7 +248,7 @@ test parse {
             "// zlint-disable foo bar baz",
             .{
                 .kind = .global,
-                .span = .{ .start = 0, .end = 28 },
+                .span = .new(0, 28),
                 .disabled_rules = @constCast(&[_]Span{
                     Span.new(17, 20),
                     Span.new(21, 24),
@@ -327,4 +327,4 @@ const Allocator = mem.Allocator;
 
 const assert = std.debug.assert;
 
-pub const DisableDirectiveComment = @import("./Comment.zig");
+const DisableDirectiveComment = @import("./Comment.zig");

--- a/src/linter/disable_directives/Parser_test.zig
+++ b/src/linter/disable_directives/Parser_test.zig
@@ -13,10 +13,13 @@ const TestCase = struct {
     check_span: bool = false,
 };
 
-/// For when you don't care about the parsed comment's span
-const NULL_SPAN = Span{ .start = 0, .end = 0 };
-const global: DisableDirectiveComment = .{ .kind = .global, .span = NULL_SPAN };
-const line: DisableDirectiveComment = .{ .kind = .line, .span = NULL_SPAN };
+fn global(span: Span) DisableDirectiveComment {
+    return .{ .kind = .global, .span = span };
+}
+
+fn line(span: Span) DisableDirectiveComment {
+    return .{ .kind = .line, .span = span };
+}
 
 fn runTests(cases: []const TestCase) !void {
     for (cases) |case| {
@@ -26,7 +29,7 @@ fn runTests(cases: []const TestCase) !void {
         const check_span = case.check_span;
 
         var parser = DisableDirectivesParser.new(source);
-        var actual = try parser.parse(t.allocator, Span.new(0, @intCast(source.len)));
+        var actual = try parser.parse(t.allocator, .new(0, @intCast(source.len)));
         if (actual) |*a| {
             defer a.deinit(t.allocator);
             const e: DisableDirectiveComment = expected.?;
@@ -58,39 +61,39 @@ fn runTests(cases: []const TestCase) !void {
 
 test "global directives that disable all rules" {
     const cases = &[_]TestCase{
-        .{ .src = "//zlint-disable", .expected = .{ .kind = .global, .span = .{ .start = 0, .end = 15 } }, .check_span = true },
-        .{ .src = "// zlint-disable", .expected = .{ .kind = .global, .span = .{ .start = 0, .end = 16 } }, .check_span = true },
-        .{ .src = "// zlint-disable            ", .expected = .{ .kind = .global, .span = .{ .start = 0, .end = 16 } }, .check_span = true },
-        .{ .src = "   //     zlint-disable", .expected = .{ .kind = .global, .span = .{ .start = 0, .end = 23 } }, .check_span = true },
+        .{ .src = "//zlint-disable", .expected = global(.new(0, 15)), .check_span = true },
+        .{ .src = "// zlint-disable", .expected = global(.new(0, 16)), .check_span = true },
+        .{ .src = "// zlint-disable            ", .expected = global(.new(0, 16)), .check_span = true },
+        .{ .src = "   //     zlint-disable", .expected = global(.new(0, 23)), .check_span = true },
     };
     try runTests(cases);
 }
 
 test "line directives that disable all rules" {
     const cases = &[_]TestCase{
-        .{ .src = "// zlint-disable-next-line", .expected = .{ .kind = .line, .span = .{ .start = 0, .end = 26 } }, .check_span = true },
-        .{ .src = "// zlint-disable-next-line            ", .expected = .{ .kind = .line, .span = .{ .start = 0, .end = 26 } }, .check_span = true },
-        .{ .src = "   //     zlint-disable-next-line", .expected = .{ .kind = .line, .span = .{ .start = 0, .end = 33 } }, .check_span = true },
+        .{ .src = "// zlint-disable-next-line", .expected = line(.new(0, 26)), .check_span = true },
+        .{ .src = "// zlint-disable-next-line            ", .expected = line(.new(0, 26)), .check_span = true },
+        .{ .src = "   //     zlint-disable-next-line", .expected = line(.new(0, 33)), .check_span = true },
     };
     try runTests(cases);
 }
 
 test "comments" {
     const cases = &[_]TestCase{
-        .{ .src = "// zlint-disable -- unsafe-undefined", .expected = global },
-        .{ .src = "// zlint-disable-next-line -- unsafe-undefined", .expected = line },
-        .{ .src = "// zlint-disable --", .expected = global },
-        .{ .src = "// zlint-disable -- foo bar baz", .expected = global },
-        .{ .src = "// zlint-disable-- foo bar baz", .expected = global },
-        .{ .src = "// zlint-disable --foo bar baz", .expected = global },
-        .{ .src = "// zlint-disable     --   foo bar baz", .expected = global },
+        .{ .src = "// zlint-disable -- unsafe-undefined", .expected = global(.empty) },
+        .{ .src = "// zlint-disable-next-line -- unsafe-undefined", .expected = line(.empty) },
+        .{ .src = "// zlint-disable --", .expected = global(.empty) },
+        .{ .src = "// zlint-disable -- foo bar baz", .expected = global(.empty) },
+        .{ .src = "// zlint-disable-- foo bar baz", .expected = global(.empty) },
+        .{ .src = "// zlint-disable --foo bar baz", .expected = global(.empty) },
+        .{ .src = "// zlint-disable     --   foo bar baz", .expected = global(.empty) },
         // space omission: rule name directly followed by '--' (no space before comment marker)
         .{
             .src = "// zlint-disable-next-line unsafe-undefined-- now heres a comment",
             .expected = .{
                 .kind = .line,
-                .span = NULL_SPAN,
-                .disabled_rules = @constCast(&[_]Span{Span.new(27, 43)}),
+                .span = .empty,
+                .disabled_rules = @constCast(&[_]Span{.new(27, 43)}),
             },
         },
     };
@@ -110,10 +113,11 @@ test "not a disable directive" {
 }
 
 test "disable directives may be in doc comments" {
+    const expected = global(.empty);
     const cases = &[_]TestCase{
-        .{ .src = "//  zlint-disable", .expected = .{ .kind = .global, .span = NULL_SPAN } },
-        .{ .src = "/// zlint-disable", .expected = .{ .kind = .global, .span = NULL_SPAN } },
-        .{ .src = "//! zlint-disable", .expected = .{ .kind = .global, .span = NULL_SPAN } },
+        .{ .src = "//  zlint-disable", .expected = expected },
+        .{ .src = "/// zlint-disable", .expected = expected },
+        .{ .src = "//! zlint-disable", .expected = expected },
     };
     try runTests(cases);
 }
@@ -124,11 +128,11 @@ test "disabling specific rules" {
             .src = "// zlint-disable foo bar baz",
             .expected = .{
                 .kind = .global,
-                .span = NULL_SPAN,
+                .span = .empty,
                 .disabled_rules = @constCast(&[_]Span{
-                    Span.new(17, 20),
-                    Span.new(21, 24),
-                    Span.new(25, 28),
+                    .new(17, 20),
+                    .new(21, 24),
+                    .new(25, 28),
                 }),
             },
         },
@@ -136,11 +140,11 @@ test "disabling specific rules" {
             .src = "// zlint-disable foo, bar, baz",
             .expected = .{
                 .kind = .global,
-                .span = NULL_SPAN,
+                .span = .empty,
                 .disabled_rules = @constCast(&[_]Span{
-                    Span.new(17, 20),
-                    Span.new(22, 25),
-                    Span.new(27, 30),
+                    .new(17, 20),
+                    .new(22, 25),
+                    .new(27, 30),
                 }),
             },
         },
@@ -156,15 +160,15 @@ test "non-letter characters in rule list do not cause infinite loop" {
         // pure digit token — skipped entirely, no rules parsed
         .{
             .src = "// zlint-disable 123",
-            .expected = global,
+            .expected = global(.empty),
         },
         // leading underscore is skipped; "foo" is still captured
         .{
             .src = "// zlint-disable _foo",
             .expected = .{
                 .kind = .global,
-                .span = NULL_SPAN,
-                .disabled_rules = @constCast(&[_]Span{Span.new(18, 21)}),
+                .span = .empty,
+                .disabled_rules = @constCast(&[_]Span{.new(18, 21)}),
             },
         },
         // valid rule name preceded by digit garbage — digit skipped, rule captured
@@ -172,8 +176,8 @@ test "non-letter characters in rule list do not cause infinite loop" {
             .src = "// zlint-disable 1foo",
             .expected = .{
                 .kind = .global,
-                .span = NULL_SPAN,
-                .disabled_rules = @constCast(&[_]Span{Span.new(18, 21)}),
+                .span = .empty,
+                .disabled_rules = @constCast(&[_]Span{.new(18, 21)}),
             },
         },
         // valid rule mixed with an all-digit token
@@ -181,10 +185,10 @@ test "non-letter characters in rule list do not cause infinite loop" {
             .src = "// zlint-disable foo 42 bar",
             .expected = .{
                 .kind = .global,
-                .span = NULL_SPAN,
+                .span = .empty,
                 .disabled_rules = @constCast(&[_]Span{
-                    Span.new(17, 20),
-                    Span.new(24, 27),
+                    .new(17, 20),
+                    .new(24, 27),
                 }),
             },
         },

--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -70,13 +70,11 @@ pub inline fn links(self: *const Context) *const Semantic.NodeLinks {
 // ============================ ERROR REPORTING ============================
 
 pub fn spanN(self: *const Context, node_id: Ast.Node.Index) LabeledSpan {
-    const span = self.semantic.nodeSpan(node_id);
-    return LabeledSpan{ .span = span };
+    return .unlabeled(self.semantic.nodeSpan(node_id));
 }
 
 pub fn spanT(self: *const Context, token_id: Ast.TokenIndex) LabeledSpan {
-    const span = self.semantic.tokenSpan(token_id);
-    return LabeledSpan{ .span = span };
+    return .unlabeled(self.semantic.tokenSpan(token_id));
 }
 
 pub inline fn labelN(
@@ -85,12 +83,9 @@ pub inline fn labelN(
     comptime fmt: []const u8,
     args: anytype,
 ) LabeledSpan {
-    const s = self.semantic.nodeSpan(node_id);
-    return LabeledSpan{
-        .span = s,
-        .label = util.Cow(false).fmt(self.gpa, fmt, args) catch @panic("OOM"),
-        .primary = false,
-    };
+    const s: Span = self.semantic.nodeSpan(node_id);
+    const label = util.Cow(false).fmt(self.gpa, fmt, args) catch std.debug.panic("OOM", .{});
+    return .labeled(s, label);
 }
 
 pub inline fn labelT(
@@ -99,22 +94,10 @@ pub inline fn labelT(
     comptime fmt: []const u8,
     args: anytype,
 ) LabeledSpan {
-    const s = self.semantic.parse.ast.tokenToSpan(token_id);
-    return LabeledSpan{
-        .span = .{ .start = s.start, .end = s.end },
-        .label = util.Cow(false).fmt(self.gpa, fmt, args) catch @panic("OOM"),
-        .primary = false,
-    };
+    const s: Span = .from(self.semantic.parse.ast.tokenToSpan(token_id));
+    const label = util.Cow(false).fmt(self.gpa, fmt, args) catch std.debug.panic("OOM", .{});
+    return .labeled(s, label);
 }
-
-// pub inline fn sliceOf(
-//     self: *const Context,
-//     comptime kind: enum { node, token },
-//     id: u32,
-// ) LabeledSpan {
-//     const span = if (kind == .node)
-//         self.semantic.nodeSpan()
-// }
 
 /// Create a new `Error` with a static message string.
 pub fn diagnostic(
@@ -290,6 +273,7 @@ const Ast = Semantic.Ast;
 const Error = @import("../Error.zig");
 const Severity = Error.Severity;
 const LabeledSpan = @import("../span.zig").LabeledSpan;
+const Span = @import("../span.zig").Span;
 const Rule = _rule.Rule;
 const Source = _source.Source;
 

--- a/src/linter/rules/line_length.zig
+++ b/src/linter/rules/line_length.zig
@@ -49,7 +49,7 @@ pub fn lineLengthDiagnostic(ctx: *LinterContext, line_start: u32, line_length: u
     return ctx.diagnosticf(
         "line length of {} characters is too big.",
         .{line_length},
-        .{LabeledSpan.unlabeled(line_start, line_start + line_length)},
+        .{LabeledSpan.unlabeled(.sized(line_start, line_length))},
     );
 }
 

--- a/src/linter/rules/no_return_try.zig
+++ b/src/linter/rules/no_return_try.zig
@@ -59,7 +59,7 @@ pub const meta: Rule.Meta = .{
 };
 
 fn returnTryDiagnostic(ctx: *LinterContext, return_start: u32, try_start: u32) Error {
-    const span = LabeledSpan.unlabeled(return_start, try_start + 3);
+    const span = LabeledSpan.unlabeled(.new(return_start, try_start + 3));
     var e = ctx.diagnostic("This error union can be directly returned.", .{span});
     e.help = Cow.static("Replace `return try` with `return`");
     return e;

--- a/src/linter/rules/returned_stack_reference.zig
+++ b/src/linter/rules/returned_stack_reference.zig
@@ -88,7 +88,7 @@ fn stackRefDiagnostic(
     var labels: [2]LabeledSpan = undefined;
     labels[0] = ctx.labelN(node, "This pointer refers to a local variable", .{});
     if (decl_loc) |loc| {
-        labels[1] = LabeledSpan{ .span = loc, .label = .static("Variable is declared locally here") };
+        labels[1] = .labeled(loc, .static("Variable is declared locally here"));
     }
     const label_slice: []const LabeledSpan = labels[0..if (decl_loc) |_| 2 else 1];
 

--- a/src/reporter/formatters/JSONFormatter.zig
+++ b/src/reporter/formatters/JSONFormatter.zig
@@ -35,14 +35,16 @@ test JSONFormatter {
     var buf = std.array_list.Managed(u8).init(allocator);
     defer buf.deinit();
 
-    var err = Error.newStatic("oof");
-    err.source = src.contents;
-    err.source_name = src.pathname;
-    err.help = Cow.static("help pls");
-    err.code = "code";
+    var err = Error{
+        .code = "code",
+        .message = .static("oof"),
+        .help = .static("help pls"),
+        .source = src.contents,
+        .source_name = src.pathname,
+    };
     try err.labels.append(allocator, LabeledSpan{
-        .label = Cow.static("some label"),
-        .span = _span.Span.new(0, 4),
+        .label = .static("some label"),
+        .span = .new(0, 4),
         .primary = true,
     });
 

--- a/src/span.zig
+++ b/src/span.zig
@@ -66,7 +66,8 @@ pub const Span = struct {
             LabeledSpan => value.span,
             Ast.Span => .{ .start = value.start, .end = value.end },
             Token.Loc => .{ .start = @intCast(value.start), .end = @intCast(value.end) },
-            [2]u32 => .{ .start = value[0], .end = value[1] },
+            Ast.Location => .{ .start = @intCast(value.line_start), .end = @intCast(value.line_end) },
+            [2]u32 => .new(value[0], value[1]),
             else => |T| {
                 const info = @typeInfo(T);
                 switch (info) {
@@ -143,22 +144,29 @@ test "Span.shiftLeft" {
 
 pub const LabeledSpan = struct {
     span: Span,
-    label: ?util.Cow(false) = null,
+    label: ?Label = null,
     primary: bool = false,
 
-    pub inline fn unlabeled(start: u32, end: u32) LabeledSpan {
-        return .{
-            .span = .{ .start = start, .end = end },
-        };
+    pub const empty: LabeledSpan = .{ .span = .empty };
+
+    const Label = util.Cow(false);
+
+    pub inline fn unlabeled(span: Span) LabeledSpan {
+        return .{ .span = span, .label = null, .primary = false };
+    }
+    pub inline fn labeled(span: Span, label: Label) LabeledSpan {
+        return .{ .span = span, .label = label, .primary = false };
     }
 
     pub fn from(value: anytype) LabeledSpan {
         return switch (@TypeOf(value)) {
             LabeledSpan => value, // base case
-            Span => .{ .span = value },
-            Ast.Span => .{ .span = Span.from(value) },
-            Token.Loc => .{ .span = Span.from(value) },
-            [2]u32 => .{ .span = Span.from(value) },
+            Span => .unlabeled(value),
+            Ast.Span,
+            Token.Loc,
+            Ast.Location,
+            [2]u32,
+            => .unlabeled(.from(value)),
             else => |T| {
                 const info = @typeInfo(T);
                 switch (info) {
@@ -173,6 +181,12 @@ pub const LabeledSpan = struct {
             },
         };
     }
+
+    pub fn deinit(self: *LabeledSpan, allocator: std.mem.Allocator) void {
+        if (self.label) |*label| label.deinit(allocator);
+        self.* = undefined;
+    }
+
     pub fn fmtJson(self: LabeledSpan, source: []const u8) LocationFormatter {
         return .{ .span = self, .source = source };
     }
@@ -185,11 +199,9 @@ pub const LabeledSpan = struct {
             start: Location,
             end: Location,
             primary: bool,
-            label: ?util.Cow(false),
+            label: ?Label,
         };
 
-        // pub fn format(self: *const LocationFormatter, comptime _: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        // pub fn format(self: *const LocationFormatter, comptime _: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
         pub fn jsonStringify(self: *const LocationFormatter, jw: anytype) !void {
             const start_offset = self.span.span.start;
             const len = self.span.span.len();

--- a/src/util/cow.zig
+++ b/src/util/cow.zig
@@ -169,7 +169,10 @@ pub fn Cow(comptime sentinel: bool) type {
         /// are responsible for ensuring that borrowing `Cow`s have a lifetime
         /// that is less than or equal to the `Cow` being deinitialized.
         pub fn deinit(self: *Self, allocator: Allocator) void {
-            if (self.borrowed) return;
+            if (self.borrowed) {
+                self.* = undefined;
+                return;
+            }
 
             if (comptime IS_DEBUG) {
                 // All constructors/methods defined in Cow set __alloc when the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic location and label handling across semantic analysis and linting.
  * Corrected cleanup and invalidation of diagnostic resources after disposal.
  * Improved handling of source locations, including AST-based locations.

* **Tests**
  * Updated diagnostic and disable-directive tests to use consistent span representations.
  * Expanded coverage for invalid disable-directive rule names and token formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->