### PR TITLE
fix(tests): Make sure CLI tests get run

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -116,11 +116,7 @@ pub fn build(b: *std.Build) void {
         .root_module = zlint,
         .use_llvm = use_llvm,
     });
-    const test_exe = b.addTest(.{
-        .name = "test-bin",
-        .root_module = exe.root_module,
-        .use_llvm = use_llvm
-    });
+    const test_exe = b.addTest(.{ .name = "test-bin", .root_module = exe.root_module, .use_llvm = use_llvm });
     // Test fixtures live outside `src/`, so they must be registered as imports
     // before unit tests can `@embedFile` them.
     inline for (.{"unresolved_reference.zig"}) |fixture| {

--- a/build.zig
+++ b/build.zig
@@ -111,19 +111,24 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(e2e);
 
-    const test_exe = b.addTest(.{
+    const test_lib = b.addTest(.{
         .name = "test",
         .root_module = zlint,
         .use_llvm = use_llvm,
     });
+    const test_exe = b.addTest(.{
+        .name = "test-bin",
+        .root_module = exe.root_module,
+        .use_llvm = use_llvm
+    });
     // Test fixtures live outside `src/`, so they must be registered as imports
     // before unit tests can `@embedFile` them.
     inline for (.{"unresolved_reference.zig"}) |fixture| {
-        test_exe.root_module.addAnonymousImport("fixtures/" ++ fixture, .{
+        test_lib.root_module.addAnonymousImport("fixtures/" ++ fixture, .{
             .root_source_file = b.path("test/fixtures/simple/pass/" ++ fixture),
         });
     }
-    b.installArtifact(test_exe);
+    b.installArtifact(test_lib);
 
     const test_utils_mod = b.createModule(.{
         .root_source_file = b.path("src/util.zig"),
@@ -152,18 +157,20 @@ pub fn build(b: *std.Build) void {
 
     // zig build test
     {
+        const run_lib_tests = b.addRunArtifact(test_lib);
         const run_exe_tests = b.addRunArtifact(test_exe);
         const run_utils_tests = b.addRunArtifact(test_utils);
         const unit_step = b.step("test", "Run unit tests");
-        unit_step.dependOn(&run_exe_tests.step);
+        unit_step.dependOn(&run_lib_tests.step);
         unit_step.dependOn(&run_utils_tests.step);
+        unit_step.dependOn(&run_exe_tests.step);
 
         const run_e2e = b.addRunArtifact(e2e);
         const e2e_step = b.step("test-e2e", "Run e2e tests");
         e2e_step.dependOn(&run_e2e.step);
 
         const test_all_step = b.step("test-all", "Run all tests");
-        test_all_step.dependOn(&run_exe_tests.step);
+        test_all_step.dependOn(&run_lib_tests.step);
         test_all_step.dependOn(&run_utils_tests.step);
         test_all_step.dependOn(&run_e2e.step);
     }

--- a/build.zig
+++ b/build.zig
@@ -166,9 +166,8 @@ pub fn build(b: *std.Build) void {
         e2e_step.dependOn(&run_e2e.step);
 
         const test_all_step = b.step("test-all", "Run all tests");
-        test_all_step.dependOn(&run_lib_tests.step);
-        test_all_step.dependOn(&run_utils_tests.step);
-        test_all_step.dependOn(&run_e2e.step);
+        test_all_step.dependOn(unit_step);
+        test_all_step.dependOn(e2e_step);
     }
 
     // zig build (docs, confgen, codegen

--- a/build.zig
+++ b/build.zig
@@ -116,7 +116,6 @@ pub fn build(b: *std.Build) void {
         .root_module = zlint,
         .use_llvm = use_llvm,
     });
-    const test_exe = b.addTest(.{ .name = "test-bin", .root_module = exe.root_module, .use_llvm = use_llvm });
     // Test fixtures live outside `src/`, so they must be registered as imports
     // before unit tests can `@embedFile` them.
     inline for (.{"unresolved_reference.zig"}) |fixture| {
@@ -154,12 +153,10 @@ pub fn build(b: *std.Build) void {
     // zig build test
     {
         const run_lib_tests = b.addRunArtifact(test_lib);
-        const run_exe_tests = b.addRunArtifact(test_exe);
         const run_utils_tests = b.addRunArtifact(test_utils);
         const unit_step = b.step("test", "Run unit tests");
         unit_step.dependOn(&run_lib_tests.step);
         unit_step.dependOn(&run_utils_tests.step);
-        unit_step.dependOn(&run_exe_tests.step);
 
         const run_e2e = b.addRunArtifact(e2e);
         const e2e_step = b.step("test-e2e", "Run e2e tests");

--- a/src/Semantic/test/fixtures/unresolved_reference.zig
+++ b/src/Semantic/test/fixtures/unresolved_reference.zig
@@ -1,0 +1,6 @@
+// `missing_symbol` is not declared anywhere, so it must show up in the
+// symbol table's unresolved references. `later` is a root-level forward
+// reference that resolves, so it must not.
+const a = missing_symbol;
+const b = later;
+const later = 1;

--- a/src/Semantic/test/fixtures/unresolved_reference.zig
+++ b/src/Semantic/test/fixtures/unresolved_reference.zig
@@ -1,6 +1,0 @@
-// `missing_symbol` is not declared anywhere, so it must show up in the
-// symbol table's unresolved references. `later` is a root-level forward
-// reference that resolves, so it must not.
-const a = missing_symbol;
-const b = later;
-const later = 1;

--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -153,11 +153,11 @@ test parse {
 
     const src_list: List = brk: {
         const items = &[_][]const u8{"src"};
-        break :brk List{ .items = @constCast(items) };
+        break :brk List{ .items = @constCast(items), .capacity = items.len };
     };
     const src_test_list: List = brk: {
         const items = &[_][]const u8{ "src", "test" };
-        break :brk List{ .items = @constCast(items) };
+        break :brk List{ .items = @constCast(items), .capacity = items.len };
     };
 
     const test_cases = [_]Case{

--- a/src/cli/lint_config.zig
+++ b/src/cli/lint_config.zig
@@ -317,10 +317,10 @@ test resolveLintConfig {
     try t.expect(err == null);
     try t.expect(config.path != null);
 
-    const expected_path = try path.resolve(t.allocator, &.{"zlint/test/fixtures/config/zlint.json"});
+    const expected_path = try path.join(t.allocator, &.{ fixtures_dir, "zlint.json" });
     defer t.allocator.free(expected_path);
 
-    try t.expectStringEndsWith(config.path.?, expected_path);
+    try t.expectEqualStrings(expected_path, config.path.?);
     try t.expectEqual(.warning, config.config.rules.rules.unsafe_undefined.severity);
 }
 

--- a/src/cli/lint_config.zig
+++ b/src/cli/lint_config.zig
@@ -352,7 +352,7 @@ test "resolveLintConfig with an empty zlint.json does not crash the formatter" {
 
     try t.expectEqual(0, err.source.?.deref().*.len);
     try t.expectEqual(1, err.labels.items.len);
-    try t.expectEqual(.empty, err.labels.items[0].span);
+    try t.expectEqual(Span.empty, err.labels.items[0].span);
 
     var fmt = GraphicalFormatter.unicode(t.allocator, false);
     var w = std.Io.Writer.Allocating.init(t.allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -82,4 +82,5 @@ test {
     std.testing.refAllDecls(@This());
     std.testing.refAllDecls(@import("visit/walk.zig"));
     std.testing.refAllDecls(@import("json.zig"));
+    std.testing.refAllDecls(lint_cmd);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -77,10 +77,3 @@ pub fn main(init: std.process.Init) !u8 {
 
     return lint_cmd.lint(alloc, io, init.minimal.environ, opts);
 }
-
-test {
-    std.testing.refAllDecls(@This());
-    std.testing.refAllDecls(@import("visit/walk.zig"));
-    std.testing.refAllDecls(@import("json.zig"));
-    std.testing.refAllDecls(lint_cmd);
-}

--- a/src/printer/SemanticPrinter.zig
+++ b/src/printer/SemanticPrinter.zig
@@ -114,7 +114,7 @@ fn printReference(self: *SemanticPrinter, ref_id: Reference.Id) !void {
     const tags = ast.nodes.items(.tag);
 
     const flag_fields = std.meta.fields(Reference.Flags);
-    var buf: [flag_fields.len * @sizeOf([]const u8)]u8 = undefined;
+    var buf: [flag_fields.len * @sizeOf([]const u8) + @alignOf([]const u8) - 1]u8 = undefined;
     var fixed_alloc = std.heap.FixedBufferAllocator.init(&buf);
     const alloc = fixed_alloc.allocator();
     var flags = std.array_list.Managed([]const u8).init(alloc);

--- a/src/reporter/formatters/GithubFormatter.zig
+++ b/src/reporter/formatters/GithubFormatter.zig
@@ -54,12 +54,8 @@ test GithubFormatter {
     const allocator = std.testing.allocator;
     const expectEqualStrings = std.testing.expectEqualStrings;
 
-    var buf = std.array_list.Managed(u8).init(allocator);
-    defer buf.deinit();
     var f = GithubFormatter{};
-    // var w = buf.writer();
     var w = std.Io.Writer.Allocating.init(allocator);
-    defer w.writer.flush() catch @panic("failed to flush writer");
     defer w.deinit();
 
     var err = Error.newStatic("Something happened");
@@ -67,10 +63,10 @@ test GithubFormatter {
     err.code = "code";
     err.source_name = "some/file.zig";
 
-    try f.format(&w, err);
-    try expectEqualStrings("::error file=some/file.zig,line=1,col=1,title=code::Something happened\n", buf.items);
+    try f.format(&w.writer, err);
+    try expectEqualStrings("::error file=some/file.zig,line=1,col=1,title=code::Something happened\n", w.writer.buffered());
 
-    buf.clearRetainingCapacity();
+    w.clearRetainingCapacity();
     err.severity = .warning;
     try err.labels.append(allocator, .{
         .label = Cow.static("here it is"),
@@ -78,10 +74,10 @@ test GithubFormatter {
     });
     defer err.labels.deinit(allocator);
 
-    try f.format(&w, err);
-    try expectEqualStrings("::warning file=some/file.zig,line=1,col=1,title=code::Something happened\n", buf.items);
+    try f.format(&w.writer, err);
+    try expectEqualStrings("::warning file=some/file.zig,line=1,col=1,title=code::Something happened\n", w.writer.buffered());
 
-    buf.clearRetainingCapacity();
+    w.clearRetainingCapacity();
     var src = try Error.ArcStr.init(
         allocator,
         try allocator.dupeZ(u8,
@@ -92,8 +88,8 @@ test GithubFormatter {
     defer src.deinit();
     err.source = src;
 
-    try f.format(&w, err);
-    try expectEqualStrings("::warning file=some/file.zig,line=2,col=5,title=code::Something happened\n", buf.items);
+    try f.format(&w.writer, err);
+    try expectEqualStrings("::warning file=some/file.zig,line=2,col=5,title=code::Something happened\n", w.writer.buffered());
 }
 
 const std = @import("std");

--- a/src/reporter/formatters/JSONFormatter.zig
+++ b/src/reporter/formatters/JSONFormatter.zig
@@ -32,9 +32,6 @@ test JSONFormatter {
     const source: [:0]const u8 = "const x: u32 = 1;";
     const src = try Source.fromString(allocator, @constCast(source), "test.zig");
 
-    var buf = std.array_list.Managed(u8).init(allocator);
-    defer buf.deinit();
-
     var err = Error{
         .code = "code",
         .message = .static("oof"),
@@ -49,10 +46,11 @@ test JSONFormatter {
     });
 
     var f = JSONFormatter{};
-    var w = buf.writer().any();
-    try f.format(&w, err);
+    var w = io.Writer.Allocating.init(allocator);
+    defer w.deinit();
+    try f.format(&w.writer, err);
 
-    var value = try json.parseFromSlice(json.Value, allocator, buf.items, .{});
+    var value = try json.parseFromSlice(json.Value, allocator, w.writer.buffered(), .{});
     defer value.deinit();
     const obj = value.value.object;
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -23,6 +23,4 @@ test {
     std.testing.refAllDecls(printer);
     std.testing.refAllDecls(json);
     std.testing.refAllDecls(lint);
-    // std.testing.refAllDecls(@import("walk/glob.zig"));
-    // std.testing.refAllDecls(@import("cli/lint_command.zig"));
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -23,4 +23,6 @@ test {
     std.testing.refAllDecls(printer);
     std.testing.refAllDecls(json);
     std.testing.refAllDecls(lint);
+    // std.testing.refAllDecls(@import("walk/glob.zig"));
+    // std.testing.refAllDecls(@import("cli/lint_command.zig"));
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -23,4 +23,12 @@ test {
     std.testing.refAllDecls(printer);
     std.testing.refAllDecls(json);
     std.testing.refAllDecls(lint);
+    std.testing.refAllDecls(walk);
+
+    // `src/cli/` isn't part of the public library surface, so it's only pulled
+    // in here to get its tests compiled and run.
+    std.testing.refAllDecls(@import("cli/Options.zig"));
+    std.testing.refAllDecls(@import("cli/lint_command.zig"));
+    std.testing.refAllDecls(@import("cli/lint_config.zig"));
+    std.testing.refAllDecls(@import("cli/print_command.zig"));
 }


### PR DESCRIPTION
## What This PR Does

Fixes a bug in `build.zig` where `main.zig` was not included as a test root, causing CLI tests not to be run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alignment padding in serialized diagnostic references.
  * Improved reliability of formatted GitHub-style and JSON error output.
* **Tests**
  * Expanded validation for command-line parsing and lint configuration.
  * Strengthened coverage for linting commands, fixtures, spans, and diagnostic formatting.
  * Improved consistency across library, utility, and end-to-end test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->