### PR TITLE
feat(cli): add zlint self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ curl -fsSL https://raw.githubusercontent.com/DonIsaac/zlint/refs/heads/main/task
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/DonIsaac/zlint/refs/heads/main/tasks/install.ps1" | Invoke-Expression
 ```
 
+### Updating
+
+Direct binary installations can be updated in place:
+
+```sh
+zlint update
+```
+
 ### 🔨 Building from Source
 
 Clone this repo and compile the project with Zig.

--- a/apps/site/docs/installation.md
+++ b/apps/site/docs/installation.md
@@ -16,6 +16,14 @@ curl -fsSL https://raw.githubusercontent.com/DonIsaac/zlint/refs/heads/main/task
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/DonIsaac/zlint/refs/heads/main/tasks/install.ps1" | Invoke-Expression
 ```
 
+## Updating
+
+Update a direct binary installation to the latest stable release with:
+
+```sh
+zlint update
+```
+
 ## Manual Installation
 
 Each release is available on the [releases page](https://github.com/DonIsaac/zlint/releases/latest).

--- a/src/cli/Options.zig
+++ b/src/cli/Options.zig
@@ -29,8 +29,13 @@ args: std.ArrayList([]const u8) = .empty,
 
 pub const usage =
     \\Usage: zlint [options] [<dirs>]
+    \\       zlint update
 ;
 const help =
+    \\Commands:
+    \\  update             Download and install the latest stable release
+    \\
+    \\Options:
     \\--print-ast <file>  Parse a file and print its AST as JSON
     \\-f, --format <fmt>  Choose an output format (default, graphical, json, github, gh)
     \\--no-summary        Do not print a summary after linting

--- a/src/cli/update/Client.zig
+++ b/src/cli/update/Client.zig
@@ -17,6 +17,8 @@ const asset_headers = [_]std.http.Header{
 
 pub const metadata_limit = 1024 * 1024;
 
+const max_redirect_url_len = 2048;
+
 /// Initializes TLS and proxy configuration from the process environment.
 pub fn init(alloc: Allocator, io: Io, environ: std.process.Environ) !Self {
     var env_map = try environ.createMap(alloc);
@@ -47,12 +49,12 @@ pub fn deinit(self: *Self) void {
 
 /// Fetches a release response into bounded, caller-owned storage.
 pub fn fetchRelease(self: *Self, url: []const u8) ![]u8 {
-    var redirect_buffer: [8 * 1024]u8 = undefined;
-    var request = try self.get(url, 3, &release_headers);
+    var head_buffer: [8 * 1024]u8 = undefined;
+    var url_buffer: [max_redirect_url_len]u8 = undefined;
+    // SAFETY: assigned by `openHttps` before it returns successfully.
+    var request: std.http.Client.Request = undefined;
+    var response = try self.openHttps(&request, &url_buffer, &head_buffer, url, 3, &release_headers);
     defer request.deinit();
-
-    try request.sendBodiless();
-    var response = try request.receiveHead(&redirect_buffer);
     try requireOk(response.head.status);
 
     var transfer_buffer: [64]u8 = undefined;
@@ -65,12 +67,12 @@ pub fn fetchRelease(self: *Self, url: []const u8) ![]u8 {
 /// Streams exactly `expected_size` bytes to `destination` while hashing them.
 /// The caller remains responsible for syncing and closing the destination.
 pub fn downloadAsset(self: *Self, url: []const u8, expected_size: u64, destination: *Io.File) !release.Digest {
-    var redirect_buffer: [8 * 1024]u8 = undefined;
-    var request = try self.get(url, 5, &asset_headers);
+    var head_buffer: [8 * 1024]u8 = undefined;
+    var url_buffer: [max_redirect_url_len]u8 = undefined;
+    // SAFETY: assigned by `openHttps` before it returns successfully.
+    var request: std.http.Client.Request = undefined;
+    var response = try self.openHttps(&request, &url_buffer, &head_buffer, url, 5, &asset_headers);
     defer request.deinit();
-
-    try request.sendBodiless();
-    var response = try request.receiveHead(&redirect_buffer);
     try requireOk(response.head.status);
     if (response.head.content_length) |content_length| {
         if (content_length != expected_size) return error.DownloadSizeMismatch;
@@ -88,14 +90,58 @@ pub fn downloadAsset(self: *Self, url: []const u8, expected_size: u64, destinati
 
 // Shared HTTP and streaming primitives
 
+/// `std.http.Client` derives each hop's protocol from the redirect URI's
+/// scheme, so its built-in redirect handling silently downgrades to plaintext.
+///
+/// `request_out` is caller-owned; the returned response borrows it, and the
+/// caller must `deinit` it on success.
+fn openHttps(
+    self: *Self,
+    request_out: *std.http.Client.Request,
+    url_buffer: *[max_redirect_url_len]u8,
+    head_buffer: []u8,
+    url: []const u8,
+    max_redirects: u8,
+    extra_headers: []const std.http.Header,
+) !std.http.Client.Response {
+    var current = url;
+    var remaining = max_redirects;
+    while (true) {
+        request_out.* = try self.get(current, extra_headers);
+        errdefer request_out.deinit();
+
+        try request_out.sendBodiless();
+        var response = try request_out.receiveHead(head_buffer);
+        if (response.head.status.class() != .redirect) return response;
+
+        if (remaining == 0) return error.TooManyHttpRedirects;
+        remaining -= 1;
+
+        const location = response.head.location orelse return error.HttpRedirectLocationMissing;
+        // Copy before deinit; `location` points into the response head.
+        current = try copyHttpsLocation(url_buffer, location);
+        request_out.deinit();
+    }
+}
+
+/// Relative locations are rejected rather than resolved; GitHub always sends
+/// absolute URLs, so failing closed beats reimplementing URI resolution.
+fn copyHttpsLocation(buffer: *[max_redirect_url_len]u8, location: []const u8) ![]const u8 {
+    const uri = std.Uri.parse(location) catch return error.InsecureRedirect;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "https")) return error.InsecureRedirect;
+    if (location.len > buffer.len) return error.RedirectLocationTooLong;
+
+    @memcpy(buffer[0..location.len], location);
+    return buffer[0..location.len];
+}
+
 fn get(
     self: *Self,
     url: []const u8,
-    comptime redirect_count: u8,
     extra_headers: []const std.http.Header,
 ) !std.http.Client.Request {
     return self.http.request(.GET, try std.Uri.parse(url), .{
-        .redirect_behavior = @enumFromInt(redirect_count),
+        .redirect_behavior = .unhandled,
         .headers = .{
             .user_agent = .{ .override = request_user_agent },
             .accept_encoding = .omit,
@@ -183,6 +229,22 @@ test "exact download rejects truncated and oversized bodies" {
     var long_output: Io.Writer.Allocating = .init(t.allocator);
     defer long_output.deinit();
     try t.expectError(error.StreamTooLong, copyExactAndHash(&long_reader, &long_output.writer, 3));
+}
+
+test "redirects may not leave HTTPS" {
+    var buffer: [max_redirect_url_len]u8 = undefined;
+
+    const absolute = "https://objects.githubusercontent.com/zlint-linux-x86_64";
+    try t.expectEqualStrings(absolute, try copyHttpsLocation(&buffer, absolute));
+    try t.expectEqualStrings("HTTPS://EXAMPLE.COM/x", try copyHttpsLocation(&buffer, "HTTPS://EXAMPLE.COM/x"));
+
+    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "http://evil.example/zlint"));
+    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "/next"));
+    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "evil.example/zlint"));
+    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "ftp://example.com/zlint"));
+
+    const too_long = "https://example.com/" ++ ("a" ** max_redirect_url_len);
+    try t.expectError(error.RedirectLocationTooLong, copyHttpsLocation(&buffer, too_long));
 }
 
 test "HTTP response statuses have actionable error categories" {

--- a/src/cli/update/Client.zig
+++ b/src/cli/update/Client.zig
@@ -18,8 +18,8 @@ const asset_headers = [_]std.http.Header{
 pub const metadata_limit = 1024 * 1024;
 
 const max_redirect_url_len = 2048;
+const release_redirect_hosts = [_][]const u8{"api.github.com"};
 
-/// Initializes TLS and proxy configuration from the process environment.
 pub fn init(alloc: Allocator, io: Io, environ: std.process.Environ) !Self {
     var env_map = try environ.createMap(alloc);
     defer env_map.deinit();
@@ -45,15 +45,12 @@ pub fn deinit(self: *Self) void {
     self.* = undefined;
 }
 
-// Release metadata
-
-/// Fetches a release response into bounded, caller-owned storage.
 pub fn fetchRelease(self: *Self, url: []const u8) ![]u8 {
     var head_buffer: [8 * 1024]u8 = undefined;
     var url_buffer: [max_redirect_url_len]u8 = undefined;
     // SAFETY: assigned by `openHttps` before it returns successfully.
     var request: std.http.Client.Request = undefined;
-    var response = try self.openHttps(&request, &url_buffer, &head_buffer, url, 3, &release_headers);
+    var response = try self.openHttps(&request, &url_buffer, &head_buffer, url, 3, &release_headers, &release_redirect_hosts);
     defer request.deinit();
     try requireOk(response.head.status);
 
@@ -62,16 +59,26 @@ pub fn fetchRelease(self: *Self, url: []const u8) ![]u8 {
     return reader.allocRemaining(self.allocator, .limited(metadata_limit));
 }
 
-// Binary download
-
-/// Streams exactly `expected_size` bytes to `destination` while hashing them.
-/// The caller remains responsible for syncing and closing the destination.
-pub fn downloadAsset(self: *Self, url: []const u8, expected_size: u64, destination: *Io.File) !release.Digest {
+/// The caller syncs and closes `destination`.
+pub fn downloadAsset(
+    self: *Self,
+    url: []const u8,
+    expected_size: u64,
+    destination: *Io.File,
+) !release.Digest {
     var head_buffer: [8 * 1024]u8 = undefined;
     var url_buffer: [max_redirect_url_len]u8 = undefined;
     // SAFETY: assigned by `openHttps` before it returns successfully.
     var request: std.http.Client.Request = undefined;
-    var response = try self.openHttps(&request, &url_buffer, &head_buffer, url, 5, &asset_headers);
+    var response = try self.openHttps(
+        &request,
+        &url_buffer,
+        &head_buffer,
+        url,
+        5,
+        &asset_headers,
+        null,
+    );
     defer request.deinit();
     try requireOk(response.head.status);
     if (response.head.content_length) |content_length| {
@@ -83,12 +90,14 @@ pub fn downloadAsset(self: *Self, url: []const u8, expected_size: u64, destinati
     var transfer_buffer: [64]u8 = undefined;
     const response_reader = response.reader(&transfer_buffer);
 
-    const digest = try copyExactAndHash(response_reader, &file_writer.interface, expected_size);
+    const digest = try copyExactAndHash(
+        response_reader,
+        &file_writer.interface,
+        expected_size,
+    );
     try file_writer.interface.flush();
     return digest;
 }
-
-// Shared HTTP and streaming primitives
 
 /// `std.http.Client` derives each hop's protocol from the redirect URI's
 /// scheme, so its built-in redirect handling silently downgrades to plaintext.
@@ -103,6 +112,8 @@ fn openHttps(
     url: []const u8,
     max_redirects: u8,
     extra_headers: []const std.http.Header,
+    /// `Location` reidrect allowlist
+    allowed_hosts: ?[]const []const u8,
 ) !std.http.Client.Response {
     var current = url;
     var remaining = max_redirects;
@@ -119,20 +130,40 @@ fn openHttps(
 
         const location = response.head.location orelse return error.HttpRedirectLocationMissing;
         // Copy before deinit; `location` points into the response head.
-        current = try copyHttpsLocation(url_buffer, location);
+        current = try copyHttpsLocation(url_buffer, location, allowed_hosts);
         request_out.deinit();
     }
 }
 
 /// Relative locations are rejected rather than resolved; GitHub always sends
 /// absolute URLs, so failing closed beats reimplementing URI resolution.
-fn copyHttpsLocation(buffer: *[max_redirect_url_len]u8, location: []const u8) ![]const u8 {
+fn copyHttpsLocation(
+    buffer: *[max_redirect_url_len]u8,
+    location: []const u8,
+    allowed_hosts: ?[]const []const u8,
+) ![]const u8 {
     const uri = std.Uri.parse(location) catch return error.InsecureRedirect;
     if (!std.ascii.eqlIgnoreCase(uri.scheme, "https")) return error.InsecureRedirect;
+    if (allowed_hosts) |hosts| {
+        if (!isAllowedHost(uri.host, hosts)) return error.RedirectHostNotAllowed;
+    }
     if (location.len > buffer.len) return error.RedirectLocationTooLong;
 
     @memcpy(buffer[0..location.len], location);
     return buffer[0..location.len];
+}
+
+fn isAllowedHost(
+    host: ?std.Uri.Component,
+    allowed_hosts: []const []const u8,
+) bool {
+    const name = switch (host orelse return false) {
+        .raw, .percent_encoded => |text| text,
+    };
+    for (allowed_hosts) |allowed| {
+        if (std.ascii.eqlIgnoreCase(name, allowed)) return true;
+    }
+    return false;
 }
 
 fn get(
@@ -235,16 +266,30 @@ test "redirects may not leave HTTPS" {
     var buffer: [max_redirect_url_len]u8 = undefined;
 
     const absolute = "https://objects.githubusercontent.com/zlint-linux-x86_64";
-    try t.expectEqualStrings(absolute, try copyHttpsLocation(&buffer, absolute));
-    try t.expectEqualStrings("HTTPS://EXAMPLE.COM/x", try copyHttpsLocation(&buffer, "HTTPS://EXAMPLE.COM/x"));
+    try t.expectEqualStrings(absolute, try copyHttpsLocation(&buffer, absolute, null));
+    try t.expectEqualStrings("HTTPS://EXAMPLE.COM/x", try copyHttpsLocation(&buffer, "HTTPS://EXAMPLE.COM/x", null));
 
-    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "http://evil.example/zlint"));
-    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "/next"));
-    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "evil.example/zlint"));
-    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "ftp://example.com/zlint"));
+    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "http://evil.example/zlint", null));
+    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "/next", null));
+    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "evil.example/zlint", null));
+    try t.expectError(error.InsecureRedirect, copyHttpsLocation(&buffer, "ftp://example.com/zlint", null));
 
     const too_long = "https://example.com/" ++ ("a" ** max_redirect_url_len);
-    try t.expectError(error.RedirectLocationTooLong, copyHttpsLocation(&buffer, too_long));
+    try t.expectError(error.RedirectLocationTooLong, copyHttpsLocation(&buffer, too_long, null));
+}
+
+test "release metadata redirects may not leave GitHub" {
+    var buffer: [max_redirect_url_len]u8 = undefined;
+    const hosts: []const []const u8 = &release_redirect_hosts;
+
+    const same_host = "https://api.github.com/repos/DonIsaac/zlint/releases/29";
+    try t.expectEqualStrings(same_host, try copyHttpsLocation(&buffer, same_host, hosts));
+    try t.expectEqualStrings("https://API.GITHUB.COM/x", try copyHttpsLocation(&buffer, "https://API.GITHUB.COM/x", hosts));
+
+    try t.expectError(error.RedirectHostNotAllowed, copyHttpsLocation(&buffer, "https://evil.example/releases", hosts));
+    try t.expectError(error.RedirectHostNotAllowed, copyHttpsLocation(&buffer, "https://api.github.com.evil.example/x", hosts));
+    try t.expectError(error.RedirectHostNotAllowed, copyHttpsLocation(&buffer, "https://api.github.com@evil.example/x", hosts));
+    try t.expectError(error.RedirectHostNotAllowed, copyHttpsLocation(&buffer, "https:///x", hosts));
 }
 
 test "HTTP response statuses have actionable error categories" {

--- a/src/cli/update/Client.zig
+++ b/src/cli/update/Client.zig
@@ -1,0 +1,199 @@
+//! HTTP client for release metadata and bounded binary downloads.
+
+allocator: Allocator,
+io: Io,
+http: std.http.Client,
+proxy_arena: std.heap.ArenaAllocator,
+
+const Self = @This();
+const request_user_agent = "zlint-update";
+const release_headers = [_]std.http.Header{
+    .{ .name = "Accept", .value = "application/vnd.github+json" },
+    .{ .name = "X-GitHub-Api-Version", .value = "2022-11-28" },
+};
+const asset_headers = [_]std.http.Header{
+    .{ .name = "Accept", .value = "application/octet-stream" },
+};
+
+pub const metadata_limit = 1024 * 1024;
+
+/// Initializes TLS and proxy configuration from the process environment.
+pub fn init(alloc: Allocator, io: Io, environ: std.process.Environ) !Self {
+    var env_map = try environ.createMap(alloc);
+    defer env_map.deinit();
+
+    var proxy_arena = std.heap.ArenaAllocator.init(alloc);
+    errdefer proxy_arena.deinit();
+
+    var http: std.http.Client = .{ .allocator = alloc, .io = io };
+    errdefer http.deinit();
+    try http.initDefaultProxies(proxy_arena.allocator(), &env_map);
+
+    return .{
+        .allocator = alloc,
+        .io = io,
+        .http = http,
+        .proxy_arena = proxy_arena,
+    };
+}
+
+pub fn deinit(self: *Self) void {
+    self.http.deinit();
+    self.proxy_arena.deinit();
+    self.* = undefined;
+}
+
+// Release metadata
+
+/// Fetches a release response into bounded, caller-owned storage.
+pub fn fetchRelease(self: *Self, url: []const u8) ![]u8 {
+    var redirect_buffer: [8 * 1024]u8 = undefined;
+    var request = try self.get(url, 3, &release_headers);
+    defer request.deinit();
+
+    try request.sendBodiless();
+    var response = try request.receiveHead(&redirect_buffer);
+    try requireOk(response.head.status);
+
+    var transfer_buffer: [64]u8 = undefined;
+    const reader = response.reader(&transfer_buffer);
+    return reader.allocRemaining(self.allocator, .limited(metadata_limit));
+}
+
+// Binary download
+
+/// Streams exactly `expected_size` bytes to `destination` while hashing them.
+/// The caller remains responsible for syncing and closing the destination.
+pub fn downloadAsset(self: *Self, url: []const u8, expected_size: u64, destination: *Io.File) !release.Digest {
+    var redirect_buffer: [8 * 1024]u8 = undefined;
+    var request = try self.get(url, 5, &asset_headers);
+    defer request.deinit();
+
+    try request.sendBodiless();
+    var response = try request.receiveHead(&redirect_buffer);
+    try requireOk(response.head.status);
+    if (response.head.content_length) |content_length| {
+        if (content_length != expected_size) return error.DownloadSizeMismatch;
+    }
+
+    var file_buffer: [64 * 1024]u8 = undefined;
+    var file_writer = destination.writer(self.io, &file_buffer);
+    var transfer_buffer: [64]u8 = undefined;
+    const response_reader = response.reader(&transfer_buffer);
+
+    const digest = try copyExactAndHash(response_reader, &file_writer.interface, expected_size);
+    try file_writer.interface.flush();
+    return digest;
+}
+
+// Shared HTTP and streaming primitives
+
+fn get(
+    self: *Self,
+    url: []const u8,
+    comptime redirect_count: u8,
+    extra_headers: []const std.http.Header,
+) !std.http.Client.Request {
+    return self.http.request(.GET, try std.Uri.parse(url), .{
+        .redirect_behavior = @enumFromInt(redirect_count),
+        .headers = .{
+            .user_agent = .{ .override = request_user_agent },
+            .accept_encoding = .omit,
+        },
+        .extra_headers = extra_headers,
+    });
+}
+
+const HttpStatusError = error{
+    HttpBadRequest,
+    HttpUnauthorized,
+    HttpForbidden,
+    HttpNotFound,
+    HttpRequestTimeout,
+    HttpRateLimited,
+    HttpClientError,
+    HttpServerError,
+    HttpUnexpectedStatus,
+};
+
+/// Converts unsuccessful HTTP statuses into stable errors that the command can
+/// explain without exposing Zig's internal status names to users.
+fn requireOk(status: std.http.Status) HttpStatusError!void {
+    if (status == .ok) return;
+
+    return switch (status) {
+        .bad_request => error.HttpBadRequest,
+        .unauthorized => error.HttpUnauthorized,
+        .forbidden => error.HttpForbidden,
+        .not_found => error.HttpNotFound,
+        .request_timeout => error.HttpRequestTimeout,
+        .too_many_requests => error.HttpRateLimited,
+        else => switch (status.class()) {
+            .client_error => error.HttpClientError,
+            .server_error => error.HttpServerError,
+            else => error.HttpUnexpectedStatus,
+        },
+    };
+}
+
+fn copyExactAndHash(reader: *Io.Reader, writer: *Io.Writer, expected_size: u64) !release.Digest {
+    var hash_buffer: [64 * 1024]u8 = undefined;
+    var hashed: Io.Writer.Hashed(Sha256) = .initHasher(writer, Sha256.init(.{}), &hash_buffer);
+
+    try reader.streamExact64(&hashed.writer, expected_size);
+    reader.fill(1) catch |err| switch (err) {
+        error.EndOfStream => {},
+        else => |e| return e,
+    };
+    if (reader.bufferedLen() != 0) return error.StreamTooLong;
+
+    try hashed.writer.flush();
+    return hashed.hasher.finalResult();
+}
+
+const std = @import("std");
+const release = @import("release.zig");
+
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
+const t = std.testing;
+
+test "exact download writes bytes and computes SHA-256" {
+    var reader = Io.Reader.fixed("abc");
+    var output: Io.Writer.Allocating = .init(t.allocator);
+    defer output.deinit();
+
+    const actual = try copyExactAndHash(&reader, &output.writer, 3);
+    var expected: release.Digest = undefined;
+    Sha256.hash("abc", &expected, .{});
+
+    try t.expectEqualStrings("abc", output.written());
+    try t.expectEqual(expected, actual);
+}
+
+test "exact download rejects truncated and oversized bodies" {
+    var short_reader = Io.Reader.fixed("ab");
+    var short_output: Io.Writer.Allocating = .init(t.allocator);
+    defer short_output.deinit();
+    try t.expectError(error.EndOfStream, copyExactAndHash(&short_reader, &short_output.writer, 3));
+
+    var long_reader = Io.Reader.fixed("abcd");
+    var long_output: Io.Writer.Allocating = .init(t.allocator);
+    defer long_output.deinit();
+    try t.expectError(error.StreamTooLong, copyExactAndHash(&long_reader, &long_output.writer, 3));
+}
+
+test "HTTP response statuses have actionable error categories" {
+    try requireOk(.ok);
+    try t.expectError(error.HttpBadRequest, requireOk(.bad_request));
+    try t.expectError(error.HttpUnauthorized, requireOk(.unauthorized));
+    try t.expectError(error.HttpForbidden, requireOk(.forbidden));
+    try t.expectError(error.HttpNotFound, requireOk(.not_found));
+    try t.expectError(error.HttpRequestTimeout, requireOk(.request_timeout));
+    try t.expectError(error.HttpRateLimited, requireOk(.too_many_requests));
+    try t.expectError(error.HttpClientError, requireOk(.unprocessable_entity));
+    try t.expectError(error.HttpServerError, requireOk(.service_unavailable));
+    try t.expectError(error.HttpUnexpectedStatus, requireOk(.not_modified));
+}

--- a/src/cli/update/StagedExecutable.zig
+++ b/src/cli/update/StagedExecutable.zig
@@ -1,0 +1,237 @@
+//! Same-directory staging and platform-specific executable replacement.
+
+io: Io,
+executable_path: []const u8,
+directory_path: []const u8,
+directory: Io.Dir,
+staged: Io.File.Atomic,
+
+const Self = @This();
+const windows_handoff_script = @embedFile("windows_handoff.ps1");
+
+pub const InstallResult = enum {
+    replaced,
+    deferred,
+};
+
+// Staging lifecycle
+
+/// Creates a temporary file beside `executable_path` with matching permissions.
+/// The executable path is borrowed for the lifetime of the returned value.
+pub fn new(io: Io, executable_path: []const u8) !Self {
+    const directory_path = std.fs.path.dirname(executable_path) orelse return error.InvalidExecutablePath;
+    const basename = std.fs.path.basename(executable_path);
+
+    var directory = try Io.Dir.openDirAbsolute(io, directory_path, .{});
+    errdefer directory.close(io);
+
+    var installed_file = try directory.openFile(io, basename, .{ .allow_directory = false });
+    defer installed_file.close(io);
+    const installed_stat = try installed_file.stat(io);
+
+    var staged = try directory.createFileAtomic(io, basename, .{
+        .permissions = installed_stat.permissions,
+        .replace = true,
+    });
+    errdefer staged.deinit(io);
+    try staged.file.setPermissions(io, installed_stat.permissions);
+
+    return .{
+        .io = io,
+        .executable_path = executable_path,
+        .directory_path = directory_path,
+        .directory = directory,
+        .staged = staged,
+    };
+}
+
+pub fn deinit(self: *Self) void {
+    self.staged.deinit(self.io);
+    self.directory.close(self.io);
+    self.* = undefined;
+}
+
+/// Returns the temporary file used as the download destination.
+pub fn file(self: *Self) *Io.File {
+    return &self.staged.file;
+}
+
+/// Makes all downloaded bytes durable and closes the temporary file.
+pub fn finishWriting(self: *Self) !void {
+    try self.staged.file.sync(self.io);
+    self.staged.file.close(self.io);
+    self.staged.file_open = false;
+}
+
+// Installation
+
+/// Installs a file finalized by `finishWriting` or starts the Windows handoff.
+pub fn install(self: *Self, alloc: Allocator) !InstallResult {
+    if (comptime builtin.os.tag == .windows) {
+        try self.handoffWindows(alloc);
+        return .deferred;
+    }
+
+    try self.staged.replace(self.io);
+    return .replaced;
+}
+
+// Windows deferred replacement
+
+fn handoffWindows(self: *Self, alloc: Allocator) !void {
+    if (comptime builtin.os.tag != .windows) unreachable;
+
+    const staged_basename = std.fmt.hex(self.staged.file_basename_hex);
+    const staged_path = try std.fs.path.join(alloc, &.{ self.directory_path, &staged_basename });
+    defer alloc.free(staged_path);
+
+    var helper_basename_buffer: [staged_basename.len + ".ps1".len]u8 = undefined;
+    const helper_basename = try std.fmt.bufPrint(&helper_basename_buffer, "{s}.ps1", .{staged_basename});
+    var helper_file = try self.staged.dir.createFile(self.io, helper_basename, .{
+        .exclusive = true,
+        .permissions = .default_file,
+    });
+    var helper_file_open = true;
+    defer if (helper_file_open) helper_file.close(self.io);
+    errdefer self.staged.dir.deleteFile(self.io, helper_basename) catch {};
+
+    const helper_path = try std.fs.path.join(alloc, &.{ self.directory_path, helper_basename });
+    defer alloc.free(helper_path);
+    const parent_pid_arg = try std.fmt.allocPrint(alloc, "{d}", .{std.os.windows.GetCurrentProcessId()});
+    defer alloc.free(parent_pid_arg);
+
+    try helper_file.writeStreamingAll(self.io, windows_handoff_script);
+    try helper_file.sync(self.io);
+    helper_file.close(self.io);
+    helper_file_open = false;
+
+    var child = std.process.spawn(self.io, .{
+        .argv = &.{
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            helper_path,
+            parent_pid_arg,
+            staged_path,
+            self.executable_path,
+            helper_path,
+        },
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .ignore,
+        .create_no_window = true,
+    }) catch return error.WindowsHandoffFailed;
+
+    std.os.windows.CloseHandle(child.thread_handle);
+    std.os.windows.CloseHandle(child.id.?);
+    child.id = null;
+    self.staged.file_exists = false;
+}
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+
+const t = std.testing;
+
+test "verified file atomically replaces executable and preserves permissions" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var tmp = t.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(t.io, .{
+        .sub_path = "zlint",
+        .data = "old binary",
+        .flags = .{ .permissions = .executable_file },
+    });
+
+    const executable_path = try tmp.dir.realPathFileAlloc(t.io, "zlint", t.allocator);
+    defer t.allocator.free(executable_path);
+    const original_stat = try tmp.dir.statFile(t.io, "zlint", .{});
+
+    var staged = try Self.new(t.io, executable_path);
+    defer staged.deinit();
+    try staged.file().writeStreamingAll(t.io, "new binary");
+    try staged.finishWriting();
+    try t.expectEqual(.replaced, try staged.install(t.allocator));
+
+    const installed = try tmp.dir.readFileAlloc(t.io, "zlint", t.allocator, .limited(1024));
+    defer t.allocator.free(installed);
+    const installed_stat = try tmp.dir.statFile(t.io, "zlint", .{});
+    try t.expectEqualStrings("new binary", installed);
+    try t.expectEqual(original_stat.permissions, installed_stat.permissions);
+}
+
+test "abandoned staged file is cleaned up without changing executable" {
+    var tmp = t.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(t.io, .{ .sub_path = "zlint", .data = "old binary" });
+
+    const executable_path = try tmp.dir.realPathFileAlloc(t.io, "zlint", t.allocator);
+    defer t.allocator.free(executable_path);
+    {
+        var staged = try Self.new(t.io, executable_path);
+        defer staged.deinit();
+        try staged.file().writeStreamingAll(t.io, "incomplete download");
+    }
+
+    const installed = try tmp.dir.readFileAlloc(t.io, "zlint", t.allocator, .limited(1024));
+    defer t.allocator.free(installed);
+    try t.expectEqualStrings("old binary", installed);
+
+    var entries = tmp.dir.iterate();
+    var entry_count: usize = 0;
+    while (try entries.next(t.io)) |entry| {
+        entry_count += 1;
+        try t.expectEqualStrings("zlint", entry.name);
+    }
+    try t.expectEqual(@as(usize, 1), entry_count);
+}
+
+test "Windows handoff replaces a file after its parent exits" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = t.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(t.io, .{ .sub_path = "installed.exe", .data = "old binary" });
+    try tmp.dir.writeFile(t.io, .{ .sub_path = "staged.exe", .data = "new binary" });
+    try tmp.dir.writeFile(t.io, .{ .sub_path = "handoff.ps1", .data = windows_handoff_script });
+
+    const command =
+        "$parent = Start-Process powershell.exe " ++
+        "-ArgumentList @('-NoProfile', '-NonInteractive', '-Command', 'Start-Sleep -Milliseconds 100') " ++
+        "-WindowStyle Hidden -PassThru; " ++
+        "& '.\\handoff.ps1' $parent.Id 'staged.exe' 'installed.exe' 'handoff.ps1'";
+    const result = try std.process.run(t.allocator, t.io, .{
+        .argv = &.{
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            command,
+        },
+        .cwd = .{ .dir = tmp.dir },
+        .stderr_limit = .limited(4096),
+        .stdout_limit = .limited(4096),
+    });
+    defer t.allocator.free(result.stdout);
+    defer t.allocator.free(result.stderr);
+
+    switch (result.term) {
+        .exited => |code| try t.expectEqual(@as(u8, 0), code),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const installed = try tmp.dir.readFileAlloc(t.io, "installed.exe", t.allocator, .limited(1024));
+    defer t.allocator.free(installed);
+    try t.expectEqualStrings("new binary", installed);
+    try t.expectError(error.FileNotFound, tmp.dir.statFile(t.io, "staged.exe", .{}));
+    try t.expectError(error.FileNotFound, tmp.dir.statFile(t.io, "handoff.ps1", .{}));
+}

--- a/src/cli/update/StagedExecutable.zig
+++ b/src/cli/update/StagedExecutable.zig
@@ -203,11 +203,23 @@ test "Windows handoff replaces a file after its parent exits" {
     try tmp.dir.writeFile(t.io, .{ .sub_path = "staged.exe", .data = "new binary" });
     try tmp.dir.writeFile(t.io, .{ .sub_path = "handoff.ps1", .data = windows_handoff_script });
 
-    const command =
-        "$parent = Start-Process powershell.exe " ++
-        "-ArgumentList @('-NoProfile', '-NonInteractive', '-Command', 'Start-Sleep -Milliseconds 100') " ++
-        "-WindowStyle Hidden -PassThru; " ++
-        "& '.\\handoff.ps1' $parent.Id 'staged.exe' 'installed.exe' 'handoff.ps1'";
+    const installed_path = try tmp.dir.realPathFileAlloc(t.io, "installed.exe", t.allocator);
+    defer t.allocator.free(installed_path);
+    const staged_path = try tmp.dir.realPathFileAlloc(t.io, "staged.exe", t.allocator);
+    defer t.allocator.free(staged_path);
+    const script_path = try tmp.dir.realPathFileAlloc(t.io, "handoff.ps1", t.allocator);
+    defer t.allocator.free(script_path);
+
+    // Spawn the script exactly as `handoffWindows` does -- `-File` with absolute
+    // paths -- so its exit code is the process exit code and nothing depends on
+    // the working directory.
+    const command = try std.fmt.allocPrint(t.allocator,
+        \\$parent = Start-Process powershell.exe -ArgumentList @('-NoProfile', '-NonInteractive', '-Command', 'Start-Sleep -Milliseconds 100') -WindowStyle Hidden -PassThru;
+        \\& powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File '{s}' $parent.Id '{s}' '{s}' '{s}';
+        \\exit $LASTEXITCODE
+    , .{ script_path, staged_path, installed_path, script_path });
+    defer t.allocator.free(command);
+
     const result = try std.process.run(t.allocator, t.io, .{
         .argv = &.{
             "powershell.exe",
@@ -218,7 +230,6 @@ test "Windows handoff replaces a file after its parent exits" {
             "-Command",
             command,
         },
-        .cwd = .{ .dir = tmp.dir },
         .stderr_limit = .limited(4096),
         .stdout_limit = .limited(4096),
     });
@@ -226,7 +237,10 @@ test "Windows handoff replaces a file after its parent exits" {
     defer t.allocator.free(result.stderr);
 
     switch (result.term) {
-        .exited => |code| try t.expectEqual(@as(u8, 0), code),
+        .exited => |code| if (code != 0) {
+            std.debug.print("handoff failed ({d}): {s}\n", .{ code, result.stderr });
+            return error.TestUnexpectedResult;
+        },
         else => return error.TestUnexpectedResult,
     }
 

--- a/src/cli/update/StagedExecutable.zig
+++ b/src/cli/update/StagedExecutable.zig
@@ -14,10 +14,7 @@ pub const InstallResult = enum {
     deferred,
 };
 
-// Staging lifecycle
-
-/// Creates a temporary file beside `executable_path` with matching permissions.
-/// The executable path is borrowed for the lifetime of the returned value.
+/// `executable_path` is borrowed for the lifetime of the returned value.
 pub fn new(io: Io, executable_path: []const u8) !Self {
     const directory_path = path.dirname(executable_path) orelse return error.InvalidExecutablePath;
     const basename = path.basename(executable_path);
@@ -51,21 +48,16 @@ pub fn deinit(self: *Self) void {
     self.* = undefined;
 }
 
-/// Returns the temporary file used as the download destination.
 pub fn file(self: *Self) *Io.File {
     return &self.staged.file;
 }
 
-/// Makes all downloaded bytes durable and closes the temporary file.
 pub fn finishWriting(self: *Self) !void {
     try self.staged.file.sync(self.io);
     self.staged.file.close(self.io);
     self.staged.file_open = false;
 }
 
-// Installation
-
-/// Installs a file finalized by `finishWriting` or starts the Windows handoff.
 pub fn install(self: *Self, alloc: Allocator) !InstallResult {
     if (comptime builtin.os.tag == .windows) {
         try self.handoffWindows(alloc);
@@ -75,8 +67,6 @@ pub fn install(self: *Self, alloc: Allocator) !InstallResult {
     try self.staged.replace(self.io);
     return .replaced;
 }
-
-// Windows deferred replacement
 
 fn handoffWindows(self: *Self, alloc: Allocator) !void {
     if (comptime builtin.os.tag != .windows) unreachable;
@@ -210,9 +200,8 @@ test "Windows handoff replaces a file after its parent exits" {
     const script_path = try tmp.dir.realPathFileAlloc(t.io, "handoff.ps1", t.allocator);
     defer t.allocator.free(script_path);
 
-    // Spawn the script exactly as `handoffWindows` does -- `-File` with absolute
-    // paths -- so its exit code is the process exit code and nothing depends on
-    // the working directory.
+    // Invoke the script the same way `handoffWindows` does; `-File` is what
+    // makes the script's exit code the process exit code.
     const command = try std.fmt.allocPrint(t.allocator,
         \\$parent = Start-Process powershell.exe -ArgumentList @('-NoProfile', '-NonInteractive', '-Command', 'Start-Sleep -Milliseconds 100') -WindowStyle Hidden -PassThru;
         \\& powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File '{s}' $parent.Id '{s}' '{s}' '{s}';

--- a/src/cli/update/StagedExecutable.zig
+++ b/src/cli/update/StagedExecutable.zig
@@ -19,8 +19,8 @@ pub const InstallResult = enum {
 /// Creates a temporary file beside `executable_path` with matching permissions.
 /// The executable path is borrowed for the lifetime of the returned value.
 pub fn new(io: Io, executable_path: []const u8) !Self {
-    const directory_path = std.fs.path.dirname(executable_path) orelse return error.InvalidExecutablePath;
-    const basename = std.fs.path.basename(executable_path);
+    const directory_path = path.dirname(executable_path) orelse return error.InvalidExecutablePath;
+    const basename = path.basename(executable_path);
 
     var directory = try Io.Dir.openDirAbsolute(io, directory_path, .{});
     errdefer directory.close(io);
@@ -82,7 +82,7 @@ fn handoffWindows(self: *Self, alloc: Allocator) !void {
     if (comptime builtin.os.tag != .windows) unreachable;
 
     const staged_basename = std.fmt.hex(self.staged.file_basename_hex);
-    const staged_path = try std.fs.path.join(alloc, &.{ self.directory_path, &staged_basename });
+    const staged_path = try path.join(alloc, &.{ self.directory_path, &staged_basename });
     defer alloc.free(staged_path);
 
     var helper_basename_buffer: [staged_basename.len + ".ps1".len]u8 = undefined;
@@ -95,7 +95,7 @@ fn handoffWindows(self: *Self, alloc: Allocator) !void {
     defer if (helper_file_open) helper_file.close(self.io);
     errdefer self.staged.dir.deleteFile(self.io, helper_basename) catch {};
 
-    const helper_path = try std.fs.path.join(alloc, &.{ self.directory_path, helper_basename });
+    const helper_path = try path.join(alloc, &.{ self.directory_path, helper_basename });
     defer alloc.free(helper_path);
     const parent_pid_arg = try std.fmt.allocPrint(alloc, "{d}", .{std.os.windows.GetCurrentProcessId()});
     defer alloc.free(parent_pid_arg);
@@ -134,6 +134,7 @@ fn handoffWindows(self: *Self, alloc: Allocator) !void {
 const std = @import("std");
 const builtin = @import("builtin");
 
+const path = std.fs.path;
 const Allocator = std.mem.Allocator;
 const Io = std.Io;
 

--- a/src/cli/update/release.zig
+++ b/src/cli/update/release.zig
@@ -1,0 +1,214 @@
+//! GitHub release metadata parsing and target selection.
+
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
+const maximum_asset_size = 128 * 1024 * 1024;
+
+pub const Digest = [Sha256.digest_length]u8;
+
+pub const Metadata = struct {
+    tag_name: []const u8,
+    assets: []const Asset,
+};
+
+pub const Asset = struct {
+    name: []const u8,
+    browser_download_url: []const u8,
+    digest: ?[]const u8 = null,
+    size: u64,
+};
+
+pub const ValidatedAsset = struct {
+    download_url: []const u8,
+    size: u64,
+    digest: Digest,
+};
+
+// Metadata and version parsing
+
+/// Parses only the GitHub fields the updater consumes.
+pub fn parseMetadata(alloc: Allocator, json: []const u8) !std.json.Parsed(Metadata) {
+    return std.json.parseFromSlice(Metadata, alloc, json, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+}
+
+/// Accepts release versions with or without the conventional leading `v`.
+pub fn parseVersion(version: []const u8) !std.SemanticVersion {
+    const normalized = if (std.mem.startsWith(u8, version, "v")) version[1..] else version;
+    return std.SemanticVersion.parse(normalized);
+}
+
+// Target and asset selection
+
+/// Maps a compilation target to the corresponding published release asset.
+pub fn assetNameForTarget(comptime os: std.Target.Os.Tag, comptime arch: std.Target.Cpu.Arch) ?[]const u8 {
+    if (!isPublishedTarget(os, arch)) return null;
+
+    const extension = if (os == .windows) ".exe" else "";
+    return "zlint-" ++ @tagName(os) ++ "-" ++ @tagName(arch) ++ extension;
+}
+
+/// Selects an asset and validates its size, URL, and GitHub digest.
+pub fn selectAsset(metadata: Metadata, name: []const u8) !ValidatedAsset {
+    const asset = findAsset(metadata.assets, name) orelse return error.ReleaseAssetNotFound;
+    if (asset.size == 0 or asset.size > maximum_asset_size) return error.ReleaseAssetTooLarge;
+    if (!isHttps(asset.browser_download_url)) return error.InsecureDownloadUrl;
+
+    return .{
+        .download_url = asset.browser_download_url,
+        .size = asset.size,
+        .digest = try parseDigest(asset.digest orelse return error.ReleaseAssetMissingDigest),
+    };
+}
+
+pub fn verifyDigest(actual: Digest, expected: Digest) !void {
+    if (!std.crypto.timing_safe.eql(Digest, actual, expected)) return error.ChecksumMismatch;
+}
+
+fn findAsset(assets: []const Asset, name: []const u8) ?Asset {
+    for (assets) |asset| {
+        if (std.mem.eql(u8, asset.name, name)) return asset;
+    }
+    return null;
+}
+
+fn isPublishedTarget(comptime os: std.Target.Os.Tag, comptime arch: std.Target.Cpu.Arch) bool {
+    return switch (os) {
+        .macos, .windows => arch == .aarch64 or arch == .x86_64,
+        .linux => arch == .aarch64 or
+            arch == .x86_64 or
+            arch == .riscv64 or
+            arch == .loongarch64,
+        else => false,
+    };
+}
+
+fn parseDigest(digest: []const u8) !Digest {
+    const prefix = "sha256:";
+    if (!std.mem.startsWith(u8, digest, prefix)) return error.InvalidDigest;
+
+    const encoded = digest[prefix.len..];
+    if (encoded.len != Sha256.digest_length * 2) return error.InvalidDigest;
+
+    var result: Digest = undefined;
+    _ = std.fmt.hexToBytes(&result, encoded) catch return error.InvalidDigest;
+    return result;
+}
+
+fn isHttps(url: []const u8) bool {
+    const uri = std.Uri.parse(url) catch return false;
+    return std.ascii.eqlIgnoreCase(uri.scheme, "https");
+}
+
+const t = std.testing;
+
+test "semantic versions are normalized and ordered" {
+    try t.expectEqual(.eq, (try parseVersion("v1.2.3")).order(try parseVersion("1.2.3")));
+    try t.expectEqual(.lt, (try parseVersion("v0.0.0")).order(try parseVersion("v0.9.1")));
+    try t.expectEqual(.gt, (try parseVersion("v1.0.0")).order(try parseVersion("v0.9.1")));
+    try t.expectEqual(.lt, (try parseVersion("v1.0.0-rc.1")).order(try parseVersion("v1.0.0")));
+    try t.expectError(error.InvalidVersion, parseVersion("not-a-version"));
+}
+
+test "asset names cover every published target" {
+    const cases = [_]struct { std.Target.Os.Tag, std.Target.Cpu.Arch, []const u8 }{
+        .{ .macos, .aarch64, "zlint-macos-aarch64" },
+        .{ .macos, .x86_64, "zlint-macos-x86_64" },
+        .{ .linux, .aarch64, "zlint-linux-aarch64" },
+        .{ .linux, .x86_64, "zlint-linux-x86_64" },
+        .{ .linux, .riscv64, "zlint-linux-riscv64" },
+        .{ .linux, .loongarch64, "zlint-linux-loongarch64" },
+        .{ .windows, .aarch64, "zlint-windows-aarch64.exe" },
+        .{ .windows, .x86_64, "zlint-windows-x86_64.exe" },
+    };
+    inline for (cases) |case| try t.expectEqualStrings(case[2], assetNameForTarget(case[0], case[1]).?);
+
+    try t.expect(assetNameForTarget(.macos, .riscv64) == null);
+    try t.expect(assetNameForTarget(.freebsd, .x86_64) == null);
+}
+
+test "metadata parsing ignores fields added by GitHub" {
+    const json =
+        \\{
+        \\  "tag_name": "v1.2.3",
+        \\  "ignored": true,
+        \\  "assets": [{
+        \\    "name": "zlint-linux-x86_64",
+        \\    "browser_download_url": "https://example.com/zlint",
+        \\    "digest": "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        \\    "size": 3,
+        \\    "ignored": "value"
+        \\  }]
+        \\}
+    ;
+    var parsed = try parseMetadata(t.allocator, json);
+    defer parsed.deinit();
+
+    try t.expectEqualStrings("v1.2.3", parsed.value.tag_name);
+    const asset = try selectAsset(parsed.value, "zlint-linux-x86_64");
+    try t.expectEqual(@as(u64, 3), asset.size);
+}
+
+test "malformed metadata is rejected" {
+    try t.expectError(error.UnexpectedEndOfInput, parseMetadata(t.allocator, "{"));
+}
+
+test "asset selection validates release metadata" {
+    const digest = "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    const valid = Asset{
+        .name = "zlint-linux-x86_64",
+        .browser_download_url = "https://example.com/zlint",
+        .digest = digest,
+        .size = 3,
+    };
+    const metadata = Metadata{ .tag_name = "v1.0.0", .assets = &.{valid} };
+
+    _ = try selectAsset(metadata, valid.name);
+    try t.expectError(error.ReleaseAssetNotFound, selectAsset(metadata, "zlint-linux-aarch64"));
+
+    var invalid = valid;
+    invalid.size = 0;
+    try expectInvalidAsset(error.ReleaseAssetTooLarge, invalid);
+    invalid.size = maximum_asset_size + 1;
+    try expectInvalidAsset(error.ReleaseAssetTooLarge, invalid);
+
+    invalid = valid;
+    invalid.browser_download_url = "http://example.com/zlint";
+    try expectInvalidAsset(error.InsecureDownloadUrl, invalid);
+
+    invalid = valid;
+    invalid.digest = null;
+    try expectInvalidAsset(error.ReleaseAssetMissingDigest, invalid);
+    invalid.digest = "sha256:invalid";
+    try expectInvalidAsset(error.InvalidDigest, invalid);
+}
+
+test "SHA-256 digests require GitHub's exact encoding" {
+    const encoded = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    var expected: Digest = undefined;
+    Sha256.hash("abc", &expected, .{});
+
+    try t.expectEqual(expected, try parseDigest("sha256:" ++ encoded));
+    try t.expectError(error.InvalidDigest, parseDigest(encoded));
+    try t.expectError(error.InvalidDigest, parseDigest("sha256:abcd"));
+    try t.expectError(error.InvalidDigest, parseDigest("sha256:" ++ ("z" ** 64)));
+}
+
+test "digest verification rejects mismatches" {
+    var actual: Digest = undefined;
+    var expected: Digest = undefined;
+    Sha256.hash("actual", &actual, .{});
+    Sha256.hash("expected", &expected, .{});
+
+    try t.expectError(error.ChecksumMismatch, verifyDigest(actual, expected));
+}
+
+fn expectInvalidAsset(expected_error: anyerror, asset: Asset) !void {
+    const metadata = Metadata{ .tag_name = "v1.0.0", .assets = &.{asset} };
+    try t.expectError(expected_error, selectAsset(metadata, asset.name));
+}

--- a/src/cli/update/release.zig
+++ b/src/cli/update/release.zig
@@ -12,6 +12,27 @@ pub const Digest = [Sha256.digest_length]u8;
 pub const Metadata = struct {
     tag_name: []const u8,
     assets: []const Asset,
+
+    /// Parses only the GitHub fields the updater consumes.
+    pub fn parseFromSlice(alloc: Allocator, json: []const u8) !std.json.Parsed(Metadata) {
+        return std.json.parseFromSlice(Metadata, alloc, json, .{
+            .allocate = .alloc_always,
+            .ignore_unknown_fields = true,
+        });
+    }
+
+    /// Selects an asset and validates its size, URL, and GitHub digest.
+    pub fn selectAsset(metadata: Metadata, name: []const u8) !Asset.Validated {
+        const asset = findAsset(metadata.assets, name) orelse return error.ReleaseAssetNotFound;
+        if (asset.size == 0 or asset.size > maximum_asset_size) return error.ReleaseAssetTooLarge;
+        if (!isHttps(asset.browser_download_url)) return error.InsecureDownloadUrl;
+
+        return .{
+            .download_url = asset.browser_download_url,
+            .size = asset.size,
+            .digest = try parseDigest(asset.digest orelse return error.ReleaseAssetMissingDigest),
+        };
+    }
 };
 
 pub const Asset = struct {
@@ -19,23 +40,14 @@ pub const Asset = struct {
     browser_download_url: []const u8,
     digest: ?[]const u8 = null,
     size: u64,
-};
-
-pub const ValidatedAsset = struct {
-    download_url: []const u8,
-    size: u64,
-    digest: Digest,
+    const Validated = struct {
+        download_url: []const u8,
+        size: u64,
+        digest: Digest,
+    };
 };
 
 // Metadata and version parsing
-
-/// Parses only the GitHub fields the updater consumes.
-pub fn parseMetadata(alloc: Allocator, json: []const u8) !std.json.Parsed(Metadata) {
-    return std.json.parseFromSlice(Metadata, alloc, json, .{
-        .allocate = .alloc_always,
-        .ignore_unknown_fields = true,
-    });
-}
 
 /// Accepts release versions with or without the conventional leading `v`.
 pub fn parseVersion(version: []const u8) !std.SemanticVersion {
@@ -51,19 +63,6 @@ pub fn assetNameForTarget(comptime os: std.Target.Os.Tag, comptime arch: std.Tar
 
     const extension = if (os == .windows) ".exe" else "";
     return "zlint-" ++ @tagName(os) ++ "-" ++ @tagName(arch) ++ extension;
-}
-
-/// Selects an asset and validates its size, URL, and GitHub digest.
-pub fn selectAsset(metadata: Metadata, name: []const u8) !ValidatedAsset {
-    const asset = findAsset(metadata.assets, name) orelse return error.ReleaseAssetNotFound;
-    if (asset.size == 0 or asset.size > maximum_asset_size) return error.ReleaseAssetTooLarge;
-    if (!isHttps(asset.browser_download_url)) return error.InsecureDownloadUrl;
-
-    return .{
-        .download_url = asset.browser_download_url,
-        .size = asset.size,
-        .digest = try parseDigest(asset.digest orelse return error.ReleaseAssetMissingDigest),
-    };
 }
 
 pub fn verifyDigest(actual: Digest, expected: Digest) !void {
@@ -146,16 +145,16 @@ test "metadata parsing ignores fields added by GitHub" {
         \\  }]
         \\}
     ;
-    var parsed = try parseMetadata(t.allocator, json);
+    var parsed = try Metadata.parseFromSlice(t.allocator, json);
     defer parsed.deinit();
 
     try t.expectEqualStrings("v1.2.3", parsed.value.tag_name);
-    const asset = try selectAsset(parsed.value, "zlint-linux-x86_64");
+    const asset = try parsed.value.selectAsset("zlint-linux-x86_64");
     try t.expectEqual(@as(u64, 3), asset.size);
 }
 
 test "malformed metadata is rejected" {
-    try t.expectError(error.UnexpectedEndOfInput, parseMetadata(t.allocator, "{"));
+    try t.expectError(error.UnexpectedEndOfInput, Metadata.parseFromSlice(t.allocator, "{"));
 }
 
 test "asset selection validates release metadata" {
@@ -168,8 +167,8 @@ test "asset selection validates release metadata" {
     };
     const metadata = Metadata{ .tag_name = "v1.0.0", .assets = &.{valid} };
 
-    _ = try selectAsset(metadata, valid.name);
-    try t.expectError(error.ReleaseAssetNotFound, selectAsset(metadata, "zlint-linux-aarch64"));
+    _ = try metadata.selectAsset(valid.name);
+    try t.expectError(error.ReleaseAssetNotFound, metadata.selectAsset("zlint-linux-aarch64"));
 
     var invalid = valid;
     invalid.size = 0;
@@ -210,5 +209,5 @@ test "digest verification rejects mismatches" {
 
 fn expectInvalidAsset(expected_error: anyerror, asset: Asset) !void {
     const metadata = Metadata{ .tag_name = "v1.0.0", .assets = &.{asset} };
-    try t.expectError(expected_error, selectAsset(metadata, asset.name));
+    try t.expectError(expected_error, metadata.selectAsset(asset.name));
 }

--- a/src/cli/update/release.zig
+++ b/src/cli/update/release.zig
@@ -94,6 +94,8 @@ fn parseDigest(digest: []const u8) !Digest {
     const encoded = digest[prefix.len..];
     if (encoded.len != Sha256.digest_length * 2) return error.InvalidDigest;
 
+    // SAFETY: `encoded` is exactly twice the digest length, so a successful
+    // `hexToBytes` writes every byte.
     var result: Digest = undefined;
     _ = std.fmt.hexToBytes(&result, encoded) catch return error.InvalidDigest;
     return result;

--- a/src/cli/update/release.zig
+++ b/src/cli/update/release.zig
@@ -21,7 +21,6 @@ pub const Metadata = struct {
         });
     }
 
-
     /// Selects an asset and validates its size, URL, and digest.
     pub fn selectAsset(metadata: Metadata, name: []const u8) !Asset.Validated {
         const asset = findAsset(metadata.assets, name) orelse return error.ReleaseAssetNotFound;

--- a/src/cli/update/release.zig
+++ b/src/cli/update/release.zig
@@ -21,7 +21,8 @@ pub const Metadata = struct {
         });
     }
 
-    /// Selects an asset and validates its size, URL, and GitHub digest.
+
+    /// Selects an asset and validates its size, URL, and digest.
     pub fn selectAsset(metadata: Metadata, name: []const u8) !Asset.Validated {
         const asset = findAsset(metadata.assets, name) orelse return error.ReleaseAssetNotFound;
         if (asset.size == 0 or asset.size > maximum_asset_size) return error.ReleaseAssetTooLarge;
@@ -47,17 +48,12 @@ pub const Asset = struct {
     };
 };
 
-// Metadata and version parsing
-
 /// Accepts release versions with or without the conventional leading `v`.
 pub fn parseVersion(version: []const u8) !std.SemanticVersion {
     const normalized = if (std.mem.startsWith(u8, version, "v")) version[1..] else version;
     return std.SemanticVersion.parse(normalized);
 }
 
-// Target and asset selection
-
-/// Maps a compilation target to the corresponding published release asset.
 pub fn assetNameForTarget(comptime os: std.Target.Os.Tag, comptime arch: std.Target.Cpu.Arch) ?[]const u8 {
     if (!isPublishedTarget(os, arch)) return null;
 

--- a/src/cli/update/windows_handoff.ps1
+++ b/src/cli/update/windows_handoff.ps1
@@ -5,14 +5,13 @@ param(
   [string]$ScriptPath
 )
 
-$backup = "$Source.bak"
 $exitCode = 1
 
 try {
   Wait-Process -Id $ParentId -ErrorAction SilentlyContinue
   for ($i = 0; $i -lt 50; $i++) {
     try {
-      [System.IO.File]::Replace($Source, $Destination, $backup, $true)
+      [System.IO.File]::Replace($Source, $Destination, $null, $true)
       $exitCode = 0
       break
     } catch {
@@ -20,12 +19,12 @@ try {
     }
   }
 } finally {
-  if ($exitCode -eq 0) {
-    Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
-  } else {
-    if ((-not (Test-Path -LiteralPath $Destination)) -and (Test-Path -LiteralPath $backup)) {
-      Move-Item -LiteralPath $backup -Destination $Destination -Force
-    }
+  # ReplaceFile can fail with the destination already unlinked, leaving the
+  # verified download at $Source. Installing it beats leaving nothing.
+  if (-not (Test-Path -LiteralPath $Destination)) {
+    Move-Item -LiteralPath $Source -Destination $Destination -Force -ErrorAction SilentlyContinue
+  }
+  if (Test-Path -LiteralPath $Destination) {
     Remove-Item -LiteralPath $Source -Force -ErrorAction SilentlyContinue
   }
   Remove-Item -LiteralPath $ScriptPath -Force -ErrorAction SilentlyContinue

--- a/src/cli/update/windows_handoff.ps1
+++ b/src/cli/update/windows_handoff.ps1
@@ -10,9 +10,6 @@ function Resolve-FullPath([string]$Path) {
   return (Join-Path -Path $PWD.ProviderPath -ChildPath $Path)
 }
 
-# [System.IO.File] resolves relative paths against the process working
-# directory, which PowerShell does not keep in sync with its own location.
-# Anchor every path so both APIs agree.
 $Source = Resolve-FullPath $Source
 $Destination = Resolve-FullPath $Destination
 $ScriptPath = Resolve-FullPath $ScriptPath

--- a/src/cli/update/windows_handoff.ps1
+++ b/src/cli/update/windows_handoff.ps1
@@ -5,7 +5,20 @@ param(
   [string]$ScriptPath
 )
 
+function Resolve-FullPath([string]$Path) {
+  if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }
+  return (Join-Path -Path $PWD.ProviderPath -ChildPath $Path)
+}
+
+# [System.IO.File] resolves relative paths against the process working
+# directory, which PowerShell does not keep in sync with its own location.
+# Anchor every path so both APIs agree.
+$Source = Resolve-FullPath $Source
+$Destination = Resolve-FullPath $Destination
+$ScriptPath = Resolve-FullPath $ScriptPath
+
 $exitCode = 1
+$lastError = $null
 
 try {
   Wait-Process -Id $ParentId -ErrorAction SilentlyContinue
@@ -15,6 +28,7 @@ try {
       $exitCode = 0
       break
     } catch {
+      $lastError = $_
       Start-Sleep -Milliseconds 100
     }
   }
@@ -28,6 +42,10 @@ try {
     Remove-Item -LiteralPath $Source -Force -ErrorAction SilentlyContinue
   }
   Remove-Item -LiteralPath $ScriptPath -Force -ErrorAction SilentlyContinue
+}
+
+if ($exitCode -ne 0 -and $null -ne $lastError) {
+  [Console]::Error.WriteLine("failed to replace ${Destination}: $lastError")
 }
 
 exit $exitCode

--- a/src/cli/update/windows_handoff.ps1
+++ b/src/cli/update/windows_handoff.ps1
@@ -1,0 +1,34 @@
+param(
+  [int]$ParentId,
+  [string]$Source,
+  [string]$Destination,
+  [string]$ScriptPath
+)
+
+$backup = "$Source.bak"
+$exitCode = 1
+
+try {
+  Wait-Process -Id $ParentId -ErrorAction SilentlyContinue
+  for ($i = 0; $i -lt 50; $i++) {
+    try {
+      [System.IO.File]::Replace($Source, $Destination, $backup, $true)
+      $exitCode = 0
+      break
+    } catch {
+      Start-Sleep -Milliseconds 100
+    }
+  }
+} finally {
+  if ($exitCode -eq 0) {
+    Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
+  } else {
+    if ((-not (Test-Path -LiteralPath $Destination)) -and (Test-Path -LiteralPath $backup)) {
+      Move-Item -LiteralPath $backup -Destination $Destination -Force
+    }
+    Remove-Item -LiteralPath $Source -Force -ErrorAction SilentlyContinue
+  }
+  Remove-Item -LiteralPath $ScriptPath -Force -ErrorAction SilentlyContinue
+}
+
+exit $exitCode

--- a/src/cli/update/windows_handoff.ps1
+++ b/src/cli/update/windows_handoff.ps1
@@ -21,7 +21,7 @@ try {
   Wait-Process -Id $ParentId -ErrorAction SilentlyContinue
   for ($i = 0; $i -lt 50; $i++) {
     try {
-      [System.IO.File]::Replace($Source, $Destination, $null, $true)
+      [System.IO.File]::Replace($Source, $Destination, [NullString]::Value, $true)
       $exitCode = 0
       break
     } catch {
@@ -42,7 +42,7 @@ try {
 }
 
 if ($exitCode -ne 0 -and $null -ne $lastError) {
-  [Console]::Error.WriteLine("failed to replace ${Destination}: $lastError")
+  [Console]::Error.WriteLine("failed to replace ${Destination} with ${Source}: $lastError")
 }
 
 exit $exitCode

--- a/src/cli/update_command.zig
+++ b/src/cli/update_command.zig
@@ -16,8 +16,20 @@ const usage =
     \\
     \\Download, verify, and install the latest stable version of zlint.
     \\
+    \\Aliases: upgrade, up
+    \\
     \\-h, --help  Show this help message
 ;
+
+/// Names that select the updater when used as the first argument.
+const command_names = [_][]const u8{ "update", "upgrade", "up" };
+
+fn isUpdateCommand(arg: []const u8) bool {
+    for (command_names) |name| {
+        if (std.mem.eql(u8, arg, name)) return true;
+    }
+    return false;
+}
 
 pub fn isCommand(alloc: Allocator, args: std.process.Args) !bool {
     var argv = try std.process.Args.Iterator.initAllocator(args, alloc);
@@ -34,6 +46,7 @@ pub fn run(
 ) u8 {
     const command = parseArgs(alloc, args) catch |err| {
         printError(io, "invalid update command: {s}", .{@errorName(err)});
+        printStderr(io, "{s}\n", .{usage});
         return 1;
     };
     if (command == .help) {
@@ -62,14 +75,14 @@ fn isCommandIterator(args_iter: anytype) bool {
     var argv = args_iter.*;
     _ = argv.next() orelse return false;
     const command = argv.next() orelse return false;
-    return std.mem.eql(u8, command, "update");
+    return isUpdateCommand(command);
 }
 
 fn parseIterator(args_iter: anytype) !Command {
     var argv = args_iter.*;
     _ = argv.next() orelse return error.MissingCommand;
     const command = argv.next() orelse return error.MissingCommand;
-    if (!std.mem.eql(u8, command, "update")) return error.InvalidCommand;
+    if (!isUpdateCommand(command)) return error.InvalidCommand;
 
     var parsed: Command = .update;
     while (argv.next()) |arg| {
@@ -98,12 +111,21 @@ fn performUpdate(
 
     const metadata_json = client.fetchRelease(latest_release_url) catch |err| switch (err) {
         error.StreamTooLong => return error.ReleaseMetadataTooLarge,
-        error.UnknownHostName => return error.CouldNotFetchRelease,
+        error.UnknownHostName,
+        error.NameServerFailure,
+        error.ConnectionRefused,
+        error.ConnectionResetByPeer,
+        error.NetworkUnreachable,
+        => return error.CouldNotFetchRelease,
         else => |e| return e,
     };
     defer alloc.free(metadata_json);
 
-    var parsed_release = release.Metadata.parseFromSlice(alloc, metadata_json) catch return error.ReleaseRequestFailed;
+    var parsed_release = release.Metadata.parseFromSlice(alloc, metadata_json) catch |err| switch (err) {
+        // A local allocation failure is not GitHub sending us bad metadata.
+        error.OutOfMemory => |e| return e,
+        else => return error.ReleaseRequestFailed,
+    };
     defer parsed_release.deinit();
     const metadata = parsed_release.value;
 
@@ -173,6 +195,10 @@ fn printUpdateError(io: Io, err: anyerror, current_version: []const u8) void {
         error.HttpServerError => printError(io, "GitHub is temporarily unavailable (HTTP 5xx); try again later", .{}),
         error.HttpUnauthorized => printError(io, "GitHub rejected the update request (HTTP 401 Unauthorized)", .{}),
         error.HttpUnexpectedStatus => printError(io, "GitHub returned an unexpected HTTP response", .{}),
+        error.HttpRedirectLocationMissing => printError(io, "GitHub sent a redirect without a location", .{}),
+        error.TooManyHttpRedirects => printError(io, "GitHub redirected the update request too many times", .{}),
+        error.InsecureRedirect => printError(io, "the update request was redirected to a non-HTTPS URL; refusing to continue", .{}),
+        error.RedirectLocationTooLong => printError(io, "GitHub redirected the update request to an excessively long URL", .{}),
         error.InsecureDownloadUrl => printError(io, "GitHub returned a non-HTTPS download URL", .{}),
         error.InvalidCurrentVersion => printError(io, "the installed version is not a valid semantic version: {s}", .{current_version}),
         error.InvalidDigest => printError(io, "GitHub returned an invalid SHA-256 digest", .{}),
@@ -195,6 +221,13 @@ fn printStdout(io: Io, comptime format: []const u8, args: anytype) void {
     writer.interface.flush() catch return;
 }
 
+fn printStderr(io: Io, comptime format: []const u8, args: anytype) void {
+    var buffer: [1024]u8 = undefined;
+    var writer = Io.File.stderr().writer(io, &buffer);
+    writer.interface.print(format, args) catch return;
+    writer.interface.flush() catch return;
+}
+
 fn printError(io: Io, comptime format: []const u8, args: anytype) void {
     var buffer: [1024]u8 = undefined;
     var writer = Io.File.stderr().writer(io, &buffer);
@@ -207,22 +240,32 @@ fn printError(io: Io, comptime format: []const u8, args: anytype) void {
 const t = std.testing;
 
 test "update is recognized only as the first argument" {
-    var command = std.mem.splitScalar(u8, "zlint update", ' ');
-    try t.expect(isCommandIterator(&command));
+    inline for (.{ "zlint update", "zlint upgrade", "zlint up" }) |argv| {
+        var command = std.mem.splitScalar(u8, argv, ' ');
+        try t.expect(isCommandIterator(&command));
+    }
 
-    var escaped = std.mem.splitScalar(u8, "zlint -- update", ' ');
-    try t.expect(!isCommandIterator(&escaped));
+    inline for (.{ "zlint -- update", "zlint -- up" }) |argv| {
+        var escaped = std.mem.splitScalar(u8, argv, ' ');
+        try t.expect(!isCommandIterator(&escaped));
+    }
 
-    var path = std.mem.splitScalar(u8, "zlint src/update", ' ');
-    try t.expect(!isCommandIterator(&path));
+    inline for (.{ "zlint src/update", "zlint src/up", "zlint updated" }) |argv| {
+        var path = std.mem.splitScalar(u8, argv, ' ');
+        try t.expect(!isCommandIterator(&path));
+    }
 }
 
 test "update accepts only help flags" {
-    var update_args = std.mem.splitScalar(u8, "zlint update", ' ');
-    try t.expectEqual(.update, try parseIterator(&update_args));
+    inline for (.{ "zlint update", "zlint upgrade", "zlint up" }) |argv| {
+        var update_args = std.mem.splitScalar(u8, argv, ' ');
+        try t.expectEqual(.update, try parseIterator(&update_args));
+    }
 
-    var short_help = std.mem.splitScalar(u8, "zlint update -h", ' ');
-    try t.expectEqual(.help, try parseIterator(&short_help));
+    inline for (.{ "zlint update -h", "zlint upgrade -h", "zlint up --help" }) |argv| {
+        var help_args = std.mem.splitScalar(u8, argv, ' ');
+        try t.expectEqual(.help, try parseIterator(&help_args));
+    }
 
     var long_help = std.mem.splitScalar(u8, "zlint update --help", ' ');
     try t.expectEqual(.help, try parseIterator(&long_help));
@@ -232,4 +275,7 @@ test "update accepts only help flags" {
 
     var help_with_arg = std.mem.splitScalar(u8, "zlint update --help extra", ' ');
     try t.expectError(error.UnexpectedArgument, parseIterator(&help_with_arg));
+
+    var not_a_command = std.mem.splitScalar(u8, "zlint lint", ' ');
+    try t.expectError(error.InvalidCommand, parseIterator(&not_a_command));
 }

--- a/src/cli/update_command.zig
+++ b/src/cli/update_command.zig
@@ -61,8 +61,6 @@ pub fn run(
     return 0;
 }
 
-// Command-line parsing
-
 const Command = enum { update, help };
 
 fn parseArgs(alloc: Allocator, args: std.process.Args) !Command {
@@ -94,8 +92,6 @@ fn parseIterator(args_iter: anytype) !Command {
     }
     return parsed;
 }
-
-// Update workflow
 
 fn performUpdate(
     alloc: Allocator,
@@ -167,8 +163,6 @@ fn performUpdate(
     }
 }
 
-// User-facing output
-
 fn printAlreadyCurrent(io: Io, current_version: []const u8, latest_version: []const u8, path: []const u8) void {
     printStdout(io, "zlint {s} is already up to date (latest: {s}) at {s}\n", .{
         current_version,
@@ -198,6 +192,7 @@ fn printUpdateError(io: Io, err: anyerror, current_version: []const u8) void {
         error.HttpRedirectLocationMissing => printError(io, "GitHub sent a redirect without a location", .{}),
         error.TooManyHttpRedirects => printError(io, "GitHub redirected the update request too many times", .{}),
         error.InsecureRedirect => printError(io, "the update request was redirected to a non-HTTPS URL; refusing to continue", .{}),
+        error.RedirectHostNotAllowed => printError(io, "the release metadata request was redirected away from GitHub; refusing to continue", .{}),
         error.RedirectLocationTooLong => printError(io, "GitHub redirected the update request to an excessively long URL", .{}),
         error.InsecureDownloadUrl => printError(io, "GitHub returned a non-HTTPS download URL", .{}),
         error.InvalidCurrentVersion => printError(io, "the installed version is not a valid semantic version: {s}", .{current_version}),

--- a/src/cli/update_command.zig
+++ b/src/cli/update_command.zig
@@ -1,0 +1,232 @@
+//! `zlint update` command parsing and update orchestration.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const UpdateClient = @import("update/Client.zig");
+const StagedExecutable = @import("update/StagedExecutable.zig");
+const release = @import("update/release.zig");
+
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+
+const latest_release_url = "https://api.github.com/repos/DonIsaac/zlint/releases/latest";
+const usage =
+    \\Usage: zlint update
+    \\
+    \\Download, verify, and install the latest stable version of zlint.
+    \\
+    \\-h, --help  Show this help message
+;
+
+pub fn isCommand(alloc: Allocator, args: std.process.Args) !bool {
+    var argv = try std.process.Args.Iterator.initAllocator(args, alloc);
+    defer argv.deinit();
+    return isCommandIterator(&argv);
+}
+
+pub fn run(
+    alloc: Allocator,
+    io: Io,
+    args: std.process.Args,
+    environ: std.process.Environ,
+    current_version: []const u8,
+) u8 {
+    const command = parseArgs(alloc, args) catch |err| {
+        printError(io, "invalid update command: {s}", .{@errorName(err)});
+        return 1;
+    };
+    if (command == .help) {
+        printStdout(io, "{s}\n", .{usage});
+        return 0;
+    }
+
+    performUpdate(alloc, io, environ, current_version) catch |err| {
+        printUpdateError(io, err, current_version);
+        return 1;
+    };
+    return 0;
+}
+
+// Command-line parsing
+
+const Command = enum { update, help };
+
+fn parseArgs(alloc: Allocator, args: std.process.Args) !Command {
+    var argv = try std.process.Args.Iterator.initAllocator(args, alloc);
+    defer argv.deinit();
+    return parseIterator(&argv);
+}
+
+fn isCommandIterator(args_iter: anytype) bool {
+    var argv = args_iter.*;
+    _ = argv.next() orelse return false;
+    const command = argv.next() orelse return false;
+    return std.mem.eql(u8, command, "update");
+}
+
+fn parseIterator(args_iter: anytype) !Command {
+    var argv = args_iter.*;
+    _ = argv.next() orelse return error.MissingCommand;
+    const command = argv.next() orelse return error.MissingCommand;
+    if (!std.mem.eql(u8, command, "update")) return error.InvalidCommand;
+
+    var parsed: Command = .update;
+    while (argv.next()) |arg| {
+        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+            parsed = .help;
+        } else {
+            return error.UnexpectedArgument;
+        }
+    }
+    return parsed;
+}
+
+// Update workflow
+
+fn performUpdate(
+    alloc: Allocator,
+    io: Io,
+    environ: std.process.Environ,
+    current_version_text: []const u8,
+) anyerror!void {
+    const asset_name = release.assetNameForTarget(builtin.os.tag, builtin.cpu.arch) orelse
+        return error.UnsupportedTarget;
+
+    var client = try UpdateClient.init(alloc, io, environ);
+    defer client.deinit();
+
+    const metadata_json = client.fetchRelease(latest_release_url) catch |err| switch (err) {
+        error.StreamTooLong => return error.ReleaseMetadataTooLarge,
+        else => |e| return e,
+    };
+    defer alloc.free(metadata_json);
+
+    var parsed_release = release.parseMetadata(alloc, metadata_json) catch return error.ReleaseRequestFailed;
+    defer parsed_release.deinit();
+
+    const latest_version = release.parseVersion(parsed_release.value.tag_name) catch return error.InvalidReleaseVersion;
+    const current_version = release.parseVersion(current_version_text) catch return error.InvalidCurrentVersion;
+    const executable_path = try std.process.executablePathAlloc(io, alloc);
+    defer alloc.free(executable_path);
+
+    if (current_version.order(latest_version) != .lt) {
+        printAlreadyCurrent(io, current_version_text, parsed_release.value.tag_name, executable_path);
+        return;
+    }
+
+    const asset = try release.selectAsset(parsed_release.value, asset_name);
+    printStdout(io, "Updating zlint from {s} to {s}...\n", .{
+        current_version_text,
+        parsed_release.value.tag_name,
+    });
+
+    var staged = try StagedExecutable.new(io, executable_path);
+    defer staged.deinit();
+
+    const actual_digest = client.downloadAsset(asset.download_url, asset.size, staged.file()) catch |err| switch (err) {
+        error.EndOfStream, error.StreamTooLong => return error.DownloadSizeMismatch,
+        else => |e| return e,
+    };
+    try staged.finishWriting();
+    try release.verifyDigest(actual_digest, asset.digest);
+
+    switch (try staged.install(alloc)) {
+        .replaced => printStdout(io, "Updated zlint to {s} at {s}\n", .{
+            parsed_release.value.tag_name,
+            executable_path,
+        }),
+        .deferred => printStdout(io, "Verified zlint {s}; installation will finish after this process exits ({s})\n", .{
+            parsed_release.value.tag_name,
+            executable_path,
+        }),
+    }
+}
+
+// User-facing output
+
+fn printAlreadyCurrent(io: Io, current_version: []const u8, latest_version: []const u8, path: []const u8) void {
+    printStdout(io, "zlint {s} is already up to date (latest: {s}) at {s}\n", .{
+        current_version,
+        latest_version,
+        path,
+    });
+}
+
+fn printUpdateError(io: Io, err: anyerror, current_version: []const u8) void {
+    switch (err) {
+        error.UnsupportedTarget => printError(io, "no release binary is available for {s}-{s}", .{
+            @tagName(builtin.os.tag),
+            @tagName(builtin.cpu.arch),
+        }),
+        error.InvalidCurrentVersion => printError(io, "the installed version is not a valid semantic version: {s}", .{current_version}),
+        error.InvalidReleaseVersion => printError(io, "GitHub returned an invalid release version", .{}),
+        error.ReleaseMetadataTooLarge => printError(io, "GitHub release metadata exceeded {d} bytes", .{UpdateClient.metadata_limit}),
+        error.ReleaseRequestFailed => printError(io, "GitHub returned invalid release metadata", .{}),
+        error.HttpBadRequest => printError(io, "GitHub rejected the update request (HTTP 400 Bad Request)", .{}),
+        error.HttpUnauthorized => printError(io, "GitHub rejected the update request (HTTP 401 Unauthorized)", .{}),
+        error.HttpForbidden => printError(io, "GitHub refused the update request (HTTP 403 Forbidden); the API rate limit may be exhausted", .{}),
+        error.HttpNotFound => printError(io, "the requested GitHub release resource was not found (HTTP 404 Not Found)", .{}),
+        error.HttpRequestTimeout => printError(io, "the update request timed out (HTTP 408 Request Timeout)", .{}),
+        error.HttpRateLimited => printError(io, "GitHub rate-limited the update request (HTTP 429 Too Many Requests); try again later", .{}),
+        error.HttpClientError => printError(io, "GitHub rejected the update request (HTTP 4xx)", .{}),
+        error.HttpServerError => printError(io, "GitHub is temporarily unavailable (HTTP 5xx); try again later", .{}),
+        error.HttpUnexpectedStatus => printError(io, "GitHub returned an unexpected HTTP response", .{}),
+        error.ReleaseAssetNotFound => printError(io, "the latest release does not contain a binary for this target", .{}),
+        error.ReleaseAssetTooLarge => printError(io, "the release binary is unexpectedly large", .{}),
+        error.ReleaseAssetMissingDigest => printError(io, "the release asset does not have a SHA-256 digest", .{}),
+        error.InvalidDigest => printError(io, "GitHub returned an invalid SHA-256 digest", .{}),
+        error.InsecureDownloadUrl => printError(io, "GitHub returned a non-HTTPS download URL", .{}),
+        error.DownloadSizeMismatch => printError(io, "the downloaded binary size does not match the release metadata", .{}),
+        error.ChecksumMismatch => printError(io, "the downloaded binary failed SHA-256 verification; the installed binary was not changed", .{}),
+        error.AccessDenied, error.PermissionDenied, error.ReadOnlyFileSystem => printError(io, "cannot replace the installed binary; rerun with permission to write its directory", .{}),
+        error.WindowsHandoffFailed => printError(io, "could not start the Windows update handoff", .{}),
+        else => printError(io, "update failed: {s}", .{@errorName(err)}),
+    }
+}
+
+fn printStdout(io: Io, comptime format: []const u8, args: anytype) void {
+    var buffer: [1024]u8 = undefined;
+    var writer = Io.File.stdout().writer(io, &buffer);
+    writer.interface.print(format, args) catch return;
+    writer.interface.flush() catch return;
+}
+
+fn printError(io: Io, comptime format: []const u8, args: anytype) void {
+    var buffer: [1024]u8 = undefined;
+    var writer = Io.File.stderr().writer(io, &buffer);
+    writer.interface.writeAll("error: ") catch return;
+    writer.interface.print(format, args) catch return;
+    writer.interface.writeByte('\n') catch return;
+    writer.interface.flush() catch return;
+}
+
+const t = std.testing;
+
+test "update is recognized only as the first argument" {
+    var command = std.mem.splitScalar(u8, "zlint update", ' ');
+    try t.expect(isCommandIterator(&command));
+
+    var escaped = std.mem.splitScalar(u8, "zlint -- update", ' ');
+    try t.expect(!isCommandIterator(&escaped));
+
+    var path = std.mem.splitScalar(u8, "zlint src/update", ' ');
+    try t.expect(!isCommandIterator(&path));
+}
+
+test "update accepts only help flags" {
+    var update_args = std.mem.splitScalar(u8, "zlint update", ' ');
+    try t.expectEqual(.update, try parseIterator(&update_args));
+
+    var short_help = std.mem.splitScalar(u8, "zlint update -h", ' ');
+    try t.expectEqual(.help, try parseIterator(&short_help));
+
+    var long_help = std.mem.splitScalar(u8, "zlint update --help", ' ');
+    try t.expectEqual(.help, try parseIterator(&long_help));
+
+    var invalid = std.mem.splitScalar(u8, "zlint update --force", ' ');
+    try t.expectError(error.UnexpectedArgument, parseIterator(&invalid));
+
+    var help_with_arg = std.mem.splitScalar(u8, "zlint update --help extra", ' ');
+    try t.expectError(error.UnexpectedArgument, parseIterator(&help_with_arg));
+}

--- a/src/cli/update_command.zig
+++ b/src/cli/update_command.zig
@@ -98,24 +98,26 @@ fn performUpdate(
 
     const metadata_json = client.fetchRelease(latest_release_url) catch |err| switch (err) {
         error.StreamTooLong => return error.ReleaseMetadataTooLarge,
+        error.UnknownHostName => return error.CouldNotFetchRelease,
         else => |e| return e,
     };
     defer alloc.free(metadata_json);
 
-    var parsed_release = release.parseMetadata(alloc, metadata_json) catch return error.ReleaseRequestFailed;
+    var parsed_release = release.Metadata.parseFromSlice(alloc, metadata_json) catch return error.ReleaseRequestFailed;
     defer parsed_release.deinit();
+    const metadata = parsed_release.value;
 
-    const latest_version = release.parseVersion(parsed_release.value.tag_name) catch return error.InvalidReleaseVersion;
+    const latest_version = release.parseVersion(metadata.tag_name) catch return error.InvalidReleaseVersion;
     const current_version = release.parseVersion(current_version_text) catch return error.InvalidCurrentVersion;
     const executable_path = try std.process.executablePathAlloc(io, alloc);
     defer alloc.free(executable_path);
 
     if (current_version.order(latest_version) != .lt) {
-        printAlreadyCurrent(io, current_version_text, parsed_release.value.tag_name, executable_path);
+        printAlreadyCurrent(io, current_version_text, metadata.tag_name, executable_path);
         return;
     }
 
-    const asset = try release.selectAsset(parsed_release.value, asset_name);
+    const asset = try metadata.selectAsset(asset_name);
     printStdout(io, "Updating zlint from {s} to {s}...\n", .{
         current_version_text,
         parsed_release.value.tag_name,
@@ -155,32 +157,33 @@ fn printAlreadyCurrent(io: Io, current_version: []const u8, latest_version: []co
 
 fn printUpdateError(io: Io, err: anyerror, current_version: []const u8) void {
     switch (err) {
-        error.UnsupportedTarget => printError(io, "no release binary is available for {s}-{s}", .{
+        error.UnsupportedTarget => printError(io, "no release binary is available for {s}-{s}. Please compile from source or open an issue on GitHub.", .{
             @tagName(builtin.os.tag),
             @tagName(builtin.cpu.arch),
         }),
-        error.InvalidCurrentVersion => printError(io, "the installed version is not a valid semantic version: {s}", .{current_version}),
-        error.InvalidReleaseVersion => printError(io, "GitHub returned an invalid release version", .{}),
-        error.ReleaseMetadataTooLarge => printError(io, "GitHub release metadata exceeded {d} bytes", .{UpdateClient.metadata_limit}),
-        error.ReleaseRequestFailed => printError(io, "GitHub returned invalid release metadata", .{}),
+        error.AccessDenied, error.PermissionDenied, error.ReadOnlyFileSystem => printError(io, "cannot replace the installed binary; rerun with permission to write its directory", .{}),
+        error.ChecksumMismatch => printError(io, "the downloaded binary failed SHA-256 verification; the installed binary was not changed", .{}),
+        error.DownloadSizeMismatch => printError(io, "the downloaded binary size does not match the release metadata", .{}),
         error.HttpBadRequest => printError(io, "GitHub rejected the update request (HTTP 400 Bad Request)", .{}),
-        error.HttpUnauthorized => printError(io, "GitHub rejected the update request (HTTP 401 Unauthorized)", .{}),
+        error.HttpClientError => printError(io, "GitHub rejected the update request (HTTP 4xx)", .{}),
         error.HttpForbidden => printError(io, "GitHub refused the update request (HTTP 403 Forbidden); the API rate limit may be exhausted", .{}),
         error.HttpNotFound => printError(io, "the requested GitHub release resource was not found (HTTP 404 Not Found)", .{}),
-        error.HttpRequestTimeout => printError(io, "the update request timed out (HTTP 408 Request Timeout)", .{}),
         error.HttpRateLimited => printError(io, "GitHub rate-limited the update request (HTTP 429 Too Many Requests); try again later", .{}),
-        error.HttpClientError => printError(io, "GitHub rejected the update request (HTTP 4xx)", .{}),
+        error.HttpRequestTimeout => printError(io, "the update request timed out (HTTP 408 Request Timeout)", .{}),
         error.HttpServerError => printError(io, "GitHub is temporarily unavailable (HTTP 5xx); try again later", .{}),
+        error.HttpUnauthorized => printError(io, "GitHub rejected the update request (HTTP 401 Unauthorized)", .{}),
         error.HttpUnexpectedStatus => printError(io, "GitHub returned an unexpected HTTP response", .{}),
+        error.InsecureDownloadUrl => printError(io, "GitHub returned a non-HTTPS download URL", .{}),
+        error.InvalidCurrentVersion => printError(io, "the installed version is not a valid semantic version: {s}", .{current_version}),
+        error.InvalidDigest => printError(io, "GitHub returned an invalid SHA-256 digest", .{}),
+        error.InvalidReleaseVersion => printError(io, "GitHub returned an invalid release version", .{}),
+        error.ReleaseAssetMissingDigest => printError(io, "the release asset does not have a SHA-256 digest", .{}),
         error.ReleaseAssetNotFound => printError(io, "the latest release does not contain a binary for this target", .{}),
         error.ReleaseAssetTooLarge => printError(io, "the release binary is unexpectedly large", .{}),
-        error.ReleaseAssetMissingDigest => printError(io, "the release asset does not have a SHA-256 digest", .{}),
-        error.InvalidDigest => printError(io, "GitHub returned an invalid SHA-256 digest", .{}),
-        error.InsecureDownloadUrl => printError(io, "GitHub returned a non-HTTPS download URL", .{}),
-        error.DownloadSizeMismatch => printError(io, "the downloaded binary size does not match the release metadata", .{}),
-        error.ChecksumMismatch => printError(io, "the downloaded binary failed SHA-256 verification; the installed binary was not changed", .{}),
-        error.AccessDenied, error.PermissionDenied, error.ReadOnlyFileSystem => printError(io, "cannot replace the installed binary; rerun with permission to write its directory", .{}),
+        error.ReleaseMetadataTooLarge => printError(io, "GitHub release metadata exceeded {d} bytes", .{UpdateClient.metadata_limit}),
+        error.ReleaseRequestFailed => printError(io, "GitHub returned invalid release metadata", .{}),
         error.WindowsHandoffFailed => printError(io, "could not start the Windows update handoff", .{}),
+        error.CouldNotFetchRelease => printError(io, "could not download binary from GitHub. Please check your internet connection.", .{}),
         else => printError(io, "update failed: {s}", .{@errorName(err)}),
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,6 +10,7 @@ const print = std.debug.print;
 const Options = @import("cli/Options.zig");
 const print_cmd = @import("cli/print_command.zig");
 const lint_cmd = @import("cli/lint_command.zig");
+const update_cmd = @import("cli/update_command.zig");
 
 // in debug builds, include more information for debugging memory leaks,
 // double-frees, etc.
@@ -30,6 +31,20 @@ pub fn main(init: std.process.Init) !u8 {
     };
     var stack = std.heap.stackFallback(16, alloc);
     const stack_alloc = stack.get();
+
+    const is_update = update_cmd.isCommand(stack_alloc, init.minimal.args) catch {
+        std.debug.print("error: ran out of memory while parsing command-line arguments\n", .{});
+        return 1;
+    };
+    if (is_update) {
+        return update_cmd.run(
+            alloc,
+            io,
+            init.minimal.args,
+            init.minimal.environ,
+            config.version,
+        );
+    }
 
     var err: Error = undefined;
     var opts = Options.parseArgv(stack_alloc, io, init.minimal.args, &err) catch |e| switch (e) {
@@ -84,6 +99,7 @@ test {
     std.testing.refAllDecls(Options);
     std.testing.refAllDecls(lint_cmd);
     std.testing.refAllDecls(print_cmd);
+    std.testing.refAllDecls(update_cmd);
     std.testing.refAllDecls(@import("cli/lint_config.zig"));
     std.testing.refAllDecls(@import("walk/Walker.zig"));
     std.testing.refAllDecls(@import("walk/glob.zig"));


### PR DESCRIPTION
Adds `zlint update` as a first-position-only command while preserving `zlint -- update` for linting a directory named `update`.

The updater fetches the latest stable GitHub release, selects the compiled target asset, avoids downgrades, streams a bounded download, verifies its size and SHA-256 digest, and reports actionable HTTP errors.

Verified binaries replace the installed executable atomically on macOS and Linux, while Windows uses a detached PowerShell handoff after the parent process exits.

CLI help and installation docs now expose the command:
```sh
zlint update
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `zlint update` to update direct binary installations to the latest stable release.
  * Added `upgrade` and `up` aliases, plus command help and validation.
  * Updates verify downloaded files before installation and preserve executable permissions.
  * Added platform-specific support for macOS, Windows, and Linux, including deferred Windows replacement.

* **Documentation**
  * Added installation guidance for updating direct binary installations.
  * Documented the new update command in CLI help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->