### PR TITLE
chore: change static library artifact name to zlint-lib

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -58,7 +58,7 @@ pub fn build(b: *std.Build) void {
         .strip = if (debug_release) false else null,
     });
     const lib = b.addLibrary(.{
-        .name = "zlint",
+        .name = "zlint-lib",
         .root_module = zlint,
         .linkage = .static,
     });


### PR DESCRIPTION
This enables importing the zlint package and running it's executable directly from the build system of other zig projects. Which is not possible currently, because of the ambiguity with the static library name.

For example, consider the following steps:

1. Copy the package to global cache and add to `build.zig.zon`:

    ```bash
    zig fetch --save git+https://github.com/DonIsaac/zlint
    ```

2. Add a lint step into `build.zig`:

    ```zig
    const zlint = b.dependency("zlint", .{
        .target = target,
        .optimize = OptimizeMode.ReleaseFast,
    });
    const zlint_exe = zlint.artifact("zlint");
    const zlint_run = b.addRunArtifact(zlint_exe);
    const zlint_step = b.step("lint", "Lint the project with zlint");
    zlint_step.dependOn(&zlint_run.step);
    ```

3. The build will fail with:


    ```bash
    $ zig build lint
    thread XXXX panic: artifact name 'zlint' is ambiguous
    ...
    ```

With this PR, this error is fixed.