### PR TITLE
refactor(sema): use .root and .empty conventions

### DIFF
--- a/src/Semantic.zig
+++ b/src/Semantic.zig
@@ -16,35 +16,13 @@
 const Semantic = @This();
 
 parse: Parse, // NOTE: allocated in _arena
-symbols: Symbol.Table = .{},
-scopes: Scope.Tree = .{},
-modules: ModuleRecord = .{},
-node_links: NodeLinks = .{},
+symbols: Symbol.Table,
+scopes: Scope.Tree,
+modules: ModuleRecord,
+node_links: NodeLinks,
 _gpa: Allocator,
 /// Used to allocate AST nodes
 _arena: ArenaAllocator,
-
-/// The scope where symbols built in to the language are declared.
-///
-/// The root scope is eventually the parent of all other scopes. Its parent is
-/// always `null`.
-pub const BUILTIN_SCOPE_ID: Scope.Id = Scope.Id.from(1);
-/// The scope created by a program/compilation unit.
-///
-/// Its parent is always `BUILTIN_SCOPE_ID`.
-///
-/// > _note_: right now root/builtin scope ids are the same. This may change in
-/// the future.
-pub const ROOT_SCOPE_ID: Scope.Id = Scope.Id.from(0);
-/// Deprecated. use `.root` instead.
-///
-/// The root node always has an index of 0. Since it is never referenced by other nodes,
-/// the Zig team uses it to represent `null` without wasting extra memory.
-pub const ROOT_NODE_ID: Ast.Node.Index = .root;
-/// Deprecated. use `.root` instead.
-///
-/// Alias for `ROOT_NODE_ID`. Used in null-node check contexts for code clarity.
-pub const NULL_NODE: Ast.Node.Index = ROOT_NODE_ID;
 
 pub inline fn source(self: *const Semantic) [:0]const u8 {
     return self.parse.ast.source;

--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -17,15 +17,15 @@ _source_code: ?_source.ArcStr = null,
 _source_path: ?[]const u8 = null,
 
 // states
-_curr_scope_flags: Scope.Flags = .{},
-_curr_symbol_flags: Symbol.Flags = .{},
+_curr_scope_flags: Scope.Flags = .empty,
+_curr_symbol_flags: Symbol.Flags = .empty,
 _curr_reference_flags: Reference.Flags = .{ .read = true },
 /// Flags added to the next block-created scope. Reset immediately after use.
 ///
 /// Nodes whose children may or may not be a block scope must be careful to
 /// reset this themselves. Although `visitBlock` will reset these flags, if a
 /// non-block node is encountered, it will not be reset.
-_next_block_scope_flags: Scope.Flags = .{},
+_next_block_scope_flags: Scope.Flags = .empty,
 
 // stacks
 _scope_stack: std.ArrayList(Semantic.Scope.Id) = .empty,
@@ -39,19 +39,13 @@ _node_stack: std.ArrayList(NodeIndex) = .empty,
 /// in the source.
 ///
 /// We try to resolve these each time a scope is exited.
-_unresolved_references: ReferenceStack = .{},
+_unresolved_references: ReferenceStack = .empty,
 
 _semantic: Semantic,
 /// Errors encountered during parsing and analysis.
 ///
 /// Errors in this list are allocated using this list's allocator.
 _errors: std.ArrayList(Error) = .empty,
-
-/// The root node always has an index of 0. Since it is never referenced by other nodes,
-/// the Zig team uses it to represent `null` without wasting extra memory.
-const NULL_NODE: NodeIndex = .root;
-const ROOT_SCOPE: Semantic.Scope.Id = .from(0);
-// const BUILTIN_SCOPE: Semantic.Scope.Id = Semantic.BUILTIN_SCOPE_ID;
 
 pub const Result = Error.Result(Semantic);
 pub const SemanticError = error{
@@ -124,6 +118,9 @@ pub fn build(builder: *SemanticBuilder, source: [:0]const u8) SemanticError!Resu
     builder._semantic = Semantic{
         .parse = parse,
         .node_links = node_links,
+        .symbols = .empty,
+        .scopes = .empty,
+        .modules = .empty,
         ._arena = builder._arena,
         ._gpa = gpa,
     };
@@ -186,7 +183,7 @@ pub fn deinit(self: *SemanticBuilder) void {
 /// handled by `visitNode`. This lets us inline checks within caller
 /// functions, reducing unnecessary branching and stack pointer pushes.
 fn visit(self: *SemanticBuilder, node_id: NodeIndex) SemanticError!void {
-    if (node_id == NULL_NODE) return;
+    if (node_id == .root) return;
     if (@intFromEnum(node_id) >= self.AST().nodes.len) {
         @branchHint(.cold);
         return;
@@ -214,7 +211,7 @@ fn visitNode(self: *SemanticBuilder, node_id: NodeIndex) SemanticError!void {
     defer self.exitNode();
 
     switch (tag) {
-        // root node is never referenced b/c of NULL_NODE check at function start
+        // root node is never referenced b/c of .root check at function start
         .root => unreachable,
         // containers and container members
         // ```zig
@@ -515,7 +512,7 @@ fn visitRecursiveSlice(self: *SemanticBuilder, node_id: NodeIndex) callconv(util
 // TODO: inline after we're done debugging
 fn visitBlock(self: *SemanticBuilder, statements: []const NodeIndex) !void {
     const NON_COMPTIME_BLOCKS: Scope.Flags = .{ .s_test = true, .s_block = true, .s_function = true };
-    const is_root = self.currentScope() == ROOT_SCOPE;
+    const is_root = self.currentScope() == .root;
     const was_comptime = self._curr_scope_flags.s_comptime;
     const is_comptime = was_comptime or (is_root and !self._curr_scope_flags.intersects(NON_COMPTIME_BLOCKS));
 
@@ -629,7 +626,7 @@ fn visitContainerField(self: *SemanticBuilder, node_id: NodeIndex, field: full.C
         .identifier = identifier,
         .flags = .{
             .s_comptime = field.comptime_token != null,
-            .s_struct = self.currentScope().eql(ROOT_SCOPE),
+            .s_struct = self.currentScope().eql(.root),
         },
     });
     try self.visitOptional(field.ast.align_expr);
@@ -760,7 +757,7 @@ fn visitAssignDestructure(
 /// Non-`var`/`const` destructuring targets: identifiers are writes; `a.b` / `a[i]` / `*p` use
 /// read flags for address operands (same idea as `visitSlice`).
 fn visitAssignmentTarget(self: *SemanticBuilder, node_id: NodeIndex) SemanticError!void {
-    if (node_id == NULL_NODE) return;
+    if (node_id == .root) return;
 
     const ast = self.AST();
     switch (ast.nodeTag(node_id)) {
@@ -1281,13 +1278,13 @@ fn enterRoot(self: *SemanticBuilder) !void {
     const root_scope_id = try self._semantic.scopes.addScope(
         self._gpa,
         null,
-        Semantic.ROOT_NODE_ID,
+        .root,
         .{ .s_top = true },
     );
     util.assert(
-        root_scope_id == Semantic.ROOT_SCOPE_ID,
+        root_scope_id == .root,
         "Creating root scope returned id {d} which is not the expected root id ({d})",
-        .{ root_scope_id, Semantic.ROOT_SCOPE_ID },
+        .{ root_scope_id, Semantic.Scope.Id.root },
     );
 
     // SemanticBuilder.init() allocates enough space for 8 scopes.
@@ -1297,7 +1294,7 @@ fn enterRoot(self: *SemanticBuilder) !void {
     // push root node onto the stack. It is never popped.
     // Similar to root scope, the root node is pushed differently than
     // other nodes because parent->child node linking is skipped.
-    self._node_stack.appendAssumeCapacity(Semantic.ROOT_NODE_ID);
+    self._node_stack.appendAssumeCapacity(.root);
 
     // Create root symbol and push it onto the stack. It too is never popped.
     // TODO: distinguish between bound name and escaped name.
@@ -1320,10 +1317,10 @@ inline fn assertRoot(self: *const SemanticBuilder) void {
     if (!util.IS_DEBUG) return;
 
     self.assertCtx(self._scope_stack.items.len == 1, "assertRoot: scope stack is not at root", .{});
-    self.assertCtx(self._scope_stack.items[0] == Semantic.ROOT_SCOPE_ID, "assertRoot: scope stack is not at root", .{});
+    self.assertCtx(self._scope_stack.items[0] == .root, "assertRoot: scope stack is not at root", .{});
 
     self.assertCtx(self._node_stack.items.len == 1, "assertRoot: node stack is not at root", .{});
-    self.assertCtx(self._node_stack.items[0] == Semantic.ROOT_NODE_ID, "assertRoot: node stack is not at root", .{});
+    self.assertCtx(self._node_stack.items[0] == .root, "assertRoot: node stack is not at root", .{});
 
     self.assertCtx(self._symbol_stack.items.len == 1, "assertRoot: symbol stack is not at root", .{});
     self.assertCtx(self._symbol_stack.items[0].int() == 0, "assertRoot: symbol stack is not at root", .{}); // TODO: create root symbol id.
@@ -1366,7 +1363,7 @@ const CreateScope = struct {
 };
 
 /// Enter a new scope, pushing it onto the stack.
-fn enterScope(self: *SemanticBuilder, opts: CreateScope) !void {
+fn enterScope(self: *SemanticBuilder, opts: CreateScope) Allocator.Error!void {
     const parent_id = self._scope_stack.getLastOrNull();
     const merged_flags = opts.flags.merge(self._curr_scope_flags);
     const node = opts.node orelse self.currentNode();
@@ -1856,7 +1853,7 @@ fn debugNodeStack(self: *const SemanticBuilder) void {
         const main_token = ast.nodeMainToken(id);
         const token_offset = ast.tokens.get(main_token).start;
 
-        const source = if (id == Semantic.ROOT_NODE_ID) "" else ast.getNodeSource(id);
+        const source = if (id == .root) "" else ast.getNodeSource(id);
         const loc = ast.tokenLocation(token_offset, main_token);
         const snippet =
             if (source.len > 128) mem.concat(
@@ -1977,7 +1974,7 @@ test "Struct/enum fields are bound bound to the struct/enums's member table" {
         // they exist
         try std.testing.expect(bar != null);
         try std.testing.expect(foo != null);
-        try std.testing.expect(bar.?.scope != Semantic.ROOT_SCOPE_ID);
+        try std.testing.expect(bar.?.scope != .root);
         // Foo has exactly 1 member and it is bar
         const foo_members = semantic.symbols.getMembers(foo.?.id);
         try std.testing.expectEqual(1, foo_members.items.len);

--- a/src/Semantic/ModuleRecord.zig
+++ b/src/Semantic/ModuleRecord.zig
@@ -1,6 +1,8 @@
 const ModuleRecord = @This();
 
-imports: std.ArrayListUnmanaged(ImportEntry) = .empty,
+imports: std.ArrayList(ImportEntry),
+
+pub const empty: ModuleRecord = .{ .imports = .empty };
 
 pub fn deinit(self: *ModuleRecord, allocator: Allocator) void {
     self.imports.deinit(allocator);

--- a/src/Semantic/NodeLinks.zig
+++ b/src/Semantic/NodeLinks.zig
@@ -15,28 +15,43 @@ const NodeLinks = @This();
 /// ### Invariants:
 /// - No node is its own parent
 /// - No node is the parent of the root node (0 in this case means `null`).
-parents: std.ArrayListUnmanaged(NodeIndex) = .empty,
+parents: NodeMap(NodeIndex),
 /// Map AST nodes to the scope they are in. Index is the node id.
 ///
 /// This is _not_ a mapping for scopes that nodes create.
-scopes: std.ArrayListUnmanaged(Scope.Id) = .empty,
+scopes: NodeMap(Scope.Id),
 /// Maps identifier tokens to the symbols bound to them.
 ///
 /// These are the same as `symbol.identifier`, but allow for lookups the other
 /// way.
-symbols: std.AutoHashMapUnmanaged(Ast.TokenIndex, Symbol.Id) = .{},
+symbols: TokenMap(Symbol.Id),
 /// Maps tokens (usually `.identifier`s) to the references they create. Since
 /// references are sparse in an AST, a hashmap is used to avoid wasting memory.
-references: std.AutoHashMapUnmanaged(Ast.TokenIndex, Reference.Id) = .{},
+references: TokenMap(Reference.Id),
+
+fn NodeMap(T: type) type {
+    return std.ArrayList(T);
+}
+
+fn TokenMap(T: type) type {
+    return std.AutoHashMapUnmanaged(Ast.TokenIndex, T);
+}
+
+pub const empty: NodeLinks = .{
+    .parents = .empty,
+    .scopes = .empty,
+    .symbols = .empty,
+    .references = .empty,
+};
 
 pub fn init(alloc: Allocator, ast: *const Ast) Allocator.Error!NodeLinks {
-    var links: NodeLinks = .{};
+    var links: NodeLinks = .empty;
     const node_count = ast.nodes.len;
 
     try links.parents.ensureTotalCapacityPrecise(alloc, node_count);
-    links.parents.appendNTimesAssumeCapacity(NULL_NODE, node_count);
+    links.parents.appendNTimesAssumeCapacity(.root, node_count);
     try links.scopes.ensureTotalCapacityPrecise(alloc, node_count);
-    links.scopes.appendNTimesAssumeCapacity(ROOT_SCOPE_ID, node_count);
+    links.scopes.appendNTimesAssumeCapacity(.root, node_count);
 
     try links.references.ensureTotalCapacity(alloc, 16);
 
@@ -61,7 +76,7 @@ pub inline fn setScope(self: *NodeLinks, node_id: NodeIndex, scope_id: Scope.Id)
 }
 
 pub inline fn getScope(self: *const NodeLinks, node_id: NodeIndex) ?Scope.Id {
-    if (node_id == ROOT_NODE_ID) {
+    if (node_id == .root) {
         @branchHint(.cold);
         return null;
     }
@@ -72,12 +87,12 @@ pub inline fn getScope(self: *const NodeLinks, node_id: NodeIndex) ?Scope.Id {
         .{ idx, self.scopes.items.len },
     );
     const scope_id = self.scopes.items[idx];
-    return if (scope_id == ROOT_SCOPE_ID) null else scope_id;
+    return if (scope_id == .root) null else scope_id;
 }
 
 pub inline fn setParent(self: *NodeLinks, child_id: NodeIndex, parent_id: NodeIndex) void {
     assert(child_id != parent_id, "AST nodes cannot be children of themselves", .{});
-    assert(child_id != NULL_NODE, "Re-assigning the root node's parent is illegal behavior", .{});
+    assert(child_id != .root, "Re-assigning the root node's parent is illegal behavior", .{});
     const parent_idx = @intFromEnum(parent_id);
     assert(
         parent_idx < self.parents.items.len,
@@ -89,7 +104,7 @@ pub inline fn setParent(self: *NodeLinks, child_id: NodeIndex, parent_id: NodeIn
 }
 
 pub inline fn getParent(self: *const NodeLinks, node_id: NodeIndex) ?NodeIndex {
-    if (node_id == ROOT_NODE_ID) {
+    if (node_id == .root) {
         return null;
     }
     return self.parents.items[@intFromEnum(node_id)];
@@ -121,9 +136,6 @@ const util = @import("util");
 const Ast = _ast.Ast;
 const NodeIndex = _ast.NodeIndex;
 const Semantic = @import("../Semantic.zig");
-const ROOT_NODE_ID = Semantic.ROOT_NODE_ID;
-const NULL_NODE = Semantic.NULL_NODE;
-const ROOT_SCOPE_ID = Semantic.ROOT_SCOPE_ID;
 const Scope = Semantic.Scope;
 const Symbol = Semantic.Symbol;
 const Reference = Semantic.Reference;

--- a/src/Semantic/Reference.zig
+++ b/src/Semantic/Reference.zig
@@ -16,8 +16,6 @@ flags: Flags,
 
 pub const Id = NominalId(u32);
 
-const FLAGS_REPR = u8;
-
 /// Describes how a reference uses a symbol.
 ///
 /// ## Chained references
@@ -27,7 +25,7 @@ const FLAGS_REPR = u8;
 /// - `foo` is `member | read`
 /// - `bar` is `member | call`
 /// - `baz` is `call`
-pub const Flags = packed struct(FLAGS_REPR) {
+pub const Flags = packed struct(u8) {
     /// Reference is reading a symbol's value.
     read: bool = false,
     /// Reference is modifying the value stored in a symbol.

--- a/src/Semantic/ReferenceStack.zig
+++ b/src/Semantic/ReferenceStack.zig
@@ -1,6 +1,8 @@
 const ReferenceStack = @This();
 
-frames: std.ArrayListUnmanaged(ReferenceIdList) = .empty,
+frames: std.ArrayList(ReferenceIdList),
+
+pub const empty: ReferenceStack = .{ .frames = .empty };
 
 const ReferenceIdList = std.ArrayListUnmanaged(Reference.Id);
 

--- a/src/Semantic/Scope.zig
+++ b/src/Semantic/Scope.zig
@@ -9,14 +9,12 @@ node: NodeIndex,
 
 /// Uniquely identifies a scope within a source file.
 pub const Id = NominalId(u32);
-pub const MAX_ID = Id.MAX;
 
-const FLAGS_REPR = u16;
 /// Scope flags provide hints about what kind of node is creating the
 /// scope.
 ///
 /// TODO: Should this be an enum?
-pub const Flags = packed struct(FLAGS_REPR) {
+pub const Flags = packed struct(u16) {
     /// Top-level "module" scope
     s_top: bool = false,
     /// Created by a function declaration.
@@ -65,21 +63,23 @@ pub const Flags = packed struct(FLAGS_REPR) {
 /// Stores variable scopes created by a zig program.
 pub const Tree = struct {
     /// Indexed by scope id.
-    scopes: std.MultiArrayList(Scope) = .{},
+    scopes: std.MultiArrayList(Scope),
     /// Mappings from scopes to their descendants.
-    children: std.ArrayListUnmanaged(ScopeIdList) = .empty,
+    children: std.ArrayList(ScopeIdList),
 
-    bindings: std.ArrayListUnmanaged(SymbolIdList) = .empty,
+    bindings: std.ArrayList(SymbolIdList),
 
-    const ScopeIdList = std.ArrayListUnmanaged(Scope.Id);
-    const SymbolIdList = std.ArrayListUnmanaged(Symbol.Id);
+    pub const empty: Tree = .{ .scopes = .empty, .children = .empty, .bindings = .empty };
+
+    const ScopeIdList = std.ArrayList(Scope.Id);
+    const SymbolIdList = std.ArrayList(Symbol.Id);
 
     /// Returns the number of declared scopes in a program.
     ///
     /// Shorthand for `scope_tree.scopes.len`.
     pub inline fn len(self: *const Scope.Tree) u32 {
         @setRuntimeSafety(!util.IS_DEBUG);
-        assert(self.scopes.len < Id.MAX);
+        assert(self.scopes.len < @intFromEnum(Id.max));
 
         return @intCast(self.scopes.len);
     }
@@ -103,7 +103,7 @@ pub const Tree = struct {
         node: NodeIndex,
         flags: Scope.Flags,
     ) !Scope.Id {
-        assert(self.scopes.len < Scope.MAX_ID);
+        assert(self.scopes.len < Scope.Id.max.int());
         const id: Scope.Id = Id.from(self.scopes.len);
 
         // initialize the new scope
@@ -217,7 +217,7 @@ test "Scope.Tree.addScope" {
     const alloc = t.allocator;
     const expectEqual = t.expectEqual;
 
-    var tree = Scope.Tree{};
+    var tree: Scope.Tree = .empty;
     defer tree.deinit(alloc);
 
     const root_id = try tree.addScope(alloc, null, @enumFromInt(0), .{ .s_top = true });

--- a/src/Semantic/Symbol.zig
+++ b/src/Semantic/Symbol.zig
@@ -38,7 +38,7 @@ scope: Scope.Id,
 decl: Node.Index,
 visibility: Visibility,
 flags: Flags,
-references: std.ArrayListUnmanaged(Reference.Id) = .empty,
+references: std.ArrayList(Reference.Id) = .empty,
 
 /// Symbols on "instance objects" (e.g. field properties and instance
 /// methods). Generally corresponds to `.container_field` nodes.
@@ -55,9 +55,8 @@ exports: SymbolIdList = .empty,
 
 /// Uniquely identifies a symbol across a source file.
 pub const Id = NominalId(u32);
-pub const MAX_ID = Id.MAX;
 
-const SymbolIdList = std.ArrayListUnmanaged(Symbol.Id);
+const SymbolIdList = std.ArrayList(Symbol.Id);
 
 /// Visibility to external code.
 ///
@@ -70,8 +69,7 @@ pub const Visibility = enum {
     private,
 };
 
-const FLAGS_REPR = u16;
-pub const Flags = packed struct(FLAGS_REPR) {
+pub const Flags = packed struct(u16) {
     /// A container-level or local variable.
     ///
     /// If it's declared with a `const` or `var` keyword, this is true. Note
@@ -170,9 +168,15 @@ pub const Table = struct {
     /// Indexed by symbol id.
     ///
     /// Do not write to this list directly.
-    symbols: std.MultiArrayList(Symbol) = .{},
-    references: std.MultiArrayList(Reference) = .{},
-    unresolved_references: std.ArrayListUnmanaged(Reference.Id) = .empty,
+    symbols: std.MultiArrayList(Symbol),
+    references: std.MultiArrayList(Reference),
+    unresolved_references: std.ArrayList(Reference.Id),
+
+    pub const empty: Table = .{
+        .symbols = .empty,
+        .references = .empty,
+        .unresolved_references = .empty,
+    };
 
     /// Get a symbol from the table.
     pub inline fn get(self: *const Symbol.Table, id: Symbol.Id) *const Symbol {
@@ -190,7 +194,7 @@ pub const Table = struct {
         visibility: Symbol.Visibility,
         flags: Symbol.Flags,
     ) Allocator.Error!Symbol.Id {
-        assert(self.symbols.len < Symbol.MAX_ID);
+        assert(self.symbols.len < Symbol.Id.max.int());
 
         // const id: Symbol.Id = @intCast(self.symbols.len).into();
         const id = Id.from(self.symbols.len);
@@ -364,7 +368,7 @@ test "Symbol.Table.iter()" {
     const a = std.testing.allocator;
     const expectEqual = std.testing.expectEqual;
 
-    var table = Symbol.Table{};
+    var table: Symbol.Table = .empty;
     defer table.deinit(a);
 
     _ = try table.addSymbol(a, @enumFromInt(1), "a", null, null, Scope.Id.new(0), .public, .{});

--- a/src/Semantic/ast.zig
+++ b/src/Semantic/ast.zig
@@ -8,13 +8,6 @@ const zig = std.zig;
 pub const Ast = zig.Ast;
 pub const Node = Ast.Node;
 
-/// The struct used in AST tokens SOA is not pub so we hack it in here.
-pub const RawToken = struct {
-    tag: zig.Token.Tag,
-    start: Ast.ByteOffset,
-    pub const Tag = zig.Token.Tag;
-};
-
 pub const TokenIndex = Ast.TokenIndex;
 pub const NodeIndex = Node.Index;
 pub const MaybeTokenId = NominalId(Ast.TokenIndex).Optional;

--- a/src/Semantic/test/modules_test.zig
+++ b/src/Semantic/test/modules_test.zig
@@ -16,7 +16,7 @@ test "@import(\"std\")" {
     const import = sema.modules.imports.items[0];
     try t.expectEqualStrings("std", import.specifier);
     try t.expectEqual(.module, import.kind);
-    try t.expect(import.node != Semantic.NULL_NODE);
+    try t.expect(import.node != .root);
 }
 
 test "@import(\"foo.zig\")" {
@@ -29,7 +29,7 @@ test "@import(\"foo.zig\")" {
     const import = sema.modules.imports.items[0];
     try t.expectEqualStrings("foo.zig", import.specifier);
     try t.expectEqual(.file, import.kind);
-    try t.expect(import.node != Semantic.NULL_NODE);
+    try t.expect(import.node != .root);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/Semantic/test/scopes_test.zig
+++ b/src/Semantic/test/scopes_test.zig
@@ -17,8 +17,8 @@ test "functions create a parameter list + function body scope" {
     const scopes = sem.scopes.scopes;
 
     const root: Scope = scopes.get(0);
-    try t.expectEqual(Semantic.ROOT_NODE_ID, root.node);
-    try t.expectEqual(Semantic.ROOT_SCOPE_ID, root.id);
+    try t.expectEqual(.root, root.node);
+    try t.expectEqual(.root, root.id);
     try t.expectEqual(2, sem.scopes.getBindings(root.id).len); // `add` + implicit file-level container
 
     // root scope only has one child: the function declaration

--- a/src/Semantic/test/symbol_decl_test.zig
+++ b/src/Semantic/test/symbol_decl_test.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const test_util = @import("util.zig");
 
-const Semantic = @import("../../Semantic.zig");
 const Symbol = @import("../Symbol.zig");
 
 const t = std.testing;
@@ -579,7 +578,7 @@ test "standalone fn protos bind their name in the enclosing scope" {
 
     const puts = sem.symbols.getSymbolNamed("puts") orelse return error.SymbolNotFound;
     // declared at file scope, not inside its own parameter list...
-    try t.expectEqual(Semantic.ROOT_SCOPE_ID, sem.symbols.symbols.items(.scope)[puts.int()]);
+    try t.expectEqual(.root, sem.symbols.symbols.items(.scope)[puts.int()]);
     // ...so the call in `main` resolves to it.
     try t.expectEqual(1, sem.symbols.getReferences(puts).len);
     try t.expect(sem.symbols.symbols.items(.flags)[puts.int()].s_extern);

--- a/src/Semantic/test/util.zig
+++ b/src/Semantic/test/util.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const _source = @import("../../source.zig");
+const Source = @import("../../source.zig").Source;
 const Semantic = @import("../../Semantic.zig");
 const report = @import("../../reporter.zig");
 
@@ -17,7 +17,7 @@ var buf: [1024]u8 = undefined;
 pub fn buildWithErrors(src: [:0]const u8) !Semantic.Builder.Result {
     var builder = Semantic.Builder.init(t.allocator);
     errdefer builder.deinit();
-    var source = try _source.Source.fromString(
+    var source = try Source.fromString(
         t.allocator,
         try t.allocator.dupeZ(u8, src),
         try t.allocator.dupe(u8, "test.zig"),
@@ -40,7 +40,7 @@ pub fn build(src: [:0]const u8) !Semantic {
     );
     defer r.deinit();
     var builder = Semantic.Builder.init(t.allocator);
-    var source = try _source.Source.fromString(
+    var source = try Source.fromString(
         t.allocator,
         try t.allocator.dupeZ(u8, src),
         try t.allocator.dupe(u8, "test.zig"),

--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -25,7 +25,7 @@ fix: bool = false,
 /// Like `--fix`, but also enable potentially dangerous fixes.
 fix_dangerously: bool = false,
 /// Positional arguments
-args: std.ArrayListUnmanaged([]const u8) = .empty,
+args: std.ArrayList([]const u8) = .empty,
 
 pub const usage =
     \\Usage: zlint [options] [<dirs>]
@@ -53,7 +53,7 @@ const ParseError = error{
 pub fn parseArgv(alloc: Allocator, io: std.Io, args: std.process.Args, err: ?*Error) ParseError!Options {
     // NOTE: on most platforms this does not actually allocate memory; only
     // Windows and WASI need the allocator to decode the command line.
-    var argv = std.process.Args.Iterator.initAllocator(args, alloc) catch return error.OutOfMemory;
+    var argv = try std.process.Args.Iterator.initAllocator(args, alloc);
     defer argv.deinit();
     return parse(alloc, io, argv, err);
 }

--- a/src/linter/ast_utils.zig
+++ b/src/linter/ast_utils.zig
@@ -4,8 +4,6 @@ const Ast = Semantic.Ast;
 const Node = Ast.Node;
 const Token = Semantic.Token;
 
-const NULL_NODE = Semantic.NULL_NODE;
-
 /// Get the right-most identifier in a field access chain.
 ///
 /// This is the opposite of `getLeftmostIdentifier`.
@@ -115,13 +113,13 @@ pub inline fn isArrayInit(tag: Node.Tag) bool {
 /// if (cond) !void else void
 /// ```
 pub fn hasErrorUnion(ast: *const Ast, node: Node.Index) bool {
-    return getErrorUnion(ast, node) != NULL_NODE;
+    return getErrorUnion(ast, node) != .root;
 }
 
 pub fn getErrorUnion(ast: *const Ast, node: Node.Index) Node.Index {
     const tok_tags: []const Token.Tag = ast.tokens.items(.tag);
     return switch (ast.nodeTag(node)) {
-        .root => NULL_NODE,
+        .root => .root,
         .error_union, .merge_error_sets, .error_set_decl => node,
         .if_simple => getErrorUnion(ast, ast.nodeData(node).node_and_node[1]),
         .@"if" => blk: {
@@ -129,11 +127,11 @@ pub fn getErrorUnion(ast: *const Ast, node: Node.Index) Node.Index {
             const main = ast.nodeMainToken(node);
             if (main > 1 and tok_tags[main - 1] == .bang) break :blk node;
             break :blk unwrapNode(getErrorUnion(ast, ifnode.ast.then_expr)) orelse
-                if (ifnode.ast.else_expr.unwrap()) |else_expr| getErrorUnion(ast, else_expr) else NULL_NODE;
+                if (ifnode.ast.else_expr.unwrap()) |else_expr| getErrorUnion(ast, else_expr) else .root;
         },
         else => blk: {
             const prev_tok = ast.firstToken(node) -| 1;
-            break :blk if (tok_tags[prev_tok] == .bang) node else NULL_NODE;
+            break :blk if (tok_tags[prev_tok] == .bang) node else .root;
         },
     };
 }
@@ -190,5 +188,5 @@ pub fn getInnerType(ast: *const Ast, node: Node.Index) Node.Index {
 
 /// Returns `null` if `node` is the null node. Identity function otherwise.
 pub inline fn unwrapNode(node: Node.Index) ?Node.Index {
-    return if (node == NULL_NODE) null else node;
+    return if (node == .root) null else node;
 }

--- a/src/linter/rules/no_catch_return.zig
+++ b/src/linter/rules/no_catch_return.zig
@@ -81,7 +81,7 @@ pub fn runOnNode(_: *const NoCatchReturn, wrapper: NodeWrapper, ctx: *LinterCont
 
     // .@"catch" data is .node_and_node: [0]=operand, [1]=fallback
     const catch_data = node.data.node_and_node;
-    if (catch_data[1] == Semantic.NULL_NODE) return; // NOTE: in v0.15, this is non-optional. Remove?
+    if (catch_data[1] == .root) return; // NOTE: in v0.15, this is non-optional. Remove?
     var return_node: Node.Index = catch_data[1];
     const end_of_last_tok = ctx.semantic.tokenSpan(ast.lastToken(return_node)).end;
 

--- a/src/linter/rules/no_return_try.zig
+++ b/src/linter/rules/no_return_try.zig
@@ -39,7 +39,6 @@
 
 const std = @import("std");
 const util = @import("util");
-const Semantic = @import("../../Semantic.zig");
 const _rule = @import("../rule.zig");
 const _span = @import("../../span.zig");
 

--- a/src/linter/rules/returned_stack_reference.zig
+++ b/src/linter/rules/returned_stack_reference.zig
@@ -252,7 +252,7 @@ const StackReferenceVisitor = struct {
         node: Node.Index,
     ) IsLocal {
         const sema = self.ctx.semantic;
-        std.debug.assert(node != Semantic.NULL_NODE);
+        std.debug.assert(node != .root);
         if (self.ast.nodeTag(node) != .identifier) return .no;
 
         const symbols = sema.symbols.symbols.slice();

--- a/src/linter/rules/unused_decls.zig
+++ b/src/linter/rules/unused_decls.zig
@@ -114,7 +114,7 @@ pub fn runOnSymbol(_: *const UnusedDecls, symbol: Symbol.Id, ctx: *LinterContext
     // are too many false positives for non-root constants. Once such references
     // are reliably resolved, remove this check.
     const scope: Scope.Id = symbols.items(.scope)[s];
-    if (!scope.eql(Semantic.ROOT_SCOPE_ID)) return;
+    if (!scope.eql(.root)) return;
 
     if (flags.s_variable and flags.s_const) {
         const span = ctx.spanT(symbols.items(.token)[s].unwrap().?.int());

--- a/src/linter/rules/useless_error_return.zig
+++ b/src/linter/rules/useless_error_return.zig
@@ -78,7 +78,6 @@ const Rule = _rule.Rule;
 
 const Error = @import("../../Error.zig");
 const Cow = util.Cow(false);
-const assert = std.debug.assert;
 
 // Rule metadata
 const UselessErrorReturn = @This();
@@ -202,7 +201,7 @@ const Visitor = struct {
     ast: *const Ast,
 
     // state
-    curr_return: Node.Index = Semantic.NULL_NODE,
+    curr_return: Node.Index = .root,
     err_stack: std.array_list.Managed(ErrState),
 
     /// Known name of error type.
@@ -219,7 +218,7 @@ const Visitor = struct {
     seen: Seen = .{},
 
     /// location of first `catch` block found. used for error reporting.
-    first_catch: Node.Index = Semantic.NULL_NODE,
+    first_catch: Node.Index = .root,
 
     const Seen = packed struct {
         return_call: bool = false, // `return foo()`;
@@ -256,7 +255,7 @@ const Visitor = struct {
     }
 
     inline fn inReturn(self: *const Visitor) bool {
-        return self.curr_return != Semantic.NULL_NODE;
+        return self.curr_return != .root;
     }
 
     inline fn inCatch(self: *const Visitor) bool {
@@ -276,8 +275,8 @@ const Visitor = struct {
     pub fn exitNode(self: *Visitor, node: Node.Index) void {
         if (self.curr_return == node) {
             // TODO: @branchHint(.unlikely) after 0.14 is released
-            util.debugAssert(node != Semantic.NULL_NODE, "null node should never be visited", .{});
-            self.curr_return = Semantic.NULL_NODE;
+            util.debugAssert(node != .root, "null node should never be visited", .{});
+            self.curr_return = .root;
         } else if (self.err_stack.getLastOrNull()) |err| {
             if (err.node == node) {
                 _ = self.err_stack.pop();
@@ -334,7 +333,7 @@ const Visitor = struct {
     }
 
     pub fn visit_catch(self: *Visitor, node: Node.Index) VisitError!walk.WalkState {
-        if (self.first_catch == Semantic.NULL_NODE) {
+        if (self.first_catch == .root) {
             self.first_catch = node;
         }
 
@@ -409,7 +408,7 @@ const Visitor = struct {
     }
 
     pub fn visitCall(self: *Visitor, _: Node.Index, _: *const Ast.full.Call) VisitError!walk.WalkState {
-        if (self.curr_return == Semantic.NULL_NODE) return .Continue;
+        if (self.curr_return == .root) return .Continue;
 
         self.seen.return_call = true;
         return .Stop;

--- a/src/printer/SemanticPrinter.zig
+++ b/src/printer/SemanticPrinter.zig
@@ -139,7 +139,7 @@ fn printReference(self: *SemanticPrinter, ref_id: Reference.Id) !void {
 }
 
 pub fn printScopeTree(self: *SemanticPrinter) !void {
-    return self.printScope(&self.semantic.scopes.getScope(Semantic.ROOT_SCOPE_ID));
+    return self.printScope(&self.semantic.scopes.getScope(.root));
 }
 
 fn printScope(self: *SemanticPrinter, scope: *const Semantic.Scope) !void {

--- a/src/reporter/formatters/JSONFormatter.zig
+++ b/src/reporter/formatters/JSONFormatter.zig
@@ -69,7 +69,6 @@ test JSONFormatter {
 
 const std = @import("std");
 const io = std.Io;
-const Cow = @import("util").Cow(false);
 const formatter = @import("../formatter.zig");
 const Meta = formatter.Meta;
 const FormatError = formatter.FormatError;

--- a/src/util.zig
+++ b/src/util.zig
@@ -66,4 +66,5 @@ pub inline fn assertUnsafe(condition: bool) void {
 
 test {
     std.testing.refAllDecls(@This());
+    _ = @import("util/id.zig");
 }

--- a/src/util/id.zig
+++ b/src/util/id.zig
@@ -18,14 +18,15 @@ pub fn NominalId(TRepr: type) type {
             else => @compileError(err),
         }
     }
-    const max = std.math.maxInt(TRepr);
+    const max_repr = std.math.maxInt(TRepr);
 
     return enum(TRepr) {
+        root = 0,
         _,
 
         const Id = @This();
         pub const Repr = TRepr;
-        pub const MAX = max;
+        pub const max: Id = .from(max_repr);
 
         pub inline fn new(value: Repr) Id {
             return @enumFromInt(value);
@@ -59,7 +60,7 @@ pub fn NominalId(TRepr: type) type {
                     switch (intoInfo) {
                         .int => {
                             if (comptime intoInfo.int.bits > info.int.bits) {
-                                assert(value <= max);
+                                assert(value <= max_repr);
                             }
                             if (comptime intoInfo.int.signedness == .signed) {
                                 assert(value >= 0);
@@ -85,7 +86,7 @@ pub fn NominalId(TRepr: type) type {
                 Repr => return @intFromEnum(self),
                 Id => return self,
                 Optional => {
-                    std.debug.assert(self.int() != MAX);
+                    std.debug.assert(self != max);
                     return @enumFromInt(@intFromEnum(self));
                 },
                 // try to turn this into another int type
@@ -111,7 +112,7 @@ pub fn NominalId(TRepr: type) type {
         /// Try to turn this id into its corresponding optional type. Returns
         /// `null` if the id is `MAX` (which is used to represent `Optional.none`).
         pub inline fn optional(self: Id) ?Optional {
-            return if (@intFromEnum(self) == MAX)
+            return if (self == .max)
                 null
             else
                 @enumFromInt(@intFromEnum(self));
@@ -119,13 +120,14 @@ pub fn NominalId(TRepr: type) type {
 
         /// A compact representation of `?Id` using the Id's maximum value as `null`.
         pub const Optional = enum(Repr) {
-            none = max,
+            none = max_repr,
             _,
 
-            pub const MAX = max - 1;
+            /// The largest value that is not `none`.
+            pub const max: Optional = @enumFromInt(max_repr - 1);
 
             pub inline fn new(value: ?Repr) Optional {
-                return if (value == null or value.? == max) Optional.none else @enumFromInt(value.?);
+                return if (value == null or value.? == max_repr) Optional.none else @enumFromInt(value.?);
             }
 
             /// Get this id in its integer representation.
@@ -160,6 +162,14 @@ pub fn NominalId(TRepr: type) type {
             }
         };
     };
+}
+
+test NominalId {
+    const Id = NominalId(u32);
+    try std.testing.expectEqual(std.math.maxInt(u32), Id.max.int());
+    try std.testing.expectEqual(std.math.maxInt(u32) - 1, Id.Optional.max.int());
+    try std.testing.expectEqual(Id.Optional.none, Id.Optional.new(std.math.maxInt(u32)));
+    try std.testing.expectEqual(Id.root, Id.Optional.new(0).unwrap());
 }
 
 pub fn IndexVecUnmanaged(Id: type, T: type) type {

--- a/src/visit/walk.zig
+++ b/src/visit/walk.zig
@@ -213,7 +213,7 @@ pub fn Walker(Visitor: type, Error: type) type {
             visitor: *Visitor,
             node: Node.Index,
         ) InitError!Self {
-            if (node == Semantic.NULL_NODE) {
+            if (node == .root) {
                 @branchHint(.cold);
                 return InitError.NullNode;
             }
@@ -450,7 +450,7 @@ pub fn Walker(Visitor: type, Error: type) type {
                         }
                     }
                     if (param.type_expr) |type_node| {
-                        if (type_node != Semantic.NULL_NODE) try parambuf.append(type_node);
+                        if (type_node != .root) try parambuf.append(type_node);
                     }
                 }
                 std.mem.reverse(Item, parambuf.items);
@@ -489,7 +489,7 @@ pub fn Walker(Visitor: type, Error: type) type {
                                 self.push(el, .{ .assume_capacity = true });
                             }
                         },
-                        Node.Index => if (subnode != Semantic.NULL_NODE) {
+                        Node.Index => if (subnode != .root) {
                             if (comptime std.mem.eql(u8, field.name, "proto_node")) {
                                 if (own_id != subnode) try self.push(subnode, .{ .maybe_null = false });
                             } else {
@@ -499,7 +499,7 @@ pub fn Walker(Visitor: type, Error: type) type {
                         },
                         Node.OptionalIndex => {
                             if (subnode.unwrap()) |n| {
-                                if (n != Semantic.NULL_NODE) {
+                                if (n != .root) {
                                     util.assert(n != own_id, "Cycle detected on node {d}", .{@intFromEnum(own_id)});
                                     try self.push(n, .{ .maybe_null = false });
                                 }
@@ -507,7 +507,7 @@ pub fn Walker(Visitor: type, Error: type) type {
                         },
                         ?Node.Index => {
                             if (subnode) |n| {
-                                if (n != Semantic.NULL_NODE) {
+                                if (n != .root) {
                                     util.assert(n != own_id, "Cycle detected on node {d}", .{@intFromEnum(own_id)});
                                     try self.push(n, .{ .maybe_null = false });
                                 }
@@ -830,7 +830,7 @@ pub fn Walker(Visitor: type, Error: type) type {
         ///   pushing many nodes at once.
         inline fn push(self: *Self, node: Node.Index, comptime opts: PushOpts) if (opts.assume_capacity) void else Allocator.Error!void {
             if (comptime opts.maybe_null) {
-                if (node == Semantic.NULL_NODE) return;
+                if (node == .root) return;
             }
             if (comptime util.RUNTIME_SAFETY) self.assertInRange(node);
             if (comptime opts.assume_capacity) {
@@ -861,7 +861,7 @@ pub fn Walker(Visitor: type, Error: type) type {
         /// Sanity check that is only enabled in safe/debug builds. Inlined so
         /// compiler can optimize away checks that aren't needed.
         inline fn assertInRange(self: *Self, node: Node.Index) void {
-            util.assert(node != Semantic.NULL_NODE, "Tried to push null node onto stack", .{});
+            util.assert(node != .root, "Tried to push null node onto stack", .{});
 
             if (comptime util.RUNTIME_SAFETY) {
                 if (@intFromEnum(node) >= self.ast.nodes.len) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal collection initialization and memory management.
  * Standardized root-node and root-scope handling across semantic analysis, linting, traversal, printing, and tests.
  * Simplified identifier and flag representations.

* **API Updates**
  * Added explicit empty initializers for semantic tables, scopes, modules, and reference stacks.
  * Removed deprecated public constants and the obsolete raw-token type.
  * Renamed identifier limit constants to lowercase forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->