### PR TITLE
test(cli): test lint command inclusion/exclusion behavior

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -38,7 +38,7 @@ jobs:
           version: ${{ env.ZIG_VERSION }}
 
       - run: just submodules
-      - run: zig build
+      - run: zig build -Dcoverage
       - run: just coverage
       - uses: codecov/codecov-action@v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ ZLint is anopinionated linter for the Zig programming language, written in Zig.
 ```
 
 ## Tools
-Zig 0.15, `just` for tasks, `bun` for package management and running JS apps, `typos` for spell checking.
+Zig 0.16, `just` for tasks, `bun` for package management and running JS apps, `typos` for spell checking.
 
 ## Build, Test, Run
 

--- a/Justfile
+++ b/Justfile
@@ -81,10 +81,11 @@ coverage:
     zig build -Dcoverage
     mkdir -p ./.coverage
     kcov --include-path=src,test ./.coverage/test zig-out/bin/test
+    kcov --include-path=src,test ./.coverage/test-cli zig-out/bin/test-cli
     kcov --include-path=src,test ./.coverage/test-utils zig-out/bin/test-utils
     kcov --include-path=src,test ./.coverage/test-e2e zig-out/bin/test-e2e
     kcov --include-path=src,test ./.coverage/test-zlint zig-out/bin/zlint || true
-    kcov --merge ./.coverage/all ./.coverage/test ./.coverage/test-utils ./.coverage/test-e2e ./.coverage/test-zlint
+    kcov --merge ./.coverage/all ./.coverage/test ./.coverage/test-cli ./.coverage/test-utils ./.coverage/test-e2e ./.coverage/test-zlint
 
 # Run benchmarks. Optionally specify a `--release` mode.
 bench mode="fast":

--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -79,8 +79,9 @@ pub fn lint(alloc: Allocator, io: Io, environ: std.process.Environ, options: Opt
         defer service.deinit();
 
         if (!options.stdin) {
-            var visitor: LintVisitor = .{
-                .service = &service,
+            var sink = LintSink{ .service = &service };
+            var visitor: FileFilter(LintSink) = .{
+                .sink = &sink,
                 .allocator = alloc,
                 .include = options.args.items,
                 .exclude = config.config.ignore,
@@ -116,75 +117,96 @@ pub fn lint(alloc: Allocator, io: Io, environ: std.process.Environ, options: Opt
     }
 }
 
-const LintWalker = walk.Walker(LintVisitor);
+const LintWalker = walk.Walker(FileFilter(LintSink));
 
-const LintVisitor = struct {
+/// Sink used by `lint`: hands each accepted file to the linter's thread pool.
+const LintSink = struct {
     /// borrowed
     service: *LintService,
-    allocator: Allocator,
-    include: []const glob.Pattern,
-    exclude: []const glob.Pattern,
 
-    pub fn visit(self: *LintVisitor, entry: walk.Entry) ?walk.WalkState {
-        switch (entry.kind) {
-            .directory => {
-                if (entry.basename.len == 0 or entry.basename[0] == '.') {
-                    return WalkState.Skip;
-                } else if (mem.eql(u8, entry.basename, "vendor") or mem.eql(u8, entry.basename, "zig-out")) {
-                    return WalkState.Skip;
-                }
-                for (self.service.config.config.ignore) |ignore| {
-                    if (mem.startsWith(u8, entry.path, ignore)) {
-                        return WalkState.Skip;
-                    }
-                }
-            },
-            .file => {
-                if (!mem.eql(u8, path.extension(entry.path), ".zig") or
-                    !self.isIncluded(&entry))
-                {
-                    return WalkState.Continue;
-                }
-
-                const filepath = self.allocator.dupe(u8, entry.path) catch {
-                    return WalkState.Stop;
-                };
-                self.service.lintFileParallel(filepath);
-            },
-            else => {
-                // todo: warn
-            },
-        }
-        return WalkState.Continue;
-    }
-
-    fn isIncluded(self: *const LintVisitor, entry: *const walk.Entry) bool {
-        util.debugAssert(
-            entry.kind != .directory,
-            "isIncluded should only be passed file-like things, got a dir.",
-            .{},
-        );
-
-        if (self.include.len > 0) matches_include: {
-            for (self.include) |pattern| {
-                if (glob.match(pattern, entry.path)) {
-                    break :matches_include;
-                }
-            }
-            return false;
-        }
-
-        if (self.exclude.len > 0) {
-            for (self.exclude) |pattern| {
-                if (glob.match(pattern, entry.path)) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
+    pub fn accept(self: *LintSink, filepath: []u8) void {
+        self.service.lintFileParallel(filepath);
     }
 };
+
+/// Decides which files in a directory tree get linted, and hands each one to
+/// `sink`, which takes ownership of the path.
+///
+/// `Sink` must expose `fn accept(*Sink, []u8) void`.
+pub fn FileFilter(comptime Sink: type) type {
+    return struct {
+        /// borrowed
+        sink: *Sink,
+        allocator: Allocator,
+        /// Paths and patterns named on the command line. Empty means "lint
+        /// everything under the walk root".
+        include: []const glob.Pattern,
+        /// `ignore` from `zlint.json`, plus whatever `.gitignore` contributed.
+        exclude: []const glob.Pattern,
+
+        const Self = @This();
+
+        pub fn visit(self: *Self, entry: walk.Entry) ?walk.WalkState {
+            switch (entry.kind) {
+                .directory => {
+                    if (entry.basename.len == 0 or entry.basename[0] == '.') {
+                        return WalkState.Skip;
+                    } else if (mem.eql(u8, entry.basename, "vendor") or mem.eql(u8, entry.basename, "zig-out")) {
+                        return WalkState.Skip;
+                    }
+                    for (self.exclude) |ignore| {
+                        if (mem.startsWith(u8, entry.path, ignore)) {
+                            return WalkState.Skip;
+                        }
+                    }
+                },
+                .file => {
+                    if (!mem.eql(u8, path.extension(entry.path), ".zig") or
+                        !self.isIncluded(&entry))
+                    {
+                        return WalkState.Continue;
+                    }
+
+                    const filepath = self.allocator.dupe(u8, entry.path) catch {
+                        return WalkState.Stop;
+                    };
+                    self.sink.accept(filepath);
+                },
+                else => {
+                    // todo: warn
+                },
+            }
+            return WalkState.Continue;
+        }
+
+        fn isIncluded(self: *const Self, entry: *const walk.Entry) bool {
+            util.debugAssert(
+                entry.kind != .directory,
+                "isIncluded should only be passed file-like things, got a dir.",
+                .{},
+            );
+
+            if (self.include.len > 0) matches_include: {
+                for (self.include) |pattern| {
+                    if (glob.match(pattern, entry.path)) {
+                        break :matches_include;
+                    }
+                }
+                return false;
+            }
+
+            if (self.exclude.len > 0) {
+                for (self.exclude) |pattern| {
+                    if (glob.match(pattern, entry.path)) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    };
+}
 
 /// Modified version of `streamUntilDelimiterOrEof` from zig v0.14.1's stdlib.
 ///
@@ -195,7 +217,7 @@ const LintVisitor = struct {
 /// Returns a slice of the stream data, with ptr equal to `buf.ptr`. The
 /// delimiter byte is written to the output buffer but is not included
 /// in the returned slice.
-pub fn readUntilDelimiterOrEof(self: *std.Io.Reader, buffer: []u8, delimiter: u8) anyerror!?[]u8 {
+fn readUntilDelimiterOrEof(self: *std.Io.Reader, buffer: []u8, delimiter: u8) anyerror!?[]u8 {
     var fbw = std.Io.Writer.fixed(buffer);
     const bytes_read = self.streamDelimiter(&fbw, delimiter) catch |err| switch (err) {
         error.EndOfStream => if (fbw.end == 0) {

--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -211,3 +211,7 @@ pub fn readUntilDelimiterOrEof(self: *std.Io.Reader, buffer: []u8, delimiter: u8
     self.toss(1); // throw out the delimiter
     return buffer[0..bytes_read];
 }
+
+test {
+    _ = @import("test/lint_command_test.zig");
+}

--- a/src/cli/lint_command.zig
+++ b/src/cli/lint_command.zig
@@ -234,6 +234,20 @@ fn readUntilDelimiterOrEof(self: *std.Io.Reader, buffer: []u8, delimiter: u8) an
     return buffer[0..bytes_read];
 }
 
+test readUntilDelimiterOrEof {
+    const expectEqualString = std.testing.expectEqualStrings;
+    const expect = std.testing.expect;
+
+    var buffer: [1024]u8 = undefined;
+    const stdin = "line1\nline2\nline3";
+    var reader = std.Io.Reader.fixed(stdin);
+
+    try expectEqualString(try readUntilDelimiterOrEof(&reader, &buffer, '\n') orelse return error.ExpectedLine, "line1");
+    try expectEqualString(try readUntilDelimiterOrEof(&reader, &buffer, '\n') orelse return error.ExpectedLine, "line2");
+    try expectEqualString(try readUntilDelimiterOrEof(&reader, &buffer, '\n') orelse return error.ExpectedLine, "line3");
+    try expect(try readUntilDelimiterOrEof(&reader, &buffer, '\n') == null);
+}
+
 test {
     _ = @import("test/lint_command_test.zig");
 }

--- a/src/cli/test/Fixture.zig
+++ b/src/cli/test/Fixture.zig
@@ -1,0 +1,43 @@
+const Fixture = @This();
+const std = @import("std");
+const path = std.fs.path;
+
+const Dir = std.Io.Dir;
+const Allocator = std.mem.Allocator;
+const TmpDir = std.testing.TmpDir;
+
+files: []File,
+dir: TmpDir,
+
+pub const File = struct {
+    /// Relative path + file name
+    /// `path/to/file.zig`
+    path: []const u8,
+    contents: []const u8,
+};
+
+pub fn new(io: std.Io, files: []File) !Fixture {
+    var buffer: [256]u8 = undefined;
+    const dir = std.testing.tmpDir(.{});
+    for (files) |f| {
+        try writeFixture(io, dir.dir, f, &buffer);
+    }
+    return .{ .dir = dir, .files = files };
+}
+
+fn writeFixture(io: std.Io, dir: Dir, fixture: Fixture.File, buf: []u8) !void {
+    const subpath = path.dirname(fixture.path);
+    if (subpath) |p| {
+        try dir.createDirPath(io, p);
+    }
+    var file = try dir.createFile(io, subpath orelse "", .{ .truncate = true });
+    defer file.close(io);
+    var w = file.writer(io, buf);
+    try w.interface.writeAll(fixture.contents);
+    try w.flush();
+}
+
+pub fn deinit(self: *Fixture) void {
+    self.dir.cleanup();
+    self.* = undefined;
+}

--- a/src/cli/test/Fixture.zig
+++ b/src/cli/test/Fixture.zig
@@ -1,43 +1,47 @@
+//! A throwaway project tree on disk, for tests that need to exercise file
+//! discovery. Files are written into a temp dir that is deleted by `deinit`.
 const Fixture = @This();
 const std = @import("std");
 const path = std.fs.path;
 
 const Dir = std.Io.Dir;
-const Allocator = std.mem.Allocator;
 const TmpDir = std.testing.TmpDir;
 
-files: []File,
-dir: TmpDir,
+tmp: TmpDir,
+io: std.Io,
 
 pub const File = struct {
-    /// Relative path + file name
-    /// `path/to/file.zig`
+    /// Path relative to the fixture root, e.g. `src/main.zig`. Parent
+    /// directories are created as needed.
     path: []const u8,
-    contents: []const u8,
+    contents: []const u8 = "",
 };
 
-pub fn new(io: std.Io, files: []File) !Fixture {
-    var buffer: [256]u8 = undefined;
-    const dir = std.testing.tmpDir(.{});
-    for (files) |f| {
-        try writeFixture(io, dir.dir, f, &buffer);
-    }
-    return .{ .dir = dir, .files = files };
+pub fn new(io: std.Io, files: []const File) !Fixture {
+    var self = Fixture{ .tmp = std.testing.tmpDir(.{ .iterate = true }), .io = io };
+    errdefer self.tmp.cleanup();
+    for (files) |f| try self.write(f);
+    return self;
 }
 
-fn writeFixture(io: std.Io, dir: Dir, fixture: Fixture.File, buf: []u8) !void {
-    const subpath = path.dirname(fixture.path);
-    if (subpath) |p| {
-        try dir.createDirPath(io, p);
+/// The project root. Iterable.
+pub fn root(self: *const Fixture) Dir {
+    return self.tmp.dir;
+}
+
+fn write(self: *Fixture, f: File) !void {
+    var buf: [1024]u8 = undefined;
+    if (path.dirname(f.path)) |parent| {
+        try self.tmp.dir.createDirPath(self.io, parent);
     }
-    var file = try dir.createFile(io, subpath orelse "", .{ .truncate = true });
-    defer file.close(io);
-    var w = file.writer(io, buf);
-    try w.interface.writeAll(fixture.contents);
+    var file = try self.tmp.dir.createFile(self.io, f.path, .{ .truncate = true });
+    defer file.close(self.io);
+    var w = file.writer(self.io, &buf);
+    try w.interface.writeAll(f.contents);
     try w.flush();
 }
 
 pub fn deinit(self: *Fixture) void {
-    self.dir.cleanup();
+    self.tmp.cleanup();
     self.* = undefined;
 }

--- a/src/cli/test/lint_command_test.zig
+++ b/src/cli/test/lint_command_test.zig
@@ -1,8 +1,388 @@
-const std = @import("std");
-const Fixture = @import("Fixture.zig");
-const t = std.testing;
+//! Which files zlint picks up, from the user's point of view.
+//!
+//! Each test lays out a project in a tmpdir, runs `FileFilter` over it, and
+//! asserts on the exact set of files selected. Nothing is parsed, so fixture
+//! files can be empty.
+//!
+//! Assertions describe the behavior documented in
+//! `apps/site/docs/configuration/ignore.md` and `zlint.schema.json`, *not*
+//! whatever zlint happens to do today. Cases zlint doesn't satisfy yet are
+//! wrapped in `todo()`.
 
-test "ignore behavior" {
-    var f = try Fixture.new(t.io, &[_]Fixture.File{});
-    defer f.deinit();
+const std = @import("std");
+const builtin = @import("builtin");
+const Fixture = @import("Fixture.zig");
+const walk = @import("../../io/Walker.zig");
+const lint_command = @import("../lint_command.zig");
+const lint_config = @import("../lint_config.zig");
+const Config = @import("zlint").lint.Config;
+
+const t = std.testing;
+const Allocator = std.mem.Allocator;
+
+/// A test scenario that needs fixing. Fails if the test passes.
+fn todo(comptime why: []const u8, result: anyerror!void) !void {
+    result catch return error.SkipZigTest;
+    std.debug.print("\nthis passes now; drop the todo(): {s}\n", .{why});
+    return error.TodoIsFixed;
+}
+
+fn skipIfWindows() !void {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+}
+
+/// A project on disk, plus how zlint was invoked in it.
+const Project = struct {
+    files: []const Fixture.File,
+    /// The `ignore` array in `zlint.json`.
+    ignore: []const []const u8 = &.{},
+    /// Paths passed on the command line. Empty means "the whole project".
+    args: []const []const u8 = &.{},
+};
+
+/// Assert that linting `project` lints exactly `expected` and nothing else.
+/// Order doesn't matter; paths are relative to the project root.
+fn expectLints(project: Project, expected: []const []const u8) !void {
+    var fixture = try Fixture.new(t.io, project.files);
+    defer fixture.deinit();
+
+    var arena = std.heap.ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
+
+    // A project with a `.gitignore` is read the way a real run reads it.
+    // `.nearest_from_root` walks *up* from the project root, and fixtures live
+    // under the repo's own `.zig-cache`, so a fixture without one of its own
+    // would silently inherit zlint's.
+    var ignore = project.ignore;
+    if (hasGitignore(project.files)) {
+        var config = Config.DEFAULT.intoManaged(&arena, null);
+        config.config.ignore = project.ignore;
+        try lint_config.readGitignore(&config, t.io, fixture.root(), .nearest_from_root);
+        ignore = config.config.ignore;
+    }
+
+    const found = try collectLintTargets(
+        t.allocator,
+        t.io,
+        fixture.root(),
+        project.args,
+        ignore,
+    );
+    defer {
+        for (found) |f| t.allocator.free(f);
+        t.allocator.free(found);
+    }
+
+    try expectSameFiles(expected, found);
+}
+
+fn hasGitignore(files: []const Fixture.File) bool {
+    for (files) |f| if (std.mem.eql(u8, f.path, ".gitignore")) return true;
+    return false;
+}
+
+/// Collects the files `lint` would send to the linter, instead of linting them.
+const ListSink = struct {
+    allocator: Allocator,
+    files: std.ArrayListUnmanaged([]u8) = .empty,
+
+    pub fn accept(self: *ListSink, filepath: []u8) void {
+        self.files.append(self.allocator, filepath) catch @panic("OOM");
+    }
+};
+
+/// Every file `lint` would send to the linter if it were run from `root`, in
+/// visit order. Paths are relative to `root`; the slice and its contents are
+/// owned by `alloc`.
+///
+/// This is discovery without a `LintService`, stdout, or a process-wide cwd.
+/// `lint` walks with the same `FileFilter`, so the two cannot disagree.
+fn collectLintTargets(
+    alloc: Allocator,
+    io: std.Io,
+    root: std.Io.Dir,
+    include: []const []const u8,
+    exclude: []const []const u8,
+) ![][]u8 {
+    const Filter = lint_command.FileFilter(ListSink);
+
+    var sink = ListSink{ .allocator = alloc };
+    errdefer {
+        for (sink.files.items) |f| alloc.free(f);
+        sink.files.deinit(alloc);
+    }
+
+    var visitor: Filter = .{
+        .sink = &sink,
+        .allocator = alloc,
+        .include = include,
+        .exclude = exclude,
+    };
+    var walker = try walk.Walker(Filter).init(alloc, io, root, &visitor);
+    defer walker.deinit();
+    try walker.walk();
+
+    return sink.files.toOwnedSlice(alloc);
+}
+
+/// Compares exactly, including path separators. Only walk order is normalized,
+/// since that's filesystem-dependent.
+fn expectSameFiles(expected: []const []const u8, found: [][]u8) !void {
+    std.mem.sort([]u8, found, {}, lessThan([]u8));
+
+    const want = try t.allocator.dupe([]const u8, expected);
+    defer t.allocator.free(want);
+    std.mem.sort([]const u8, want, {}, lessThan([]const u8));
+
+    same: {
+        if (want.len != found.len) break :same;
+        for (want, found) |w, f| {
+            if (!std.mem.eql(u8, w, f)) break :same;
+        }
+        return;
+    }
+
+    std.debug.print("\nexpected these files to be linted:\n", .{});
+    for (want) |f| std.debug.print("  {s}\n", .{f});
+    std.debug.print("but zlint linted:\n", .{});
+    for (found) |f| std.debug.print("  {s}\n", .{f});
+    return error.TestExpectedEqual;
+}
+
+fn lessThan(comptime S: type) fn (void, S, S) bool {
+    return struct {
+        fn cmp(_: void, a: S, b: S) bool {
+            return std.mem.lessThan(u8, a, b);
+        }
+    }.cmp;
+}
+
+// =============================================================================
+// A project with no configuration
+// =============================================================================
+
+test "lints every zig file in the project" {
+    try expectLints(.{ .files = &.{
+        .{ .path = "build.zig" },
+        .{ .path = "src/main.zig" },
+        .{ .path = "src/nested/deep.zig" },
+    } }, &.{ "build.zig", "src/main.zig", "src/nested/deep.zig" });
+}
+
+test "does not lint files that aren't zig source" {
+    try expectLints(.{ .files = &.{
+        .{ .path = "src/main.zig" },
+        .{ .path = "build.zig.zon" },
+        .{ .path = "README.md" },
+        .{ .path = "LICENSE" },
+    } }, &.{"src/main.zig"});
+}
+
+test "never lints vendor or zig-out" {
+    try expectLints(.{ .files = &.{
+        .{ .path = "src/main.zig" },
+        .{ .path = "vendor/dep.zig" },
+        .{ .path = "zig-out/bin/gen.zig" },
+    } }, &.{"src/main.zig"});
+}
+
+test "never lints hidden directories" {
+    try expectLints(.{ .files = &.{
+        .{ .path = "src/main.zig" },
+        .{ .path = ".zig-cache/o/tmp.zig" },
+        .{ .path = ".git/hooks/thing.zig" },
+    } }, &.{"src/main.zig"});
+}
+
+test "never lints a vendor directory nested inside the project" {
+    try expectLints(.{ .files = &.{
+        .{ .path = "src/main.zig" },
+        .{ .path = "tools/vendor/dep.zig" },
+    } }, &.{"src/main.zig"});
+}
+
+// =============================================================================
+// `ignore` in zlint.json
+// =============================================================================
+
+test "ignore skips a directory named directly" {
+    try expectLints(.{
+        .files = &.{ .{ .path = "src/main.zig" }, .{ .path = "examples/demo.zig" } },
+        .ignore = &.{"examples"},
+    }, &.{"src/main.zig"});
+}
+
+// The example given in apps/site/docs/configuration/ignore.md.
+test "ignore accepts glob patterns" {
+    try skipIfWindows();
+    try expectLints(.{
+        .files = &.{
+            .{ .path = "src/main.zig" },
+            .{ .path = "src/test/helper.zig" },
+            .{ .path = "src/test/deep/other.zig" },
+        },
+        .ignore = &.{"src/test/**"},
+    }, &.{"src/main.zig"});
+}
+
+test "ignore matches a file pattern at any depth" {
+    try skipIfWindows();
+    try expectLints(.{
+        .files = &.{
+            .{ .path = "src/main.zig" },
+            .{ .path = "src/proto.gen.zig" },
+            .{ .path = "src/deep/other.gen.zig" },
+        },
+        .ignore = &.{"**/*.gen.zig"},
+    }, &.{"src/main.zig"});
+}
+
+test "ignore matches a directory at any depth" {
+    try skipIfWindows();
+    try todo(
+        "`**/generated` matches nothing: directories are pruned with startsWith, " ++
+            "which a glob never matches, and the file pattern stops at the directory name",
+        expectLints(.{
+            .files = &.{
+                .{ .path = "src/main.zig" },
+                .{ .path = "src/generated/proto.zig" },
+                .{ .path = "lib/generated/other.zig" },
+            },
+            .ignore = &.{"**/generated"},
+        }, &.{"src/main.zig"}),
+    );
+}
+
+test "ignore does not skip sibling directories that share a prefix" {
+    try todo(
+        "directories are pruned with startsWith, so `src` also prunes `srcgen`",
+        expectLints(.{
+            .files = &.{ .{ .path = "src/main.zig" }, .{ .path = "srcgen/tool.zig" } },
+            .ignore = &.{"src"},
+        }, &.{"srcgen/tool.zig"}),
+    );
+}
+
+// =============================================================================
+// .gitignore
+//
+// "ZLint respects .gitignore files by default; no files ignored by git will be
+// linted." Entries are appended to `ignore` verbatim and then matched as globs,
+// so these tests really ask whether gitignore syntax survives that trip.
+// =============================================================================
+
+test "respects a plain directory name in gitignore" {
+    try expectLints(.{ .files = &.{
+        .{ .path = ".gitignore", .contents = "build\n" },
+        .{ .path = "src/main.zig" },
+        .{ .path = "build/gen.zig" },
+    } }, &.{"src/main.zig"});
+}
+
+test "ignores comments and blank lines in gitignore" {
+    try expectLints(.{ .files = &.{
+        .{ .path = ".gitignore", .contents = "# a comment\n\n   \nbuild\n" },
+        .{ .path = "src/main.zig" },
+        .{ .path = "build/gen.zig" },
+    } }, &.{"src/main.zig"});
+}
+
+test "respects gitignore directory entries written with a trailing slash" {
+    try todo(
+        "`build/` matches neither the directory prune (startsWith) nor the file " ++
+            "glob, so a trailing slash silently disables the entry",
+        expectLints(.{ .files = &.{
+            .{ .path = ".gitignore", .contents = "build/\n" },
+            .{ .path = "src/main.zig" },
+            .{ .path = "build/gen.zig" },
+        } }, &.{"src/main.zig"}),
+    );
+}
+
+test "respects gitignore patterns at any depth" {
+    try todo(
+        "git matches a slash-free pattern at any depth, but `*` in a zlint glob " ++
+            "does not cross path separators",
+        expectLints(.{ .files = &.{
+            .{ .path = ".gitignore", .contents = "*.gen.zig\n" },
+            .{ .path = "src/main.zig" },
+            .{ .path = "root.gen.zig" },
+            .{ .path = "src/deep/proto.gen.zig" },
+        } }, &.{"src/main.zig"}),
+    );
+}
+
+test "respects gitignore entries for a directory nested in the project" {
+    try todo(
+        "git ignores `node_modules` at any depth; startsWith only prunes it at " ++
+            "the project root",
+        expectLints(.{ .files = &.{
+            .{ .path = ".gitignore", .contents = "node_modules\n" },
+            .{ .path = "src/main.zig" },
+            .{ .path = "node_modules/a.zig" },
+            .{ .path = "tools/node_modules/b.zig" },
+        } }, &.{"src/main.zig"}),
+    );
+}
+
+test "respects root-anchored gitignore entries" {
+    try todo(
+        "a leading `/` anchors a gitignore pattern to the project root; zlint " ++
+            "matches it literally, so it never matches anything",
+        expectLints(.{ .files = &.{
+            .{ .path = ".gitignore", .contents = "/dist\n" },
+            .{ .path = "src/main.zig" },
+            .{ .path = "dist/out.zig" },
+            .{ .path = "src/dist/keep.zig" },
+        } }, &.{ "src/dist/keep.zig", "src/main.zig" }),
+    );
+}
+
+// =============================================================================
+// Paths passed on the command line
+// =============================================================================
+
+test "lints only the file named on the command line" {
+    try skipIfWindows();
+    try expectLints(.{
+        .files = &.{ .{ .path = "src/main.zig" }, .{ .path = "src/other.zig" } },
+        .args = &.{"src/main.zig"},
+    }, &.{"src/main.zig"});
+}
+
+test "lints a directory named on the command line" {
+    try todo(
+        "`zlint src` matches nothing: command-line paths are matched as globs, " ++
+            "and `src` does not match `src/main.zig`",
+        expectLints(.{
+            .files = &.{
+                .{ .path = "src/main.zig" },
+                .{ .path = "src/deep/other.zig" },
+                .{ .path = "test/helper.zig" },
+            },
+            .args = &.{"src"},
+        }, &.{ "src/deep/other.zig", "src/main.zig" }),
+    );
+}
+
+test "lints a file named with a leading ./" {
+    try todo(
+        "walk paths carry no `./` prefix, so `./src/main.zig` never matches",
+        expectLints(.{
+            .files = &.{ .{ .path = "src/main.zig" }, .{ .path = "src/other.zig" } },
+            .args = &.{"./src/main.zig"},
+        }, &.{"src/main.zig"}),
+    );
+}
+
+test "lints a file named on the command line even when it is ignored" {
+    try todo(
+        "naming a file explicitly should override `ignore` (or report that it " ++
+            "was skipped); today it is dropped silently and zlint exits 0",
+        expectLints(.{
+            .files = &.{ .{ .path = "src/main.zig" }, .{ .path = "generated/proto.zig" } },
+            .ignore = &.{"generated"},
+            .args = &.{"generated/proto.zig"},
+        }, &.{"generated/proto.zig"}),
+    );
 }

--- a/src/cli/test/lint_command_test.zig
+++ b/src/cli/test/lint_command_test.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const Fixture = @import("Fixture.zig");
+const t = std.testing;
+
+test "ignore behavior" {
+    var f = try Fixture.new(t.io, &[_]Fixture.File{});
+    defer f.deinit();
+}

--- a/src/cli/test/lint_command_test.zig
+++ b/src/cli/test/lint_command_test.zig
@@ -10,7 +10,6 @@
 //! wrapped in `todo()`.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const Fixture = @import("Fixture.zig");
 const walk = @import("../../io/Walker.zig");
 const lint_command = @import("../lint_command.zig");
@@ -22,13 +21,13 @@ const Allocator = std.mem.Allocator;
 
 /// A test scenario that needs fixing. Fails if the test passes.
 fn todo(comptime why: []const u8, result: anyerror!void) !void {
-    result catch return error.SkipZigTest;
+    result catch |e| switch (e) {
+        error.TestExpectedEqual => return error.SkipZigTest,
+        // the fixture or the walk broke; that's a real failure, not a todo
+        else => return e,
+    };
     std.debug.print("\nthis passes now; drop the todo(): {s}\n", .{why});
     return error.TodoIsFixed;
-}
-
-fn skipIfWindows() !void {
-    if (builtin.os.tag == .windows) return error.SkipZigTest;
 }
 
 /// A project on disk, plus how zlint was invoked in it.
@@ -125,9 +124,12 @@ fn collectLintTargets(
     return sink.files.toOwnedSlice(alloc);
 }
 
-/// Compares exactly, including path separators. Only walk order is normalized,
-/// since that's filesystem-dependent.
 fn expectSameFiles(expected: []const []const u8, found: [][]u8) !void {
+    // Walk order is filesystem-dependent, and paths are joined with the native
+    // separator. Neither is a behavior worth pinning: `glob.match` treats `/`
+    // and `\\` alike (see `isSeparator` in io/glob.zig), so patterns written
+    // with `/` work on every platform.
+    for (found) |f| std.mem.replaceScalar(u8, f, std.fs.path.sep, '/');
     std.mem.sort([]u8, found, {}, lessThan([]u8));
 
     const want = try t.allocator.dupe([]const u8, expected);
@@ -214,7 +216,6 @@ test "ignore skips a directory named directly" {
 
 // The example given in apps/site/docs/configuration/ignore.md.
 test "ignore accepts glob patterns" {
-    try skipIfWindows();
     try expectLints(.{
         .files = &.{
             .{ .path = "src/main.zig" },
@@ -226,7 +227,6 @@ test "ignore accepts glob patterns" {
 }
 
 test "ignore matches a file pattern at any depth" {
-    try skipIfWindows();
     try expectLints(.{
         .files = &.{
             .{ .path = "src/main.zig" },
@@ -238,7 +238,6 @@ test "ignore matches a file pattern at any depth" {
 }
 
 test "ignore matches a directory at any depth" {
-    try skipIfWindows();
     try todo(
         "`**/generated` matches nothing: directories are pruned with startsWith, " ++
             "which a glob never matches, and the file pattern stops at the directory name",
@@ -343,7 +342,6 @@ test "respects root-anchored gitignore entries" {
 // =============================================================================
 
 test "lints only the file named on the command line" {
-    try skipIfWindows();
     try expectLints(.{
         .files = &.{ .{ .path = "src/main.zig" }, .{ .path = "src/other.zig" } },
         .args = &.{"src/main.zig"},


### PR DESCRIPTION
## What This PR Does
Adds tests covering cli inclusion/exclusion behavior in preparation of upcoming CLI changes.

## Other changes
- run `test-cli` in `coverage` workflow
- fix incorrectly documented zig version in AGENTS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Linting**
  - Improved file discovery and filtering for the lint command.
  - File selection now covers configuration-based exclusions, `.gitignore` rules, projects without configuration, and explicit command-line paths.

- **Documentation**
  - Updated the required Zig toolchain version to Zig 0.16.

- **Tests**
  - Added broader coverage to help ensure linting processes the intended files consistently.
  - Improved cross-platform handling of file paths in linting tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->