### PR TITLE
fix(reporter): use monotonic loading when updating statistics

### DIFF
--- a/src/linter/LintService.zig
+++ b/src/linter/LintService.zig
@@ -74,7 +74,7 @@ fn tryLintFile(self: *LintService, filepath: []u8) !void {
         if (errors) |e| {
             try self.reporter.reportErrors(e);
         } else {
-            _ = self.reporter.stats.num_errors.fetchAdd(1, .acquire);
+            self.reporter.stats.recordFailure();
         }
         return err;
     };

--- a/src/linter/LintService.zig
+++ b/src/linter/LintService.zig
@@ -67,7 +67,6 @@ fn tryLintFile(self: *LintService, filepath: []u8) !void {
         return e;
     };
 
-    errdefer self.allocator.free(filepath);
     var source = Source.init(self.allocator, self.io, file, filepath) catch |e| {
         self.reporter.stats.recordFailure();
         return e;

--- a/src/linter/LintService.zig
+++ b/src/linter/LintService.zig
@@ -63,10 +63,15 @@ pub fn lintFile(self: *LintService, filepath: []u8) void {
 fn tryLintFile(self: *LintService, filepath: []u8) !void {
     const file = Io.Dir.cwd().openFile(self.io, filepath, .{}) catch |e| {
         self.allocator.free(filepath);
+        self.reporter.stats.recordFailure();
         return e;
     };
 
-    var source = try Source.init(self.allocator, self.io, file, filepath);
+    errdefer self.allocator.free(filepath);
+    var source = Source.init(self.allocator, self.io, file, filepath) catch |e| {
+        self.reporter.stats.recordFailure();
+        return e;
+    };
     defer source.deinit();
     var errors: ?std.array_list.Managed(Error) = null;
 

--- a/src/reporter/Reporter.zig
+++ b/src/reporter/Reporter.zig
@@ -214,13 +214,18 @@ const Stats = struct {
                 else => {},
             }
         }
-        _ = self.num_files.fetchAdd(1, .acquire);
-        _ = self.num_errors.fetchAdd(num_errors, .acquire);
-        _ = self.num_warnings.fetchAdd(num_warnings, .acquire);
+        _ = self.num_files.fetchAdd(1, .monotonic);
+        _ = self.num_errors.fetchAdd(num_errors, .monotonic);
+        _ = self.num_warnings.fetchAdd(num_warnings, .monotonic);
+    }
+
+    pub fn recordFailure(self: *Stats) void {
+        _ = self.num_files.fetchAdd(1, .monotonic);
+        _ = self.num_errors.fetchAdd(1, .monotonic);
     }
 
     pub fn recordSuccess(self: *Stats) void {
-        _ = self.num_files.fetchAdd(1, .acquire);
+        _ = self.num_files.fetchAdd(1, .monotonic);
     }
 
     /// Get the number of linted files. Only call this after all files have been


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linting statistics so failures to process files are recorded consistently.
  * Ensured file and error totals include all linting failures, including issues encountered before linting completes.
  * Updated success and error reporting for more reliable results.
  * Improved the accuracy and consistency of summary statistics across linting runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->