### PR TITLE
feat(linter): Perform control flow analysis when rules need it

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -109,6 +109,14 @@ lint:
         bunx oxlint@latest -D correctness -D suspicious -D perf
     fi
 
+# Render a file's control flow graph into tmp/
+cfg file image_type='svg': build
+    #!/bin/bash
+    mkdir -p tmp
+    out="tmp/$(echo "{{file}}" | tr '/' '_')"
+    zig-out/bin/zlint --print-cfg "{{file}}" > "$out"
+    dot -T {{image_type}} -O "$out"
+
 codegen:
     zig build docs
     zig build config

--- a/apps/site/docs/rules/allocator-first-param.mdx
+++ b/apps/site/docs/rules/allocator-first-param.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"allocator-first-param","category":"style","default":"off","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"allocator-first-param","category":"style","default":"off","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `allocator-first-param`

--- a/apps/site/docs/rules/avoid-as.mdx
+++ b/apps/site/docs/rules/avoid-as.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"avoid-as","category":"pedantic","default":"warning","fix":{"kind":"fix","dangerous":false}}'
+rule: '{"name":"avoid-as","category":"pedantic","default":"warning","fix":{"kind":"fix","dangerous":false},"needs_cfg":false}'
 ---
 
 # `avoid-as`

--- a/apps/site/docs/rules/case-convention.mdx
+++ b/apps/site/docs/rules/case-convention.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"case-convention","category":"style","default":"off","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"case-convention","category":"style","default":"off","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `case-convention`

--- a/apps/site/docs/rules/duplicate-case.mdx
+++ b/apps/site/docs/rules/duplicate-case.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"duplicate-case","category":"suspicious","default":"off","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"duplicate-case","category":"suspicious","default":"off","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `duplicate-case`

--- a/apps/site/docs/rules/empty-file.mdx
+++ b/apps/site/docs/rules/empty-file.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"empty-file","category":"style","default":"warning","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"empty-file","category":"style","default":"warning","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `empty-file`

--- a/apps/site/docs/rules/homeless-try.mdx
+++ b/apps/site/docs/rules/homeless-try.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"homeless-try","category":"compiler","default":"err","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"homeless-try","category":"compiler","default":"err","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `homeless-try`

--- a/apps/site/docs/rules/line-length.mdx
+++ b/apps/site/docs/rules/line-length.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"line-length","category":"style","default":"off","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"line-length","category":"style","default":"off","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `line-length`

--- a/apps/site/docs/rules/must-return-ref.mdx
+++ b/apps/site/docs/rules/must-return-ref.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"must-return-ref","category":"suspicious","default":"warning","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"must-return-ref","category":"suspicious","default":"warning","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `must-return-ref`

--- a/apps/site/docs/rules/no-catch-return.mdx
+++ b/apps/site/docs/rules/no-catch-return.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"no-catch-return","category":"pedantic","default":"warning","fix":{"kind":"fix","dangerous":false}}'
+rule: '{"name":"no-catch-return","category":"pedantic","default":"warning","fix":{"kind":"fix","dangerous":false},"needs_cfg":false}'
 ---
 
 # `no-catch-return`

--- a/apps/site/docs/rules/no-print.mdx
+++ b/apps/site/docs/rules/no-print.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"no-print","category":"restriction","default":"warning","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"no-print","category":"restriction","default":"warning","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `no-print`

--- a/apps/site/docs/rules/no-return-try.mdx
+++ b/apps/site/docs/rules/no-return-try.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"no-return-try","category":"pedantic","default":"off","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"no-return-try","category":"pedantic","default":"off","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `no-return-try`

--- a/apps/site/docs/rules/no-unresolved.mdx
+++ b/apps/site/docs/rules/no-unresolved.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"no-unresolved","category":"correctness","default":"err","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"no-unresolved","category":"correctness","default":"err","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `no-unresolved`

--- a/apps/site/docs/rules/returned-stack-reference.mdx
+++ b/apps/site/docs/rules/returned-stack-reference.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"returned-stack-reference","category":"nursery","default":"off","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"returned-stack-reference","category":"nursery","default":"off","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `returned-stack-reference`

--- a/apps/site/docs/rules/suppressed-errors.mdx
+++ b/apps/site/docs/rules/suppressed-errors.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"suppressed-errors","category":"suspicious","default":"warning","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"suppressed-errors","category":"suspicious","default":"warning","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `suppressed-errors`

--- a/apps/site/docs/rules/unsafe-undefined.mdx
+++ b/apps/site/docs/rules/unsafe-undefined.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"unsafe-undefined","category":"restriction","default":"warning","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"unsafe-undefined","category":"restriction","default":"warning","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `unsafe-undefined`

--- a/apps/site/docs/rules/unused-decls.mdx
+++ b/apps/site/docs/rules/unused-decls.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"unused-decls","category":"correctness","default":"warning","fix":{"kind":"fix","dangerous":true}}'
+rule: '{"name":"unused-decls","category":"correctness","default":"warning","fix":{"kind":"fix","dangerous":true},"needs_cfg":false}'
 ---
 
 # `unused-decls`

--- a/apps/site/docs/rules/useless-error-return.mdx
+++ b/apps/site/docs/rules/useless-error-return.mdx
@@ -1,5 +1,5 @@
 ---
-rule: '{"name":"useless-error-return","category":"suspicious","default":"off","fix":{"kind":"none","dangerous":false}}'
+rule: '{"name":"useless-error-return","category":"suspicious","default":"off","fix":{"kind":"none","dangerous":false},"needs_cfg":false}'
 ---
 
 # `useless-error-return`

--- a/src/linter/LintService.zig
+++ b/src/linter/LintService.zig
@@ -13,6 +13,7 @@ reporter: *reporters.Reporter,
 group: Io.Group = .init,
 io: Io,
 allocator: Allocator,
+_enable_cfg: bool,
 
 pub fn init(
     allocator: Allocator,
@@ -32,6 +33,7 @@ pub fn init(
         .reporter = reporter,
         .io = io,
         .allocator = allocator,
+        ._enable_cfg = linter.rules.needsCfg(),
     };
 }
 
@@ -99,6 +101,7 @@ pub fn lintSource(
     if (source.text().len == 0) return;
     var builder = Semantic.Builder.init(self.allocator);
     builder.withSource(source);
+    builder.withCfg(self._enable_cfg);
     defer builder.deinit();
 
     var semantic_result = builder.build(source.text()) catch |e| {

--- a/src/linter/RuleSet.zig
+++ b/src/linter/RuleSet.zig
@@ -4,15 +4,9 @@ const RuleSet = @This();
 
 /// Total number of all lint rules, builtin and custom.
 pub const RULES_COUNT: usize = @typeInfo(RulesConfig.Rules).@"struct".fields.len;
-const ALL_RULE_IMPLS_SIZE: usize = Rule.MAX_SIZE * RULES_COUNT;
-const ALL_RULES_SIZE: usize = @sizeOf(Rule.WithSeverity) * RULES_COUNT;
-
-pub fn ensureTotalCapacityForAllRules(self: *RuleSet, arena: Allocator) Allocator.Error!void {
-    try self.rules.ensureTotalCapacityPrecise(arena.allocator(), RULES_COUNT);
-}
 
 pub fn loadRulesFromConfig(self: *RuleSet, arena: Allocator, config: *const RulesConfig) !void {
-    try self.rules.ensureUnusedCapacity(arena, ALL_RULES_SIZE);
+    try self.rules.ensureUnusedCapacity(arena, RULES_COUNT);
     const info = @typeInfo(RulesConfig.Rules);
     inline for (info.@"struct".fields) |field| {
         const rule = @field(config.rules, field.name);
@@ -28,6 +22,15 @@ pub fn loadRulesFromConfig(self: *RuleSet, arena: Allocator, config: *const Rule
 
 pub fn deinit(self: *RuleSet, arena: Allocator) void {
     self.rules.deinit(arena);
+    self.* = undefined;
+}
+
+/// Check if at least 1 enabled rule requires control flow analysis to run.
+pub fn needsCfg(self: *const RuleSet) bool {
+    for (self.rules.items) |rule| {
+        if (rule.severity != .off and rule.rule.meta.needs_cfg) return true;
+    }
+    return false;
 }
 
 const std = @import("std");

--- a/src/linter/lint_context.zig
+++ b/src/linter/lint_context.zig
@@ -12,6 +12,7 @@ curr_rule_name: []const u8 = "",
 curr_severity: Severity = Severity.err,
 // TODO: `void` in release builds
 curr_fix_capabilities: Fix.Meta = Fix.Meta.disabled,
+curr_rule_needs_cfg: bool = false,
 
 /// Are auto fixes enabled?
 // fix: bool = false,
@@ -37,6 +38,7 @@ pub inline fn updateForRule(self: *Context, rule: *const Rule.WithSeverity) void
     self.curr_rule_name = rule.rule.meta.name;
     self.curr_severity = rule.severity;
     self.curr_fix_capabilities = rule.rule.meta.fix;
+    self.curr_rule_needs_cfg = rule.rule.meta.needs_cfg;
 }
 
 pub fn takeDiagnostics(self: *Context) Diagnostic.List {
@@ -65,6 +67,11 @@ pub inline fn symbols(self: *const Context) *const Semantic.Symbol.Table {
 
 pub inline fn links(self: *const Context) *const Semantic.NodeLinks {
     return &self.semantic.node_links;
+}
+
+pub inline fn cfg(self: *const Context) *const Semantic.Cfg {
+    util.debugAssert(self.curr_rule_needs_cfg, "Rules cannot use a CFG unless `needs_cfg` is enabled.", .{});
+    return &self.semantic.cfg;
 }
 
 // ============================ ERROR REPORTING ============================

--- a/src/linter/rule.zig
+++ b/src/linter/rule.zig
@@ -59,6 +59,10 @@ pub const Rule = struct {
         ///
         /// Used (in part) when generating documentation.
         fix: Fix.Meta = Fix.Meta.disabled,
+        /// Whether or not this rule relies on control flow analysis.
+        ///
+        /// A CFG will not be available to rules unless this flag is enabled.
+        needs_cfg: bool = false,
     };
 
     pub const Category = enum {

--- a/src/linter/test/lint_context_test.zig
+++ b/src/linter/test/lint_context_test.zig
@@ -4,6 +4,8 @@ const Fix = @import("../fix.zig").Fix;
 const Semantic = @import("../../Semantic.zig");
 const _span = @import("../../span.zig");
 const Source = @import("../../source.zig").Source;
+const Rule = @import("../rule.zig").Rule;
+const AvoidAs = @import("../rules/avoid_as.zig");
 
 const t = std.testing;
 const print = std.debug.print;
@@ -64,4 +66,27 @@ test "Dangerous fixes do not get saved when only safe fixes are allowed" {
     try t.expectEqual(1, ctx.diagnostics.items.len);
     try t.expectEqual(null, ctx.diagnostics.items[0].fix);
     try t.expectEqualStrings("ahhh", ctx.diagnostics.items[0].err.message.borrow());
+}
+
+test "updateForRule tracks the current rule's needs_cfg flag" {
+    var sema: Semantic = undefined;
+    var source: Source = undefined;
+    var ctx = try createCtx("const x = 1;", &sema, &source);
+    defer {
+        ctx.deinit();
+        sema.deinit();
+        source.deinit();
+    }
+
+    var impl: AvoidAs = .{};
+    var rule = Rule.init(&impl);
+    try t.expect(!ctx.curr_rule_needs_cfg);
+
+    rule.meta.needs_cfg = true;
+    ctx.updateForRule(&.{ .rule = rule, .severity = .err });
+    try t.expect(ctx.curr_rule_needs_cfg);
+
+    rule.meta.needs_cfg = false;
+    ctx.updateForRule(&.{ .rule = rule, .severity = .err });
+    try t.expect(!ctx.curr_rule_needs_cfg);
 }

--- a/src/linter/tester.zig
+++ b/src/linter/tester.zig
@@ -14,6 +14,7 @@ diagnostic: TestDiagnostic = .{},
 fmt: GraphicalFormatter,
 
 alloc: Allocator,
+_enable_cfg: bool,
 
 const RuleTester = @This();
 
@@ -61,6 +62,7 @@ pub fn init(alloc: Allocator, rule: Rule) RuleTester {
         .linter = linter,
         .fmt = fmt,
         .alloc = alloc,
+        ._enable_cfg = rule.meta.needs_cfg,
     };
 }
 
@@ -290,6 +292,7 @@ fn lint(
     var builder = Semantic.Builder.init(self.alloc);
     defer builder.deinit();
     builder.withSource(&source);
+    builder.withCfg(self._enable_cfg);
 
     var semantic_result = builder.build(source.text()) catch |e| {
         try errors.ensureUnusedCapacity(builder._errors.items.len);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command for generating control-flow graph images from source files, with SVG output supported.

- **Improvements**
  - Linting now provides control-flow analysis only to rules that require it.
  - Rule metadata now clearly identifies whether control-flow information is needed.

- **Documentation**
  - Updated documentation for applicable linting rules to reflect their control-flow analysis requirements.

- **Tests**
  - Added coverage verifying that control-flow requirements are correctly tracked as rules change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->