### PR TITLE
feat: Add build.zig util  (start of path for source based distribution with comptime rule config)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -323,7 +323,7 @@ const Linker = struct {
     }
 };
 
-const ZLintStep = struct {
+pub const ZLintStep = struct {
     step: Build.Step,
 };
 

--- a/build.zig
+++ b/build.zig
@@ -3,11 +3,7 @@ const Build = std.Build;
 const Module = std.Build.Module;
 const codegen = @import("tasks/codegen_task.zig");
 
-const ZLintBuildGraph = struct {
-    exe: *Build.Step.Compile,
-};
-
-fn _build(b: *std.Build, in_opts: Linker.Options) ZLintBuildGraph {
+pub fn build(b: *std.Build) void {
     // default to -freference-trace, but respect -fnoreference-trace
     if (b.reference_trace == null) {
         b.reference_trace = 256;
@@ -22,7 +18,7 @@ fn _build(b: *std.Build, in_opts: Linker.Options) ZLintBuildGraph {
     const coverage = b.option(bool, "coverage", "Build test binaries with the LLVM backend for kcov coverage") orelse false;
     const use_llvm: ?bool = if (coverage) true else null;
 
-    var l = Linker.init(b, in_opts);
+    var l = Linker.init(b);
     defer l.deinit();
     if (debug_release) {
         l.optimize = .ReleaseSafe;
@@ -234,17 +230,6 @@ fn _build(b: *std.Build, in_opts: Linker.Options) ZLintBuildGraph {
     check.dependOn(&ct.docgen().step);
     check.dependOn(&ct.confgen().step);
     check.dependOn(&e2e.step);
-
-    return .{
-        .exe = exe,
-    };
-}
-
-pub fn build(b: *std.Build) void {
-    _ = _build(b, .{
-        .target = b.standardTargetOptions(.{}),
-        .optimize = b.standardOptimizeOption(.{}),
-    });
 }
 
 /// Stores modules and dependencies. Use `link` to register them as imports.
@@ -257,19 +242,14 @@ const Linker = struct {
     modules: std.StringHashMapUnmanaged(*Module) = .{},
     dev_modules: std.StringHashMapUnmanaged(*Module) = .{},
 
-    pub const Options = struct {
-        target: Build.ResolvedTarget,
-        optimize: std.builtin.OptimizeMode,
-    };
-
-    fn init(b: *Build, in_opts: Options) Linker {
+    fn init(b: *Build) Linker {
         var opts = b.addOptions();
         opts.addOption([]const u8, "version", b.option([]const u8, "version", "ZLint version") orelse "v0.0.0");
         var linker = Linker{
             .b = b,
             .options = opts,
-            .target = in_opts.target,
-            .optimize = in_opts.optimize,
+            .target = b.standardTargetOptions(.{}),
+            .optimize = b.standardOptimizeOption(.{}),
         };
         const opts_module = opts.createModule();
         linker.modules.put(b.allocator, "config", opts_module) catch @panic("OOM");

--- a/build.zig
+++ b/build.zig
@@ -3,7 +3,11 @@ const Build = std.Build;
 const Module = std.Build.Module;
 const codegen = @import("tasks/codegen_task.zig");
 
-pub fn build(b: *std.Build) void {
+const ZLintBuildGraph = struct {
+    exe: *Build.Step.Compile,
+};
+
+fn _build(b: *std.Build, in_opts: Linker.Options) ZLintBuildGraph {
     // default to -freference-trace, but respect -fnoreference-trace
     if (b.reference_trace == null) {
         b.reference_trace = 256;
@@ -18,7 +22,7 @@ pub fn build(b: *std.Build) void {
     const coverage = b.option(bool, "coverage", "Build test binaries with the LLVM backend for kcov coverage") orelse false;
     const use_llvm: ?bool = if (coverage) true else null;
 
-    var l = Linker.init(b);
+    var l = Linker.init(b, in_opts);
     defer l.deinit();
     if (debug_release) {
         l.optimize = .ReleaseSafe;
@@ -230,6 +234,17 @@ pub fn build(b: *std.Build) void {
     check.dependOn(&ct.docgen().step);
     check.dependOn(&ct.confgen().step);
     check.dependOn(&e2e.step);
+
+    return .{
+        .exe = exe,
+    };
+}
+
+pub fn build(b: *std.Build) void {
+    _ = _build(b, .{
+        .target = b.standardTargetOptions(.{}),
+        .optimize = b.standardOptimizeOption(.{}),
+    });
 }
 
 /// Stores modules and dependencies. Use `link` to register them as imports.
@@ -242,14 +257,19 @@ const Linker = struct {
     modules: std.StringHashMapUnmanaged(*Module) = .{},
     dev_modules: std.StringHashMapUnmanaged(*Module) = .{},
 
-    fn init(b: *Build) Linker {
+    pub const Options = struct {
+        target: Build.ResolvedTarget,
+        optimize: std.builtin.OptimizeMode,
+    };
+
+    fn init(b: *Build, in_opts: Options) Linker {
         var opts = b.addOptions();
         opts.addOption([]const u8, "version", b.option([]const u8, "version", "ZLint version") orelse "v0.0.0");
         var linker = Linker{
             .b = b,
             .options = opts,
-            .target = b.standardTargetOptions(.{}),
-            .optimize = b.standardOptimizeOption(.{}),
+            .target = in_opts.target,
+            .optimize = in_opts.optimize,
         };
         const opts_module = opts.createModule();
         linker.modules.put(b.allocator, "config", opts_module) catch @panic("OOM");
@@ -322,3 +342,16 @@ const Linker = struct {
         self.modules.deinit(self.b.allocator);
     }
 };
+
+const ZLintStep = struct {
+    step: Build.Step,
+};
+
+pub fn addRunLint(b: *std.Build, zlint_dep: *std.Build.Dependency) *ZLintStep {
+    const exe = zlint_dep.artifact("zlint");
+    const run = b.addRunArtifact(exe);
+    if (b.args) |args| {
+        run.addArgs(args);
+    }
+    return @ptrCast(run);
+}


### PR DESCRIPTION
I've been thinking about using zlint for a bit but wanted a different custom rule story.

Then I had an issue where I wanted to start using zlint yesterday, and realized it could be installed and used via the zig build system, and probably custom rules could be added that way too using build time config in build.zig that can then be read at comptime.

The following change exposes a method from your build.zig that can then be used by zig projects that add a "zlint" dependency via `zig fetch`.

All I did to test it works is ran `zig init` in a folder, then `zig fetch <MY_PATH_TO_ZLINT_FORK>`, and copy and pasted the following code into the `build.zig`

```zig
    const zlint_dep = b.dependency("zlint", .{});
    const run_lint = zlint.addRunLint(b, zlint_dep);
    const lint_step = b.step("lint", "run zlint");
    lint_step.dependOn(&run_lint.step);
```

And I got the following output when running `zig build lint` in that project:

```zig
  ⚠ no-print: Using `std.debug.print` is not allowed.
   ╭─[src/main.zig:8:15]
 7 │     // Prints to stderr, unbuffered, ignoring potential errors.
 8 │     std.debug.print("All your {s} are belong to us.\n", .{"codebase"});
   ·               ─────
   ╰────
  help: End-users don't want to see debug logs. Use `std.log` instead.

        Found 0 errors and 1 warnings across 3 files in 2ms.
```

Please discuss the approach, it turned out to be less code than I expected! I am now going to try to setup a custom rule for my project that can be read at comptime

Another interesting ramification of the approach is that if config is added as a build argument so it can be used in build.zig (like custom rules in #411), then it can be used to e.g. make zig not compile turned off rules or even unused features through zig's laziness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added build integration for running the ZLint tool directly from project builds.
* Added support for passing command-line arguments to ZLint during build execution.
* Exposed the linting step for use alongside other build steps, enabling smoother workflow integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->