### PR TITLE
fix(sema): preserve while body scope flags

### DIFF
--- a/src/Semantic/Builder.zig
+++ b/src/Semantic/Builder.zig
@@ -878,10 +878,12 @@ fn visitWhile(self: *SemanticBuilder, _: NodeIndex, while_stmt: full.While) call
                 .flags = .{ .s_payload = true, .s_const = true },
             });
         }
-        // TODO: `cont_expr` is visited before `then_expr`, so a pending
-        // `_next_block_scope_flags` (e.g. `s_catch` from `visitCatch`) gets
-        // consumed by the continue block instead of the loop body.
-        try self.visitOptional(ast.cont_expr);
+        {
+            const pending = self._next_block_scope_flags;
+            self._next_block_scope_flags = .{};
+            defer self._next_block_scope_flags = pending;
+            try self.visitOptional(ast.cont_expr);
+        }
         try self.visit(ast.then_expr);
     }
 
@@ -2003,4 +2005,57 @@ test "comptime blocks" {
     const block_scope = scopes.get(1);
     try std.testing.expect(block_scope.flags.s_block);
     try std.testing.expect(block_scope.flags.s_comptime);
+}
+
+test "catch flags apply to a while body instead of its continue expression" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\fn bar() anyerror!u32 {
+        \\    return 1;
+        \\}
+        \\
+        \\fn foo() u32 {
+        \\    var i: u32 = 0;
+        \\    return bar() catch while (i < 10) : ({
+        \\        i += 1;
+        \\    }) {
+        \\        const inner = i;
+        \\        _ = inner;
+        \\    } else 0;
+        \\}
+    ;
+
+    var builder = SemanticBuilder.init(alloc);
+    defer builder.deinit();
+    var result = try builder.build(src);
+    defer result.deinit();
+    try std.testing.expect(!result.hasErrors());
+    var semantic = result.value;
+
+    var body_scope_id: ?Semantic.Scope.Id = null;
+    var symbols = semantic.symbols.iter();
+    while (symbols.next()) |id| {
+        const symbol = semantic.symbols.get(id);
+        if (std.mem.eql(u8, symbol.name, "inner")) {
+            body_scope_id = symbol.scope;
+            break;
+        }
+    }
+
+    const body_scope = semantic.scopes.getScope(body_scope_id orelse return error.TestExpectedEqual);
+    try std.testing.expect(body_scope.flags.s_catch);
+
+    const parent_id = body_scope.parent.unwrap() orelse return error.TestExpectedEqual;
+    const siblings = semantic.scopes.children.items[parent_id.int()].items;
+    var continue_scope_id: ?Semantic.Scope.Id = null;
+    for (siblings) |sibling_id| {
+        if (sibling_id != body_scope.id) {
+            continue_scope_id = sibling_id;
+            break;
+        }
+    }
+
+    const continue_scope = semantic.scopes.getScope(continue_scope_id orelse return error.TestExpectedEqual);
+    try std.testing.expect(continue_scope.flags.s_block);
+    try std.testing.expect(!continue_scope.flags.s_catch);
 }


### PR DESCRIPTION
Fixes #400.

### What changed
- isolate pending next-block scope flags while visiting a `while` continue expression
- restore the pending flags for the loop body
- add a regression test proving `s_catch` reaches the body and stays off the continue block

### Validation
- `zig build check -Dtarget=x86_64-linux-musl`
- `zig build codegen -Dtarget=x86_64-linux-musl` with a clean generated diff
- `zig build test -Dtarget=x86_64-linux-musl`
- `zig build test-e2e -Dtarget=x86_64-linux-musl`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scope handling in `while` loops so error-handling behavior is applied consistently within the loop body.
  * Prevented scope settings from incorrectly carrying over to loop continuation logic.
  * Added regression coverage to ensure loop behavior remains correct in future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->